### PR TITLE
only rate limit when not in the middle of a transaction.

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsItemOperationsCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsItemOperationsCommand.cs
@@ -148,7 +148,6 @@ namespace NachoCore.ActiveSync
                     var xmlServerId = xmlFetch.Element (AirSyncNs + Xml.AirSync.ServerId);
                     var xmlProperties = xmlFetch.Element (m_ns + Xml.ItemOperations.Properties);
                     xmlStatus = xmlFetch.ElementAnyNs (Xml.ItemOperations.Status);
-                    NcResult.WhyEnum why;
                     switch ((Xml.ItemOperations.StatusCode)Convert.ToUInt32 (xmlStatus.Value)) {
                     case Xml.ItemOperations.StatusCode.Success_1:
                         if (null != xmlFileReference) {

--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -69,7 +69,8 @@ namespace NachoCore.Brain
             int numGleaned = 0;
             while (numGleaned < count) {
                 // Slow down when the UI is busy
-                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId) {
+                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId &&
+                    !NcModel.Instance.IsInTransaction ()) {
                     NcModel.Instance.RateLimiter.TakeTokenOrSleep ();
                 }
                 McEmailMessage emailMessage = NcModel.Instance.Db.Table<McEmailMessage> ().Where (x => 
@@ -89,7 +90,8 @@ namespace NachoCore.Brain
             int numAnalyzed = 0;
             while (numAnalyzed < count) {
                 // Slow down when the UI is busy
-                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId) {
+                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId &&
+                    !NcModel.Instance.IsInTransaction ()) {
                     NcModel.Instance.RateLimiter.TakeTokenOrSleep ();
                 }
                 McContact contact = NcModel.Instance.Db.Table<McContact> ().Where (x => x.ScoreVersion < Scoring.Version).FirstOrDefault ();
@@ -108,7 +110,8 @@ namespace NachoCore.Brain
             int numAnalyzed = 0;
             while (numAnalyzed < count) {
                 // Slow down when the UI is busy
-                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId) {
+                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId &&
+                    !NcModel.Instance.IsInTransaction ()) {
                     NcModel.Instance.RateLimiter.TakeTokenOrSleep ();
                 }
                 McEmailMessage emailMessage = NcModel.Instance.Db.Table<McEmailMessage> ().Where (x => x.ScoreVersion < Scoring.Version).FirstOrDefault ();
@@ -127,7 +130,8 @@ namespace NachoCore.Brain
             int numUpdated = 0;
             while (numUpdated < count) {
                 // Slow down when the UI is busy
-                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId) {
+                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId &&
+                    !NcModel.Instance.IsInTransaction ()) {
                     NcModel.Instance.RateLimiter.TakeTokenOrSleep ();
                 }
                 McContact contact = NcModel.Instance.Db.Table<McContact> ().Where (x => x.NeedUpdate).FirstOrDefault ();
@@ -150,7 +154,8 @@ namespace NachoCore.Brain
             int numUpdated = 0;
             while (numUpdated < count) {
                 // Slow down when the UI is busy
-                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId) {
+                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId &&
+                    !NcModel.Instance.IsInTransaction ()) {
                     NcModel.Instance.RateLimiter.TakeTokenOrSleep ();
                 }
                 McEmailMessage emailMessage = NcModel.Instance.Db.Table<McEmailMessage> ().Where (x => x.NeedUpdate).FirstOrDefault ();

--- a/NachoClient.Android/NachoCore/Model/McObject.cs
+++ b/NachoClient.Android/NachoCore/Model/McObject.cs
@@ -105,7 +105,8 @@ namespace NachoCore.Model
         public virtual int Insert ()
         {
             NcAssert.True (0 == Id);
-            if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId) {
+            if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId &&
+                !NcModel.Instance.IsInTransaction ()) {
                 NcModel.Instance.RateLimiter.TakeTokenOrSleep ();
             }
             LastModified = DateTime.UtcNow;
@@ -122,7 +123,8 @@ namespace NachoCore.Model
         public virtual int Delete ()
         {
             NcAssert.True (0 < Id);
-            if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId) {
+            if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId &&
+                !NcModel.Instance.IsInTransaction ()) {
                 NcModel.Instance.RateLimiter.TakeTokenOrSleep ();
             }
             NcCapture capture = DeleteCaptures.Find (ClassName ());
@@ -138,7 +140,8 @@ namespace NachoCore.Model
         public virtual int Update ()
         {
             NcAssert.True (0 < Id);
-            if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId) {
+            if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId &&
+                !NcModel.Instance.IsInTransaction ()) {
                 NcModel.Instance.RateLimiter.TakeTokenOrSleep ();
             }
             LastModified = DateTime.UtcNow;

--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -180,6 +180,9 @@ namespace NachoCore.Model
         {
             // DO NOT ADD LOGGING IN THE TRANSACTION, BECAUSE WE DON'T WANT LOGGING WRITES TO GET LUMPED IN.
             var threadId = Thread.CurrentThread.ManagedThreadId;
+            if (NcApplication.Instance.UiThreadId != threadId && !NcModel.Instance.IsInTransaction ()) {
+                NcModel.Instance.RateLimiter.TakeTokenOrSleep ();
+            }
             int exitValue = 0;
             TransDepth.AddOrUpdate (threadId, 1, (key, oldValue) => {
                 exitValue = oldValue;

--- a/NachoClient.Android/NachoCore/Utils/NcStateMachine.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcStateMachine.cs
@@ -250,14 +250,21 @@ namespace NachoCore.Utils
                     var oldState = State;
                     State = NextState;
                     if (oldState != State && null != StateChangeIndication) {
-                        StateChangeIndication ();
+                        try {
+                            StateChangeIndication ();
+                        } catch (Exception ex) {
+                            Log.Error (Log.LOG_STATE, "Exception in StateMachine.StateChangeIndication: {0}, stack: {1}", ex.ToString (),
+                                new System.Diagnostics.StackTrace (true));
+                            throw;
+                        }
                     }
                 } catch (Exception ex) {
-                    Log.Error (Log.LOG_STATE, "Exception in StateMachine.FireLoop: {0}", ex.ToString ());
+                    Log.Error (Log.LOG_STATE, "Exception in StateMachine.FireLoop: {0}, stack: {1}", ex.ToString (),
+                        new System.Diagnostics.StackTrace (true));
                     lock (LockObj) {
                         InProcess = false;
                     }
-                    throw ex;
+                    throw;
                 }
                 PossiblyLeave:
                 lock (LockObj) {

--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -439,7 +439,8 @@ namespace NachoCore.Utils
                 // idea to upload a lot of data. The exact algorithm is TBD.
                 // But for now, let's not run when we're scrolling.
                 NcAssert.True (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId);
-                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId) {
+                if (NcApplication.Instance.UiThreadId != System.Threading.Thread.CurrentThread.ManagedThreadId &&
+                    !NcModel.Instance.IsInTransaction ()) {
                     NcModel.Instance.RateLimiter.TakeTokenOrSleep ();
                 }
                 TelemetryEvent tEvent = null;


### PR DESCRIPTION
If the rate limiter kicks in the middle of a transaction by a non-UI thread then the transaction can take a long time, as we are currently allowing only 16 ops/second for all non-UI when rate limiting. The non-UI thread holds the write lock on the entire DB the whole time.
