### PR TITLE
Add status indication of score updates. Send due date and deferred until...

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrainEvent.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainEvent.cs
@@ -10,7 +10,8 @@ namespace NachoCore.Brain
         PERIODIC_GLEAN,
         UI,
         STATE_MACHINE,
-        TERMINATE
+        TERMINATE,
+        MESSAGE_FLAGS,
     };
 
     public class NcBrainEvent : NcQueueElement
@@ -22,9 +23,14 @@ namespace NachoCore.Brain
             Type = type;
         }
 
+        public string GetEventType ()
+        {
+            return Enum.GetName (typeof(NcBrainEventType), Type);
+        }
+
         public override string ToString ()
         {
-            return String.Format ("<NcBrainEvent: type={0}>", Enum.GetName (typeof(NcBrainEventType), Type));
+            return String.Format ("[NcBrainEvent: type={0}]", GetEventType ());
         }
 
         public uint GetSize ()
@@ -41,20 +47,59 @@ namespace NachoCore.Brain
     {
 
         public NcBrainUIEventType UIType;
+
+        public NcBrainUIEvent (NcBrainUIEventType type) : base (NcBrainEventType.UI)
+        {
+            UIType = type;
+        }
+
+        public string GetUIType ()
+        {
+            return Enum.GetName (typeof(NcBrainUIEventType), UIType);
+        }
+
+        public override string ToString ()
+        {
+            return String.Format ("[NcBrainUIEvent: type={0}, uitype={1}]", GetEventType (), GetUIType ());
+        }
+    }
+
+    public class NcBrainUIMessageViewEvent : NcBrainUIEvent
+    {
         public DateTime Start;
         public DateTime End;
 
-        public NcBrainUIEvent (NcBrainUIEventType type, DateTime start, DateTime end) : base (NcBrainEventType.UI)
+        public NcBrainUIMessageViewEvent (NcBrainUIEventType type, DateTime start, DateTime end) : base (type)
         {
-            UIType = type;
             Start = start;
             End = end;
         }
 
         public override string ToString ()
         {
-            return String.Format ("<NcBrainUIEvent: type={0}, start={1}, end={2}>",
-                Enum.GetName (typeof(NcBrainUIEventType), Type), Start, End);
+            return String.Format ("[NcBrainUIMessageViewEvent: type={0}, uitype={1}, start={2}, end={3}]",
+                GetEventType (), GetUIType (), Start, End);
+        }
+    }
+
+    /// This event tells brain that user has changed either the due date or the deferred until date.
+    /// Upon receiving this, brain will re-evaluate the time variance state machine for the
+    /// email message
+    public class NcBrainMessageFlagEvent : NcBrainEvent
+    {
+        public Int64 AccountId;
+        public Int64 EmailMessageId;
+
+        public NcBrainMessageFlagEvent (Int64 accountId, Int64 emailMessageId) : base (NcBrainEventType.MESSAGE_FLAGS)
+        {
+            AccountId = accountId;
+            EmailMessageId = emailMessageId;
+        }
+
+        public override string ToString ()
+        {
+            return String.Format ("[NcBrainMessageFlagEvent: type={0}, accountId={2}, emailMessageId={3}",
+                GetEventType (), AccountId, EmailMessageId);
         }
     }
 }

--- a/NachoClient.Android/NachoCore/Brain/NcMessageDeferral.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcMessageDeferral.cs
@@ -49,6 +49,7 @@ namespace NachoCore.Brain
                 var utc = deferUntil;
                 var local = deferUntil.ToLocalTime ();
                 BackEnd.Instance.SetEmailFlagCmd (message.AccountId, message.Id, "Defer until", local, utc, local, utc);
+                NcBrain.SharedInstance.Enqueue (new NcBrainMessageFlagEvent (message.AccountId, message.Id));
             }
             return NcResult.OK ();
         }
@@ -57,6 +58,7 @@ namespace NachoCore.Brain
         {
             foreach (var message in thread) {
                 BackEnd.Instance.ClearEmailFlagCmd (message.AccountId, message.Id);
+                NcBrain.SharedInstance.Enqueue (new NcBrainMessageFlagEvent (message.AccountId, message.Id));
             }
             return NcResult.OK ();
         }
@@ -71,6 +73,7 @@ namespace NachoCore.Brain
             foreach (var message in thread) {
                 var start = DateTime.UtcNow;
                 BackEnd.Instance.SetEmailFlagCmd (message.AccountId, message.Id, "For follow up by", start.ToLocalTime (), start, dueOn.ToLocalTime (), dueOn);
+                NcBrain.SharedInstance.Enqueue (new NcBrainMessageFlagEvent (message.AccountId, message.Id));
             }
             return NcResult.OK ();
         }

--- a/NachoClient.Android/NachoCore/Brain/NcTimeVariance.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcTimeVariance.cs
@@ -384,6 +384,19 @@ namespace NachoCore.Brain
             Run ();
         }
 
+        public static void StopList (string description)
+        {
+            TimeVarianceList tvList = ActiveList.GetList (description);
+            if (null == tvList) {
+                return;
+            }
+            foreach (NcTimeVariance tv in tvList) {
+                tv.StopTimer ();
+            }
+            bool removed = ActiveList.RemoveList (description);
+            NcAssert.True (removed);
+        }
+
         public static void AdvanceCallback (object obj)
         {
             NcTimeVariance tv = obj as NcTimeVariance;

--- a/NachoClient.Android/NachoCore/Model/EmailAddressScore.cs
+++ b/NachoClient.Android/NachoCore/Model/EmailAddressScore.cs
@@ -182,7 +182,9 @@ namespace NachoCore.Model
         {
             int rc = Insert ();
             if (0 < rc) {
-                NcBrain.SharedInstance.McEmailAddressCounters.Insert.Click ();
+                NcBrain brain = NcBrain.SharedInstance;
+                brain.McEmailAddressCounters.Insert.Click ();
+                brain.NotifyEmailAddressUpdates ();
             }
         }
 
@@ -190,7 +192,9 @@ namespace NachoCore.Model
         {
             int rc = Update ();
             if (0 < rc) {
-                NcBrain.SharedInstance.McEmailAddressCounters.Update.Click ();
+                NcBrain brain = NcBrain.SharedInstance;
+                brain.McEmailAddressCounters.Update.Click ();
+                brain.NotifyEmailAddressUpdates ();
                 if (null != SyncInfo) {
                     SyncInfo.Update ();
                 }
@@ -201,7 +205,9 @@ namespace NachoCore.Model
         {
             int rc = Delete ();
             if (0 < rc) {
-                NcBrain.SharedInstance.McEmailAddressCounters.Delete.Click ();
+                NcBrain brain = NcBrain.SharedInstance;
+                brain.McEmailAddressCounters.Delete.Click ();
+                brain.NotifyEmailAddressUpdates ();
             }
         }
 

--- a/NachoClient.Android/NachoCore/Utils/NcResult.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcResult.cs
@@ -72,6 +72,10 @@ namespace NachoCore.Utils
             Info_AsProvisionSuccess,
             Info_AsOptionsSuccess,
             Info_AsSettingsSuccess,
+
+            Info_EmailAddressScoreUpdated,
+            Info_EmailMessageScoreUpdated,
+
             // Warning.
             // Error.
             Error_NetworkUnavailable,


### PR DESCRIPTION
Add status indication for brain to broadcast score updates. Two separate subkinds are created - one for email addresses and one for email messages. UI view controllers that care about scores of these objects should listen for that status indication.

UI updates of due date and deferred until flags are sent to brain via brain event queue. (It seems kind of strange for one brain object to talk to another brain object via status indication.) API is added to re-evaluate a list of time variance state machines for an email message after they are started.
