### PR TITLE
Add UI button telemetry support.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -21,13 +21,15 @@ namespace NachoCore.Utils
         STATE_MACHINE,
         COUNTER,
         CAPTURE,
-        MAX_TELEMETRY_EVENT_TYPE}
-
-    ;
+        UI,
+        MAX_TELEMETRY_EVENT_TYPE
+    };
 
     [Serializable]
     public class TelemetryEvent : NcQueueElement
     {
+        public const string UIBUTTON = "UIButton";
+
         public DateTime Timestamp { set; get; }
 
         private TelemetryEventType _Type;
@@ -182,6 +184,33 @@ namespace NachoCore.Utils
             }
         }
 
+
+        // UI event fields
+        // UI type is the type of objects - UIButton, UILabel and etc
+        private string _UiType;
+
+        public string UiType {
+            get {
+                return _UiType;
+            }
+            set {
+                NcAssert.True (IsUiEvent ());
+                _UiType = value;
+            }
+        }
+
+        private string _UiObject;
+
+        public string UiObject {
+            get {
+                return _UiObject;
+            }
+            set {
+                NcAssert.True (IsUiEvent ());
+                _UiObject = value;
+            }
+        }
+
         public static bool IsLogEvent (TelemetryEventType type)
         {
             return ((TelemetryEventType.ERROR == type) ||
@@ -206,6 +235,11 @@ namespace NachoCore.Utils
             return (TelemetryEventType.CAPTURE == type);
         }
 
+        public static bool IsUiEvent (TelemetryEventType type)
+        {
+            return (TelemetryEventType.UI == type);
+        }
+
         public bool IsLogEvent ()
         {
             return IsLogEvent (Type);
@@ -224,6 +258,11 @@ namespace NachoCore.Utils
         public bool IsCaptureEvent ()
         {
             return IsCaptureEvent (Type);
+        }
+
+        public bool IsUiEvent ()
+        {
+            return IsUiEvent (Type);
         }
 
         public TelemetryEvent (TelemetryEventType type)
@@ -404,6 +443,20 @@ namespace NachoCore.Utils
             tEvent.Min = min;
             tEvent.Max = max;
             tEvent.StdDev = stddev;
+
+            RecordRawEvent (tEvent);
+        }
+
+        public static void RecordUiButton (string uiObject)
+        {
+            if (!ENABLED) {
+                return;
+            }
+
+            TelemetryEvent tEvent = new TelemetryEvent (TelemetryEventType.UI);
+
+            tEvent.UiType = TelemetryEvent.UIBUTTON;
+            tEvent.UiObject = uiObject;
 
             RecordRawEvent (tEvent);
         }

--- a/NachoClient.Android/NachoCore/Utils/TelemetryParse.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryParse.cs
@@ -169,12 +169,12 @@ namespace NachoCore.Utils
                 }
                 dict.AddData ("wbxml", tEvent.Wbxml);
             } else if (tEvent.IsCounterEvent ()) {
-                dict.AddString ("event_type",  "COUNTER");
+                dict.AddString ("event_type", "COUNTER");
                 dict.AddString ("counter_name", tEvent.CounterName);
                 dict.AddInteger ("count", tEvent.Count);
                 dict.AddDate ("counter_start", tEvent.CounterStart);
                 dict.AddDate ("counter_end", tEvent.CounterEnd);
-            } else if (tEvent.IsCaptureEvent()) {
+            } else if (tEvent.IsCaptureEvent ()) {
                 dict.AddString ("event_type", "CAPTURE");
                 dict.AddString ("capture_name", tEvent.CaptureName);
                 dict.AddInteger ("count", tEvent.Count);
@@ -182,6 +182,14 @@ namespace NachoCore.Utils
                 dict.AddInteger ("min", tEvent.Min);
                 dict.AddInteger ("max", tEvent.Max);
                 dict.AddInteger ("stddev", tEvent.StdDev);
+            } else if (tEvent.IsUiEvent ()) {
+                dict.AddString ("event_type", "UI");
+                dict.AddString ("ui_type", tEvent.UiType);
+                if (null == tEvent.UiObject) {
+                    dict.AddString ("ui_object", "(unknown)");
+                } else { 
+                    dict.AddString ("ui_object", tEvent.UiObject);
+                }
             } else {
                 NcAssert.True (false);
             }

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -22,6 +22,7 @@ using MonoTouch.ObjCRuntime;
 using ParseBinding;
 using NachoClient.Build;
 using HockeyApp;
+using NachoUIMonitorBinding;
 
 namespace NachoClient.iOS
 {
@@ -117,12 +118,25 @@ namespace NachoClient.iOS
             Log.Info (Log.LOG_LIFECYCLE, "FailedToRegisterForRemoteNotifications: {0}", error.LocalizedDescription);
         }
 
+        /// This is not a service but rather initialization of some native
+        /// ObjC functions. It must be initialized before any UI object is
+        /// created.
+        private void StartUIMonitor ()
+        {
+            NachoUIMonitor.SetupUIButton (delegate(string description) {
+                if (null == description) {
+                    description = "(unknown)";
+                }
+                Telemetry.RecordUiButton (description);
+            });
+        }
+
         // This method is common to both launching into the background and into the foreground.
         // It gets called once during the app lifecycle.
         public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
         {
             Log.Info (Log.LOG_LIFECYCLE, "FinishedLaunching: Called");
-
+            StartUIMonitor ();
             NcApplication.Instance.StartClass1Services ();
             Log.Info (Log.LOG_LIFECYCLE, "FinishedLaunching: StartClass1Services complete");
 


### PR DESCRIPTION
Add NachoUIMonitor repo (already separately committed) that provides an ObjC library that invokes a callback whenever an UIButton is clicked. Add a new UI telemetry event and a new API to send an UI event in the callback.

The current object id is self.currentTitle which does not work for image-based buttons. A future commit will implement a better id scheme.
