### PR TITLE
Implement VIP and UserAction correctly.

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrainEvent.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainEvent.cs
@@ -11,8 +11,11 @@ namespace NachoCore.Brain
         UI,
         STATE_MACHINE,
         TERMINATE,
+        TEST,
         MESSAGE_FLAGS,
         INITIAL_RIC,
+        UPDATE_ADDRESS_SCORE,
+        UPDATE_MESSAGE_SCORE
     };
 
     public class NcBrainEvent : NcQueueElement
@@ -83,6 +86,65 @@ namespace NachoCore.Brain
         }
     }
 
+    public class NcBrainInitialRicEvent : NcBrainEvent
+    {
+        public Int64 AccountId;
+
+        public NcBrainInitialRicEvent (Int64 accountId) : base (NcBrainEventType.INITIAL_RIC)
+        {
+            AccountId = accountId;
+        }
+
+        public override string ToString ()
+        {
+            return String.Format ("[NcBrainInitialRicEvent: type={0}, accountId={1}]", GetEventType (), AccountId);
+        }
+    }
+
+    /// This event is used when an UI / backend action causes the score of 
+    /// an email address to be updated.
+    public class NcBrainUpdateAddressScoreEvent : NcBrainEvent
+    {
+        public Int64 EmailAddressId;
+
+        /// Normally, dependent messages are only updated if the address score changes.
+        /// Setting this flag to true causes dependent email message scores to be 
+        /// updated regardless.
+        public bool ForceUpdateDependentMessages;
+
+        public NcBrainUpdateAddressScoreEvent (Int64 emailAddressId, bool forcedUpdateDependentMessages)
+            : base (NcBrainEventType.UPDATE_ADDRESS_SCORE)
+        {
+            EmailAddressId = emailAddressId;
+            ForceUpdateDependentMessages = forcedUpdateDependentMessages;
+        }
+
+        public override string ToString ()
+        {
+            return String.Format ("[NcBrainUpdateAddressScoreEvent: type={0}, emailAddressId={1}",
+                GetEventType (), EmailAddressId);
+        }
+    }
+
+    /// This event is used when an UI / backend action causes the score of 
+    /// an email message to be updated.
+    public class NcBrainUpdateMessageScoreEvent : NcBrainEvent
+    {
+        public Int64 EmailMessageId;
+
+        public NcBrainUpdateMessageScoreEvent (Int64 emailMessageId)
+            : base (NcBrainEventType.UPDATE_MESSAGE_SCORE)
+        {
+            EmailMessageId = emailMessageId;
+        }
+
+        public override string ToString ()
+        {
+            return String.Format ("[NcBrainUpdateMessageScoreEvent: type={0}, emailMessageId={1}",
+                GetEventType (), EmailMessageId);
+        }
+    }
+
     /// This event tells brain that user has changed either the due date or the deferred until date.
     /// Upon receiving this, brain will re-evaluate the time variance state machine for the
     /// email message
@@ -101,21 +163,6 @@ namespace NachoCore.Brain
         {
             return String.Format ("[NcBrainMessageFlagEvent: type={0}, accountId={1}, emailMessageId={2}]",
                 GetEventType (), AccountId, EmailMessageId);
-        }
-    }
-
-    public class NcBrainInitialRicEvent : NcBrainEvent
-    {
-        public Int64 AccountId;
-
-        public NcBrainInitialRicEvent (Int64 accountId) : base (NcBrainEventType.INITIAL_RIC)
-        {
-            AccountId = accountId;
-        }
-
-        public override string ToString ()
-        {
-            return String.Format ("[NcBrainInitialRicEvent: type={0}, accountId={1}]", GetEventType (), AccountId);
         }
     }
 }

--- a/NachoClient.Android/NachoCore/Model/EmailAddressScore.cs
+++ b/NachoClient.Android/NachoCore/Model/EmailAddressScore.cs
@@ -54,10 +54,6 @@ namespace NachoCore.Model
 
         public double GetScore ()
         {
-            if (IsVip) {
-                return 1.0; // 100% sure. User says so.
-            }
-
             int total = EmailsReceived + EmailsSent + EmailsDeleted;
             if (0 == total) {
                 return 0.0;
@@ -75,6 +71,11 @@ namespace NachoCore.Model
             }
             if (1 == ScoreVersion) {
                 // Version 2 statistics are updated by emails. Nothing to do here
+                ScoreVersion++;
+            }
+            if (2 == ScoreVersion) {
+                // No statisitcs are updated in v3. Just need to recompute the score
+                // using the new function.
                 ScoreVersion++;
             }
             NcAssert.True (Scoring.Version == ScoreVersion);
@@ -107,7 +108,7 @@ namespace NachoCore.Model
             SyncInfo = null;
         }
 
-        private void MarkDependencies ()
+        public void MarkDependencies ()
         {
             MarkDependentEmailMessages ();
             // TODO - mark dependent meetings later

--- a/NachoClient.Android/NachoCore/Model/McEmailAddress.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailAddress.cs
@@ -11,10 +11,6 @@ namespace NachoCore.Model
 {
     public partial class McEmailAddress : McAbstrObjectPerAcc
     {
-        public const int minHotScore = 1;
-        public const int minVipScore = 1000000;
-
-
         public McEmailAddress ()
         {
         }
@@ -27,8 +23,6 @@ namespace NachoCore.Model
 
         [Indexed]
         public string CanonicalEmailAddress { get; set; }
-
-        public bool IsHot { get; set; }
 
         public bool IsVip { get; set; }
 
@@ -64,22 +58,6 @@ namespace NachoCore.Model
                 emailAddress.Insert ();
             }
             return true;
-        }
-
-        /// TODO: VIPness should be in its own member
-        public bool isHot ()
-        {
-            if (isVip ()) {
-                return ((Score - minVipScore) >= minHotScore);
-            } else {
-                return (Score >= minHotScore);
-            }
-        }
-
-        /// TODO: VIPness should be in its own member
-        public bool isVip ()
-        {
-            return (Score >= minVipScore);
         }
     }
 }

--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
@@ -328,7 +328,7 @@ namespace NachoCore.Model
             return McAbstrFolderEntry.ClassCodeEnum.Email;
         }
 
-        public const double minHotScore = 0.1;
+        public const double minHotScore = 0.5;
 
         public bool isHot ()
         {

--- a/NachoClient.Android/NachoCore/Utils/NcQueue.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcQueue.cs
@@ -111,6 +111,13 @@ namespace NachoCore.Utils
                 return obj;
             }
         }
+
+        public bool IsEmpty ()
+        {
+            lock (Lock) {
+                return (0 == _Queue.Count);
+            }
+        }
     }
 }
 

--- a/NachoClient.Android/NachoCore/Utils/Scoring.cs
+++ b/NachoClient.Android/NachoCore/Utils/Scoring.cs
@@ -14,7 +14,8 @@ namespace NachoCore.Utils
         // Version 2 - Enforce EmailsReplied counter. Migrate EmailsRead count
         //             to EmailsReplied counter when appropriate. Add ScoreIsRead,
         //             ScoreIsReplied.
-        public const int Version = 2;
+        // Version 3 - Implement VIP email addresses and hot email messages.
+        public const int Version = 3;
     }
 }
 

--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -325,7 +325,7 @@ namespace NachoCore.Utils
 
     public class Telemetry
     {
-        private static bool ENABLED = true;
+        public static bool ENABLED = true;
         private static bool PERSISTED = true;
         // Parse has a maximum data size of 128K for PFObject. But the
         // exact definition of data size of an object with multiple

--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -13,6 +13,7 @@ using NachoCore.Model;
 using NachoCore.Utils;
 using MCSwipeTableViewCellBinding;
 using MonoTouch.Dialog;
+using NachoCore.Brain;
 
 namespace NachoClient.iOS
 {
@@ -574,6 +575,7 @@ namespace NachoClient.iOS
                     var message = messageThread.SingleMessageSpecialCase ();
                     message.UserAction = 1;
                     message.Update ();
+                    NcBrain.UpdateMessageScore (message.Id);
                     break;
                 case 1:
                     PerformSegue ("NachoNowToMessagePriority", new SegueHolder (messageThread));
@@ -718,6 +720,7 @@ namespace NachoClient.iOS
                     var message = messageThread.SingleMessageSpecialCase ();
                     message.UserAction = -1;
                     message.Update ();
+                    NcBrain.UpdateMessageScore (message.Id);
                 }
                 return;
             }

--- a/Test.Android/NcBrainTest.cs
+++ b/Test.Android/NcBrainTest.cs
@@ -1,0 +1,161 @@
+﻿//  Copyright (C) 2014 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+using System.Threading;
+using NUnit.Framework;
+using NachoCore.Utils;
+using NachoCore.Model;
+using NachoCore.Brain;
+
+namespace Test.Common
+{
+    public class NcBrainTest
+    {
+        static bool Initialized = false;
+
+        McEmailAddress Address;
+
+        McEmailMessage Message;
+
+        McEmailMessageDependency Dependency;
+
+        [SetUp]
+        public void SetUp ()
+        {
+            Telemetry.ENABLED = false;
+            if (!Initialized) {
+                NcTask.StartService ();
+                Initialized = true;
+            }
+            Address = new McEmailAddress ();
+            Address.AccountId = 1;
+            Address.CanonicalEmailAddress = "bob@company.com";
+            Address.Insert ();
+
+            Message = new McEmailMessage ();
+            Message.AccountId = 1;
+            Message.From = "bob@company.com";
+            Message.DateReceived = DateTime.Now;
+            Message.Insert ();
+
+            Dependency = new McEmailMessageDependency ();
+            Dependency.EmailMessageId = Message.Id;
+            Dependency.EmailAddressId = Address.Id;
+            Dependency.EmailAddressType = "Sender";
+            Dependency.Insert ();
+        }
+
+        [TearDown]
+        public void TearDown ()
+        {
+            if (0 != Dependency.Id) {
+                Dependency.Delete ();
+            }
+            if (0 != Message.Id) {
+                Message.Delete ();
+            }
+            if (0 != Address.Id) {
+                Address.Delete ();
+            }
+        }
+
+        private void WaitForBrain ()
+        {
+            while (!NcBrain.SharedInstance.IsQueueEmpty ()) {
+                Thread.Sleep (50);
+            }
+            NcBrain.SharedInstance.Enqueue (new NcBrainEvent (NcBrainEventType.TEST));
+            while (!NcBrain.SharedInstance.IsQueueEmpty ()) {
+                Thread.Sleep (50);
+            }
+        }
+
+        [TestCase]
+        public void UpdateEmailAddress ()
+        {
+            // Imagine initially 1 out of 3 emails are read
+            Address.Score = 1.0 / 3.0;
+            // Then receive one more and read it.
+            Address.EmailsReceived = 4;
+            Address.EmailsRead = 2;
+            Address.ScoreVersion = Scoring.Version;
+            Address.Update ();
+
+            long origCount = NcBrain.SharedInstance.McEmailAddressCounters.Update.Count;
+            NcBrain.UpdateAddressScore (Address.Id);
+            WaitForBrain ();
+
+            // The new score should be 0.5 with one update
+            Address = McEmailAddress.QueryById<McEmailAddress> (Address.Id);
+            Assert.AreEqual (0.5, Address.Score);
+            Assert.AreEqual (origCount + 1, NcBrain.SharedInstance.McEmailAddressCounters.Update.Count);
+
+            // Update again. Should get the same score with no update
+            NcBrain.UpdateAddressScore (Address.Id);
+            WaitForBrain ();
+        }
+
+        private void TestUpdateMessageScore (ref McEmailMessage message)
+        {
+            NcBrain.UpdateMessageScore (message.Id);
+            WaitForBrain ();
+            message = McEmailMessage.QueryById<McEmailMessage> (message.Id);
+        }
+
+        [TestCase]
+        public void UpdateEmailMessage ()
+        {
+            Address.IsVip = false;
+            Address.EmailsRead = 2;
+            Address.EmailsReceived = 3;
+            Address.Score = 2.0 / 3.0;
+            Address.Update ();
+
+            // Setting UserAction to +1 changes the score to VipScore. 
+            Message.Score = 2.0 / 3.0;
+            Message.ScoreVersion = Scoring.Version;
+            Message.UserAction = +1;
+            Message.Update ();
+
+            TestUpdateMessageScore (ref Message);
+            Assert.AreEqual (McEmailMessage.VipScore, Message.Score);
+
+            // Setting UserAction to -1 changes the score to less than minHotScore
+            Message.UserAction = -1;
+            Message.Update ();
+
+            TestUpdateMessageScore (ref Message);
+            Assert.True (McEmailMessage.VipScore > Message.Score);
+
+            // Settting UserAction back to 0 changes it back to 2/3
+            Message.UserAction = 0;
+            Message.Update ();
+
+            TestUpdateMessageScore (ref Message);
+            Assert.AreEqual (2.0 / 3.0, Message.Score);
+
+            // Setting McEmailAddress.IsVip to true changes the score to VipScore again.
+            Address.IsVip = true;
+            Address.Update ();
+
+            TestUpdateMessageScore (ref Message);
+            Assert.AreEqual (McEmailMessage.VipScore, Message.Score);
+
+            // Error case. Update a message that does not exist
+            NcBrain brain = NcBrain.SharedInstance;
+            long origCount = brain.McEmailAddressCounters.Update.Count;
+
+            NcBrain.UpdateMessageScore (1000000);
+            WaitForBrain ();
+
+            Assert.AreEqual (origCount, brain.McEmailAddressCounters.Update.Count);
+
+            // Error case. Update a message who score does not change
+            NcBrain.UpdateMessageScore (Message.Id);
+            WaitForBrain ();
+
+            Assert.AreEqual (origCount, brain.McEmailAddressCounters.Update.Count);
+        }
+    }
+}
+

--- a/Test.Android/Test.Android.csproj
+++ b/Test.Android/Test.Android.csproj
@@ -104,6 +104,7 @@
     <Compile Include="NcTimeVarianceTest.cs" />
     <Compile Include="NcTimerTest.cs" />
     <Compile Include="NcTimerPoolTest.cs" />
+    <Compile Include="NcBrainTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/Test.iOS/Test.iOS.csproj
+++ b/Test.iOS/Test.iOS.csproj
@@ -218,8 +218,12 @@
     <Compile Include="..\Test.Android\NcTimerPoolTest.cs">
       <Link>NcTimerPoolTest.cs</Link>
     </Compile>
+    <Compile Include="..\Test.Android\NcBrainTest.cs">
+      <Link>NcBrainTest.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\NachoClient.iOS\NachoClient.iOS.csproj">
       <Project>{7B5D1554-2619-4B46-BE91-585C896047AC}</Project>


### PR DESCRIPTION
McEmailAddress
- Get rid of IsHot and isHot().
- IsVip no longer affect address score.

McEmailMessage
- McEmailAddress.IsVip pins message score to VipScore.
- Implements UserAction.
- Change minimal score to be considered hot (minHotScore) to 0.5.

Bump Scoring.Version to 3 to force a re-scoring of all addresses and messages.
Add unit test. (Add some minor changes in various utility classes to make unit test works.)
