### PR TITLE
McContact notes are stored in the McContact's McBody, not as a

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
@@ -552,6 +552,7 @@ namespace NachoCore.ActiveSync
         public override string CreateContactCmd (int contactId, int folderId)
         {
             McContact contact;
+
             McFolder folder;
             if (!GetItemAndFolder<McContact> (contactId, out contact, folderId, out folder)) {
                 return null;
@@ -593,6 +594,7 @@ namespace NachoCore.ActiveSync
             };   
             pending.Insert ();
 
+            StatusInd (NcResult.Info (NcResult.SubKindEnum.Info_ContactSetChanged));
             NcTask.Run (delegate {
                 Sm.PostEvent ((uint)CtlEvt.E.PendQ, "ASPCCHGCTC");
             }, "UpdateContactCmd");

--- a/NachoClient.Android/NachoCore/Model/McBody.cs
+++ b/NachoClient.Android/NachoCore/Model/McBody.cs
@@ -52,8 +52,20 @@ namespace NachoCore.Model
         {
             var body = SaveStart ();
             File.WriteAllText (GetBodyPath (body.Id), content);
+
             body.SaveDone ();
             return body;
+        }
+
+        public void UpdateBody (string content)
+        {
+            File.WriteAllText (GetBodyPath (Id), content);
+
+            if (!IsValid) {
+                SaveDone ();
+            } else {
+                Update ();
+            }
         }
 
         public FileStream SaveFileStream ()

--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -565,7 +565,9 @@ namespace NachoCore.Model
         public override int Update ()
         {
             int retval = base.Update ();
-            InsertAncillaryData (NcModel.Instance.Db);
+            if (HasReadAncillaryData) {
+                InsertAncillaryData (NcModel.Instance.Db);
+            }
             return retval;
         }
 

--- a/Test.iOS/McContactTest.cs
+++ b/Test.iOS/McContactTest.cs
@@ -1,0 +1,30 @@
+﻿//  Copyright (C) 2014 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+using NUnit.Framework;
+using NachoCore;
+using NachoCore.Utils;
+using NachoCore.Model;
+using System.Collections.Generic;
+
+namespace Test.Common
+{
+    public class McContactTest : NcTestBase
+    {
+
+        [Test]
+        public void Update_01 ()
+        {
+            var c = new McContact ();
+            c.AccountId = 1;
+            c.AddEmailAddressAttribute ("bob", "home", "bob@foo.com");
+            c.Insert ();
+            var d = McContact.QueryById<McContact> (c.Id);
+            // Don't assert anything about 'd' because we don't want to read it in
+            d.Update ();
+            var e = McContact.QueryById<McContact> (d.Id);
+            Assert.AreEqual (1, e.EmailAddresses.Count);
+        }
+    }
+}
+

--- a/Test.iOS/Test.iOS.csproj
+++ b/Test.iOS/Test.iOS.csproj
@@ -227,6 +227,7 @@
     <Compile Include="..\Test.Android\McAttachmentTest.cs">
       <Link>McAttachmentTest.cs</Link>
     </Compile>
+    <Compile Include="McContactTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />


### PR DESCRIPTION
McNote. If a Contact's Source isn't ActiveSync, than notes are disabled for that contact. Fixed a bug in McContact's Update.
