### PR TITLE
Expandable header in message view

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcEmailAddress.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcEmailAddress.cs
@@ -212,7 +212,7 @@ namespace NachoCore.Utils
         }
 
         private static List<NcEmailAddress> ParseAddressListString (string addressString,
-            Kind addressKind,int accountId = 0)
+            Kind addressKind)
         {
             List<NcEmailAddress> addressList = new List<NcEmailAddress> ();
             if (null == addressString) {
@@ -223,37 +223,20 @@ namespace NachoCore.Utils
                 return addressList;
             }
             foreach (var inetAddress in inetAddressList.Mailboxes) {
-                NcEmailAddress address = new NcEmailAddress (addressKind, inetAddress.Address);
-                if (0 < accountId) {
-                    var contactList = McContact.QueryByEmailAddress (accountId, address.address);
-                    if (0 < contactList.Count) {
-                        // If there is more than one McContact that matches the email address,
-                        // prefer one that has a proper display name.
-                        foreach (var contact in contactList) {
-                            if ("" != contact.GetDisplayName ()) {
-                                address.contact = contact;
-                                break;
-                            }
-                        }
-                        // If no contact has a proper display name, default to 1st contact
-                        if (null == address.contact) {
-                            address.contact = contactList [0];
-                        }
-                    }
-                }
+                NcEmailAddress address = new NcEmailAddress (addressKind, inetAddress.ToString ());
                 addressList.Add (address);
             }
             return addressList;
         }
 
-        public static List<NcEmailAddress> ParseToAddressListString (string toAddressString, int accountId = 0)
+        public static List<NcEmailAddress> ParseToAddressListString (string toAddressString)
         {
-            return ParseAddressListString (toAddressString, Kind.To, accountId);
+            return ParseAddressListString (toAddressString, Kind.To);
         }
 
-        public static List<NcEmailAddress> ParseCcAddressListString (string ccAddressString, int accountId = 0)
+        public static List<NcEmailAddress> ParseCcAddressListString (string ccAddressString)
         {
-            return ParseAddressListString (ccAddressString, Kind.Cc, accountId);
+            return ParseAddressListString (ccAddressString, Kind.Cc);
         }
 
         /// <summary>

--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -630,11 +630,11 @@ namespace NachoClient.iOS
                 ccView.Hidden = true;
             } else {
                 toView.Clear ();
-                foreach (var address in NcEmailAddress.ParseToAddressListString (message.To, message.AccountId)) {
+                foreach (var address in NcEmailAddress.ParseToAddressListString (message.To)) {
                     toView.Append (address);
                 }
                 ccView.Clear ();
-                foreach (var address in NcEmailAddress.ParseCcAddressListString (message.Cc, message.AccountId)) {
+                foreach (var address in NcEmailAddress.ParseCcAddressListString (message.Cc)) {
                     ccView.Append (address);
                 }
                 toView.Hidden = false;
@@ -877,7 +877,10 @@ namespace NachoClient.iOS
 
             // Toggle header display mode and redraw
             expandedHeader = !expandedHeader;
-            ConfigureView ();
+
+            UIView.Animate (0.2, 0, UIViewAnimationOptions.CurveLinear, () => {
+                ConfigureView ();
+            }, () => {});
         }
 
         protected void RenderMime (string bodyPath)

--- a/NachoClient.iOS/NachoUI.iOS/Support/UcAddressBlock.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/UcAddressBlock.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
 
+using MimeKit;
 using NachoCore.Utils;
 
 namespace NachoClient.iOS
@@ -103,7 +104,18 @@ namespace NachoClient.iOS
             }
 
             if (null == address.contact) {
-                AppendInternal (address.address, address, UcAddressField.TEXT_FIELD);
+                string text;
+                InternetAddress parsedAddress;
+                if (!InternetAddress.TryParse (address.address, out parsedAddress)) {
+                    text = address.address; // can't parse the string. just display verbatim
+                } else {
+                    if ((null != parsedAddress.Name) && (0 < parsedAddress.Name.Length)) {
+                        text = parsedAddress.Name; // prefer display name
+                    } else {
+                        text = (parsedAddress as MailboxAddress).Address; // fallback to email address
+                    }
+                }
+                AppendInternal (text, address, UcAddressField.TEXT_FIELD);
             } else {
                 AppendInternal (address.contact.GetDisplayNameOrEmailAddress(), address, UcAddressField.TEXT_FIELD);
             }


### PR DESCRIPTION
- Add API to NcEmailAddress to convert a string (of email addresses) to a list of NcEmailAddress with optional McContacts.
- Add API to make UcAddressBlock non-editable and adjustable line height. (The to and cc in message view is read-only.)
- Make message view header section expandable via single tap.
- The compact header has From, subject, and received date. The expanded header adds to and cc list.

The following is a screenshot of the expanded view. The compact is the same as previous header.

![expanded_header_screenshot](https://cloud.githubusercontent.com/assets/6926104/4210027/5b430294-3870-11e4-9cc0-16083c13a8bd.png)
