### PR TITLE
Rework message preview. 

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -768,8 +768,6 @@ namespace NachoClient.iOS
 
             if (McAbstrItem.BodyStateEnum.Whole_0 != message.BodyState) {
                 Log.Info (Log.LOG_EMAIL, "Starting download of whole message body");
-                RenderPartialDownloadMessage ("[ Message preview only. Downloading the complete message ]");
-                RenderTextString (message.GetBodyPreviewOrEmpty ());
                 StartSpinner ();
                 BackEnd.Instance.DnldEmailBodyCmd (message.AccountId, message.Id);
                 return;


### PR DESCRIPTION
- Now show a preview header that indicates the display is only a partial message.
- Preview is shown during download.
- If downlaod fails, preview header instructs users to tap the header to restart downloading.

![preview_screenshot](https://cloud.githubusercontent.com/assets/6926104/4227051/a9e210a6-393e-11e4-81a0-f284bdf7be20.png)
