### PR TITLE
Rework UcAddressField. 

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/UcAddressField.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/UcAddressField.cs
@@ -1,9 +1,11 @@
-﻿using System;
+﻿//#define DEBUG_UI
+using System;
 using System.Drawing;
 using System.Collections.Generic;
 
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
+using MonoTouch.ObjCRuntime;
 
 using NachoCore.Utils;
 
@@ -13,18 +15,54 @@ namespace NachoClient.iOS
     {
         // Shows the contact
         public const int TEXT_FIELD = 1;
-        // Shows the separating comma
-        public const int COMMA_FIELD = 2;
+        // Shows the white space between text fields
+        public const int GAP_FIELD = 2;
         // Text field at the end of the list
         public const int ENTRY_FIELD = 3;
 
         public int type;
-        public bool selected;
         public NcEmailAddress address;
 
         public UcAddressField (int type)
         {
             this.type = type;
+            switch (this.type) {
+            case GAP_FIELD:
+                #if (DEBUG_UI)
+                BackgroundColor = UIColor.Red;
+                #else
+                BackgroundColor = UIColor.White;
+                #endif
+                break;
+            case TEXT_FIELD:
+                #if (DEBUG_UI)
+                BackgroundColor = UIColor.Yellow;
+                #else
+                BackgroundColor = A.Color_NachoLightGrayBackground;
+                #endif
+                BorderStyle = UITextBorderStyle.RoundedRect;
+
+                // Short taps on the text field activate the closest gap or entry field.
+                var shortTap = new UITapGestureRecognizer ();
+                shortTap.NumberOfTapsRequired = 1;
+                shortTap.AddTarget (this, new Selector ("onShortTap:"));
+                shortTap.ShouldRecognizeSimultaneously = delegate {
+                    return true;
+                };
+                AddGestureRecognizer (shortTap);
+
+                // TODO - If we want to support copy-n-paste of email addresses, we can
+                // add a long tap gesture recognizer to pop up the copy menu.
+                UserInteractionEnabled = true;
+                break;
+            case ENTRY_FIELD:
+                #if (DEBUG_UI)
+                BackgroundColor = UIColor.Orange;
+                #else
+                BackgroundColor = UIColor.White;
+                #endif
+                break;
+            }
         }
 
         // Return null to hide the caret.  We want it hidden in a text field.
@@ -38,7 +76,32 @@ namespace NachoClient.iOS
                 return base.GetCaretRectForPosition (position);
             }
         }
-         
+
+        public bool IsTextField ()
+        {
+            return (TEXT_FIELD == type);
+        }
+
+        public bool IsGapField ()
+        {
+            return (GAP_FIELD == type);
+        }
+
+        [MonoTouch.Foundation.Export ("onShortTap:")]
+        public void OnShortTap (UIGestureRecognizer sender)
+        {
+            var addressField = sender.View as UcAddressField;
+            PointF touch = sender.LocationInView (addressField);
+            var addressBlock = addressField.Superview as UcAddressBlock;
+            // Depnding on whether the touch is on the left half or right half
+            // of the text field, we make either the gap before or after this
+            // text field active.
+            var field = (touch.X > (Frame.Width / 2) ? 
+                addressBlock.AddressFieldSuccessor (addressField) : 
+                addressBlock.AddressFieldPredecessor (addressField));
+            NcAssert.True (null != field);
+            field.BecomeFirstResponder ();
+        }
     };
 }
 


### PR DESCRIPTION
- Text field is no longer selectable. ('selected' field is removed.)
- Comma fields become gap fields that provide only whitespace (no more commas).
- Tapping on addresses activates closest gap fields with a caret.
- Address can now be inserted in any gap.

The following two screenshots are the message compose view with expanded and compact headers:

![compose_expanded](https://cloud.githubusercontent.com/assets/6926104/4315164/3bfa27a2-3eef-11e4-84f8-addab154f036.png)

![compose_compact](https://cloud.githubusercontent.com/assets/6926104/4315165/41085a34-3eef-11e4-818d-1cca562c2cf9.png)

Message view also uses UcAddressBlock for displaying address lists. (The black bar seen below seems to be introduce in the last 24 hrs. Will track that down separately.)

![message_view_expanded](https://cloud.githubusercontent.com/assets/6926104/4315171/69751ae8-3eef-11e4-9346-47a4f5c66387.png)
