### PR TITLE
Convert smart F/R to send; un-downloaded attachments during forward

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
@@ -135,8 +135,6 @@ namespace NachoCore.ActiveSync
 
             var refdEmailMessage = McAbstrObject.QueryById<McEmailMessage> (refdEmailMessageId);
             var newEmailMessage = McAbstrObject.QueryById<McEmailMessage> (newEmailMessageId);
-            newEmailMessage.ReferencedEmailId = refdEmailMessageId;
-            newEmailMessage.Update ();
             folder = McAbstrObject.QueryById<McFolder> (folderId);
             if (null == refdEmailMessage || null == newEmailMessage || null == folder) {
                 return null;

--- a/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
+++ b/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
@@ -509,8 +509,9 @@ namespace NachoCore.Utils
             // Convert the McAttachments into MIME attachments.
             AttachmentCollection mimeAttachments = new AttachmentCollection ();
             foreach (var attachment in attachments) {
-                NcAssert.True (McAttachment.FilePresenceEnum.Complete == attachment.FilePresence, "An attachment needs to be downloaded before it can be added to a message.");
-                mimeAttachments.Add (attachment.GetFilePath ());
+                if (McAttachment.FilePresenceEnum.Complete == attachment.FilePresence) {
+                    mimeAttachments.Add (attachment.GetFilePath ());
+                }
             }
 
             Multipart attachmentsParent = null; // Where to put the attachments

--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -23,7 +23,7 @@ namespace NachoClient.iOS
         // iOS Bug Workaround
         // The cancel button on the search bar breaks
         // if the searchbar is hidden by a scrolled tableview.
-        PointF savedContentOffset;
+        //PointF savedContentOffset; all uses are commented out, so comment out the definition to avoid a warning.
         protected UIBarButtonItem composeMailButton;
         protected UIBarButtonItem cancelSelectedButton;
         protected UIBarButtonItem deleteSelectedButton;


### PR DESCRIPTION
Provide a method that converts a message from a smart forward or smart reply to a regular send. This conversion may involve adding the body of the original message into the body of the outgoing message, and adding any attachments from the original message.

Correctly handle the case where a message with attachments is forwarded, but some of those attachments have not yet been downloaded.  The attachments need to be downloaded before they can be attached to the outgoing message.
