### PR TITLE
Add a specialized McEmailMessage update API for brain.

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -177,8 +177,7 @@ namespace NachoCore.Brain
                 Log.Debug (Log.LOG_BRAIN, "[McEmailMessage:{0}] update score -> {1:F6}",
                     emailMessage.Id, emailMessage.Score);
                 emailMessage.NeedUpdate = false;
-                emailMessage.UpdateByBrain ();
-
+                emailMessage.UpdateScoreAndNeedUpdate ();
                 numUpdated++;
             }
             Log.Info (Log.LOG_BRAIN, "{0} email message scores updated", numUpdated);

--- a/NachoClient.Android/NachoCore/Model/EmailAddressScore.cs
+++ b/NachoClient.Android/NachoCore/Model/EmailAddressScore.cs
@@ -181,7 +181,7 @@ namespace NachoCore.Model
                 foreach (McEmailMessage m in emailMesageList) {
                     NcAssert.True (!m.NeedUpdate);
                     m.NeedUpdate = true;
-                    m.UpdateByBrain ();
+                    m.UpdateScoreAndNeedUpdate ();
                 }
             }
         }

--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/EmailMessageScore.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/EmailMessageScore.cs
@@ -459,6 +459,19 @@ namespace NachoCore.Model
             }
         }
 
+        public void UpdateScoreAndNeedUpdate ()
+        {
+            int rc = NcModel.Instance.Db.Execute (
+                         "UPDATE McEmailMessage " +
+                         "SET Score = ?,  NeedUpdate = ? " +
+                         "WHERE Id = ?", Score, NeedUpdate, Id);
+            if (0 < rc) {
+                NcBrain brain = NcBrain.SharedInstance;
+                brain.McEmailAddressCounters.Update.Click ();
+                brain.NotifyEmailMessageUpdates ();
+            }
+        }
+
         private static void TimeVarianceCallBack (int state, Int64 objId)
         {
             McEmailMessage emailMessage = McEmailMessage.QueryById<McEmailMessage> ((int)objId);

--- a/Test.Android/McEmailMessageTest.cs
+++ b/Test.Android/McEmailMessageTest.cs
@@ -150,6 +150,41 @@ namespace Test.Common
             NcAssert.Equals (2, result.Count ());
             NcAssert.True (result.All (x => x.AccountId == 1 && x.BodyId == 55));
         }
+
+        private void CheckScoreAndUpdate (int id, double expectedScore, bool expectedNeedUpdate)
+        {
+            McEmailMessage message = McEmailMessage.QueryById<McEmailMessage> (id);
+            Assert.True (null != message);
+
+            Assert.AreEqual(expectedScore, message.Score);
+            Assert.AreEqual (expectedNeedUpdate, message.NeedUpdate);
+        }
+
+        [Test]
+        public void TestUpdateScoreAndNeedUpdate ()
+        {
+            McEmailMessage message = new McEmailMessage () {
+                AccountId = 1,
+            };
+            message.Insert ();
+            NcAssert.True (0 < message.Id);
+
+            Assert.AreEqual (0.0, message.Score);
+            Assert.AreEqual (false, message.NeedUpdate);
+
+            message.Score = 1.0;
+            message.UpdateScoreAndNeedUpdate ();
+            CheckScoreAndUpdate (message.Id, 1.0, false);
+
+            message.NeedUpdate = true;
+            message.UpdateScoreAndNeedUpdate ();
+            CheckScoreAndUpdate (message.Id, 1.0, true);
+
+            message.Score = 0.5;
+            message.NeedUpdate = false;
+            message.UpdateScoreAndNeedUpdate ();
+            CheckScoreAndUpdate (message.Id, 0.5, false);
+        }
     }
 }
 


### PR DESCRIPTION
Intermittently, brain is taking a long time to update McEmailMessage. An example is:

Sep 17 09:24:38  NachoClientiOS[7626] <Warning>: Error:31:: SQLite: 1111ms for: update "McEmailMessage" set "To" = ? ,"Cc" = ? ,"From" = ? ,"cachedFromColor" = ? ,"cachedFromLetters" = ? ,"Subject" = ? ,"ReplyTo" = ? ,"DateReceived" = ? ,"DisplayTo" = ? ,"ThreadTopic" = ? ,"Importance" 

There are lots of update due to email address dependency in email messages. In these updates, only two fields are updated - Score and NeedUpdate. But a regular update does the entire ancillary data dance; doing a lot of unnecessary work.

The solution is to create a UpdateScoreAndNeedUpdate() API that uses SQL to update those two fields directly.
