### PR TITLE
Improve code to update an existing McBody

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McAttachment.cs
+++ b/NachoClient.Android/NachoCore/Model/McAttachment.cs
@@ -23,6 +23,19 @@ namespace NachoCore.Model
             return att;
         }
 
+        /// <summary>
+        /// Create a new McAttachment. The contents are filled in by passing a FileStream for the McAttachment's file to a delegate.
+        /// </summary>
+        /// <returns>A new McAttachment object that has been added to the database</returns>
+        public static McAttachment InsertFile (int accountId, WriteFileDelegate writer)
+        {
+            var body = new McAttachment () {
+                AccountId = accountId,
+            };
+            body.CompleteInsertFile (writer);
+            return body;
+        }
+
         [Indexed]
         public int EmailMessageId { get; set; }
 

--- a/NachoClient.Android/NachoCore/Model/McBody.cs
+++ b/NachoClient.Android/NachoCore/Model/McBody.cs
@@ -31,12 +31,29 @@ namespace NachoCore.Model
             return body;
         }
 
+        /// <summary>
+        /// Create a new McBody with the given string as the contents
+        /// </summary>
+        /// <returns>A new McBody object that has been added to the database</returns>
         public static McBody InsertFile (int accountId, string content)
         {
             var body = new McBody () {
                 AccountId = accountId,
             };
             body.CompleteInsertFile (content);
+            return body;
+        }
+
+        /// <summary>
+        /// Create a new McBody. The contents are filled in by passing a FileStream for the McBody's file to a delegate.
+        /// </summary>
+        /// <returns>A new McBody object that has been added to the database</returns>
+        public static McBody InsertFile (int accountId, WriteFileDelegate writer)
+        {
+            var body = new McBody () {
+                AccountId = accountId,
+            };
+            body.CompleteInsertFile (writer);
             return body;
         }
 

--- a/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
+++ b/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
@@ -384,14 +384,12 @@ namespace NachoCore.Utils
             msg.Subject = mimeMessage.Subject;
 
             // Create body
-            var body = McBody.InsertSaveStart (AccountId);
-            using (var fileStream = body.SaveFileStream ()) {
-                mimeMessage.WriteTo (fileStream);
-            }
-            body.UpdateSaveFinish ();
+            var body = McBody.InsertFile (AccountId, (FileStream stream) => {
+                mimeMessage.WriteTo (stream);
+            });
             msg.BodyId = body.Id;
 
-            NcModel.Instance.Db.Insert (msg);
+            msg.Insert ();
 
             return msg;
         }

--- a/NachoClient.Android/NachoCore/Utils/WBXML.cs
+++ b/NachoClient.Android/NachoCore/Utils/WBXML.cs
@@ -142,12 +142,10 @@ namespace NachoCore.Wbxml
                             #if (!WBXMLTOOL)
                             // We don't need to save the body to a file in the redacted XML case.
                             if (0 < accountId) {
-                                var data = McBody.InsertSaveStart (accountId);
-                                using (var fileStream = data.SaveFileStream ()) {
-                                    bytes.DequeueStringToStream (fileStream, CToken);
-                                }
+                                var data = McBody.InsertFile(accountId, ((FileStream stream) => {
+                                    bytes.DequeueStringToStream (stream, CToken);
+                                }));
                                 currentNode.Add (new XAttribute ("nacho-body-id", data.Id.ToString ()));
-                                data.UpdateSaveFinish ();
                             }
                             #else
                             // In WbxmlTool, we just write it to a memory stream and create a node for it.

--- a/NachoClient.iOS/NachoUI.iOS/EventAttachmentViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventAttachmentViewController.cs
@@ -241,13 +241,11 @@ namespace NachoClient.iOS
                     image = e.Info [UIImagePickerController.OriginalImage] as UIImage;
                 }
                 NcAssert.True (null != image);
-                var attachment = McAttachment.InsertSaveStart (account.Id);
-                using (var fileStream = attachment.SaveFileStream ()) {
+                var attachment = McAttachment.InsertFile (account.Id, ((FileStream stream) => {
                     using (var jpg = image.AsJPEG ().AsStream ()) {
-                        jpg.CopyTo (fileStream);
-                        jpg.Close ();
+                        jpg.CopyTo (stream);
                     }
-                }
+                }));
                 attachment.SetDisplayName (attachment.Id.ToString () + ".jpg");
                 attachment.UpdateSaveFinish ();
                 AttachmentsList.Add (attachment);

--- a/NachoClient.iOS/NachoUI.iOS/Support/UcAttachmentBlock.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/UcAttachmentBlock.cs
@@ -259,13 +259,11 @@ namespace NachoClient.iOS
                     image = e.Info [UIImagePickerController.OriginalImage] as UIImage;
                 }
                 NcAssert.True (null != image);
-                var attachment = McAttachment.InsertSaveStart (accountId);
-                using (var fileStream = attachment.SaveFileStream ()) {
+                var attachment = McAttachment.InsertFile (accountId, ((FileStream stream) => {
                     using (var jpg = image.AsJPEG ().AsStream ()) {
-                        jpg.CopyTo (fileStream);
-                        jpg.Close ();
+                        jpg.CopyTo (stream);
                     }
-                }
+                }));
                 attachment.SetDisplayName (attachment.Id.ToString () + ".jpg");
                 attachment.UpdateSaveFinish ();
                 Append (attachment);


### PR DESCRIPTION
Provide a way to update the existing contents of a McBody when you don't have a string, but instead have code that writes to a FileStream.

Improve the code for updating a McBody so that files are better managed and the backing file spends less time in an inconsistent state.
