### PR TITLE
Misc. modifications to login flow: Always enter server record into DB if...

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/HomeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/HomeViewController.cs
@@ -70,7 +70,7 @@ namespace NachoClient.iOS
                 LoginHelpers.SetFirstSyncCompleted (accountId, true);
             }
             if (NcResult.SubKindEnum.Info_AsAutoDComplete == s.Status.SubKind) {
-                Log.Info (Log.LOG_UI, "Auto-D-Completed Status Ind");
+                Log.Info (Log.LOG_UI, "Info_AsAutoDComplete Status Ind (Tutorial)");
                 LoginHelpers.SetAutoDCompleted (LoginHelpers.GetCurrentAccountId (), true);
             }
         }

--- a/NachoClient.iOS/NachoUI.iOS/Support/LoginHelpers.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/LoginHelpers.cs
@@ -11,6 +11,7 @@ namespace NachoClient.iOS
 {
     public class LoginHelpers
     {
+        protected const string MODULE = "ClientConfigurationBits";
         public LoginHelpers ()
         {
         }
@@ -19,7 +20,7 @@ namespace NachoClient.iOS
         static public void SetFirstSyncCompleted (int accountId, bool toWhat)
         {
             NcAssert.True (GetCurrentAccountId() == accountId);
-            McMutables.SetBool (accountId, "hasSyncedFolders", accountId.ToString (), toWhat);
+            McMutables.SetBool (accountId, MODULE, "hasSyncedFolders", toWhat);
         }
 
         //Gets the status of the sync bit for given accountId
@@ -28,23 +29,7 @@ namespace NachoClient.iOS
         static public bool HasFirstSyncCompleted(int accountId)
         {
             NcAssert.True (GetCurrentAccountId() == accountId);
-            return McMutables.GetOrCreateBool(accountId, "hasSyncedFolders", accountId.ToString (), false);
-        }
-
-        //Sets the status of the auto-d success bit for given accountId
-        static public void SetAutoDCompleted (int accountId, bool toWhat)
-        {
-            NcAssert.True (GetCurrentAccountId() == accountId);
-            McMutables.SetBool (accountId, "hasAutoDCompleted", accountId.ToString (), toWhat);
-        }
-
-        //Gets the status of the auto-d success bit for given accountId
-        //True if they have succesfully sync'd folders
-        //False if not
-        static public bool HasAutoDCompleted(int accountId)
-        {
-            NcAssert.True (GetCurrentAccountId() == accountId);
-            return McMutables.GetOrCreateBool(accountId, "hasAutoDCompleted", accountId.ToString (), false);
+            return McMutables.GetOrCreateBool(accountId, MODULE, "hasSyncedFolders", false);
         }
 
         //Sets the status of the tutorial bit for given accountId
@@ -52,7 +37,7 @@ namespace NachoClient.iOS
         {
             NcAssert.True (GetCurrentAccountId() == accountId);
             // TODO: should this really be per-account or once for all accounts?
-            McMutables.SetBool (accountId, "hasViewedTutorial", accountId.ToString (), toWhat);
+            McMutables.SetBool (accountId, MODULE, "hasViewedTutorial", toWhat);
         }
 
         //Gets the status of the tutorial bit for given accountId
@@ -61,14 +46,30 @@ namespace NachoClient.iOS
         static public bool HasViewedTutorial(int accountId)
         {
             NcAssert.True (GetCurrentAccountId() == accountId);
-            return McMutables.GetOrCreateBool(accountId, "hasViewedTutorial", accountId.ToString (), false);
+            return McMutables.GetOrCreateBool(accountId, MODULE, "hasViewedTutorial", false);
+        }
+
+        //Sets the status of the auto-d success bit for given accountId
+        static public void SetAutoDCompleted (int accountId, bool toWhat)
+        {
+            NcAssert.True (GetCurrentAccountId() == accountId);
+            McMutables.SetBool (accountId, MODULE, "hasAutoDCompleted", toWhat);
+        }
+
+        //Gets the status of the auto-d success bit for given accountId
+        //True if they have succesfully sync'd folders
+        //False if not
+        static public bool HasAutoDCompleted(int accountId)
+        {
+            NcAssert.True (GetCurrentAccountId() == accountId);
+            return McMutables.GetOrCreateBool(accountId, MODULE, "hasAutoDCompleted", false);
         }
 
         //Sets the status of the creds bit for given accountId
         static public void SetHasProvidedCreds (int accountId, bool toWhat)
         {
             NcAssert.True (GetCurrentAccountId() == accountId);
-            McMutables.SetBool (accountId, "hasProvidedCreds", accountId.ToString (), toWhat);
+            McMutables.SetBool (accountId, MODULE, "hasProvidedCreds", toWhat);
         }
 
         //Gets the status of the creds bit for given accountId
@@ -77,7 +78,7 @@ namespace NachoClient.iOS
         static public bool HasProvidedCreds(int accountId)
         {
             NcAssert.True (GetCurrentAccountId() == accountId);
-            return McMutables.GetOrCreateBool(accountId, "hasProvidedCreds", accountId.ToString (), false);
+            return McMutables.GetOrCreateBool(accountId, MODULE, "hasProvidedCreds", false);
         }
 
         static public int GetCurrentAccountId()

--- a/NachoClient.iOS/NachoUI.iOS/Support/WaitingScreen.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/WaitingScreen.cs
@@ -42,7 +42,7 @@ namespace NachoClient.iOS
         protected PointF topHalfSpinnerCenter;
         protected PointF bottomHalfSpinnerCenter;
 
-        protected NSTimer SegueToTutorial;
+        public NSTimer SegueToTutorial;
         protected const int WAIT_TIME = 12;
 
         public WaitingScreen ()
@@ -194,7 +194,7 @@ namespace NachoClient.iOS
             }));
         }
 
-        public void ShowView ()
+        public void InitializeAutomaticSegueTimer ()
         {
             if (!LoginHelpers.HasViewedTutorial (LoginHelpers.GetCurrentAccountId ())) {
                 SegueToTutorial = NSTimer.CreateScheduledTimer (WAIT_TIME, delegate {
@@ -203,7 +203,11 @@ namespace NachoClient.iOS
                     }
                 });
             }
+        }
 
+        public void ShowView ()
+        {
+            InitializeAutomaticSegueTimer ();
             this.Hidden = false;
             owner.NavigationItem.Title = "";
             Util.ConfigureNavBar (true, owner.NavigationController);


### PR DESCRIPTION
... user manually enters one on Advanced Login view. Invalidate automatic-segue-to-tutorial if certificate appears, validate timer if they accept the certificate. Added logging information to determine which view the user is on when different status indicators are handled. Reformatted the McMutable bits used in the login process to follow the standard naming convention.
