### PR TITLE
In Nacho Now view, add spinner when downloading an email.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -206,6 +206,24 @@ namespace NachoClient.iOS
                 priorityInbox.Refresh ();
                 carouselView.ReloadData ();
             }
+            if (NcResult.SubKindEnum.Info_EmailMessageBodyDownloadSucceeded == s.Status.SubKind) {
+                ProcessDownloadComplete (true);
+            }
+            if (NcResult.SubKindEnum.Error_EmailMessageBodyDownloadFailed == s.Status.SubKind) {
+                ProcessDownloadComplete (false);
+            }
+        }
+
+        private void ProcessDownloadComplete (bool succeed)
+        {
+            var bodyView = carouselView.CurrentItemView.ViewWithTag (HotListCarouselDataSource.PREVIEW_TAG) as BodyView;
+            // To avoid unnecessary reload, we only reload if the current item was downloading
+            // and the body is now completely downloaded.
+            if (!bodyView.IsDownloadComplete ()) {
+                return;
+            }
+            bodyView.DownloadComplete (succeed);
+            carouselView.ReloadItemAtIndex (carouselView.CurrentItemIndex, true);
         }
 
         /// <summary>

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -56,7 +56,7 @@ namespace NachoClient.iOS
             ScrollView.MultipleTouchEnabled = false;
             ContentMode = UIViewContentMode.ScaleAspectFit;
             BackgroundColor = UIColor.White;
-            Tag = BodyView.MESSAGE_PART_TAG;
+            Tag = (int)BodyView.TagType.MESSAGE_PART_TAG;
 
             LoadStarted += (object sender, EventArgs e) => {
                 htmlBusy.Increment ();

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
@@ -21,7 +21,7 @@ namespace NachoClient.iOS
         protected const int USER_IMAGE_TAG = 101;
         protected const int FROM_TAG = 102;
         protected const int SUBJECT_TAG = 103;
-        protected const int PREVIEW_TAG = 104;
+        public const int PREVIEW_TAG = 104;
         protected const int REMINDER_ICON_TAG = 105;
         protected const int REMINDER_TEXT_TAG = 106;
         protected const int ATTACHMENT_TAG = 107;
@@ -230,8 +230,6 @@ namespace NachoClient.iOS
             previewLabelView.OnRenderComplete = () => {
             };
             previewLabelView.OnDownloadStart = () => {
-            };
-            previewLabelView.OnDownloadComplete = (bool success) => {
             };
             view.AddSubview (previewLabelView);
 


### PR DESCRIPTION
- Add spinner in BodyView. It is either centered in BodyView's frame or its parent's view's frame. (Message view uses the parent as its final size is not determined. Nacho now view uses the view's frame.)
- Remove DownloadComplete handler because the status indication is moved back to the view controller.
- Handle status indication in message view and nacho now view. This means BodyView is no longer self-contained. The host view controller must handle the status indication for BodyView. But this is better because BodyView does not have life cycle event information and cannot easily install and uninstall event handler.
