### PR TITLE
Get attachments on calendar events mostly working.

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -939,7 +939,8 @@ namespace NachoCore.ActiveSync
                         // Create & save the attachment record.
                         var attachment = new McAttachment {
                             AccountId = msg.AccountId,
-                            EmailMessageId = msg.Id,
+                            ItemId = msg.Id,
+                            ClassCode = msg.GetClassCode (),
                             FileSize = long.Parse (xmlAttachment.Element (m_baseNs + Xml.AirSyncBase.EstimatedDataSize).Value),
                             FileSizeAccuracy = McAbstrFileDesc.FileSizeAccuracyEnum.Estimate,
                             FileReference = xmlAttachment.Element (m_baseNs + Xml.AirSyncBase.FileReference).Value,

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
@@ -165,7 +165,7 @@ namespace NachoCore.ActiveSync
                                                 int folderId, bool originalEmailIsEmbedded)
         {
             if (originalEmailIsEmbedded) {
-                var attachments = McAttachment.QueryByItemId<McEmailMessage> (AccountId, forwardedEmailMessageId);
+                var attachments = McAttachment.QueryByItemId (AccountId, forwardedEmailMessageId, McAbstrFolderEntry.ClassCodeEnum.Email);
                 foreach (var attach in attachments) {
                     if (McAbstrFileDesc.FilePresenceEnum.None == attach.FilePresence) {
                         var token = DnldAttCmd (attach.Id);
@@ -423,7 +423,7 @@ namespace NachoCore.ActiveSync
             if (McAbstrFileDesc.FilePresenceEnum.None != att.FilePresence) {
                 return null;
             }
-            var emailMessage = McAbstrObject.QueryById<McEmailMessage> (att.EmailMessageId);
+            var emailMessage = McAbstrObject.QueryById<McEmailMessage> (att.ItemId);
             if (null == emailMessage) {
                 return null;
             }

--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
@@ -257,7 +257,7 @@ namespace NachoCore.Model
                 // Attachments, if any, are already taken care of.
                 return;
             }
-            var originalAttachments = McAttachment.QueryByItemId<McEmailMessage> (AccountId, ReferencedEmailId);
+            var originalAttachments = McAttachment.QueryByItemId (AccountId, ReferencedEmailId, this.GetClassCode ());
             var body = McBody.QueryById<McBody> (BodyId);
             MimeMessage mime = MimeHelpers.LoadMessage (body.GetFilePath ());
             MimeHelpers.AddAttachments (mime, originalAttachments);
@@ -291,7 +291,7 @@ namespace NachoCore.Model
             }
             if (ReferencedIsForward && (!ReferencedBodyIsIncluded || WaitingForAttachmentsToDownload)) {
                 // Add all the attachments from the original message.
-                var originalAttachments = McAttachment.QueryByItemId<McEmailMessage> (AccountId, ReferencedEmailId);
+                var originalAttachments = McAttachment.QueryByItemId (originalMessage);
                 MimeHelpers.AddAttachments (outgoingMime, originalAttachments);
             }
             body.UpdateData ((FileStream stream) => {
@@ -306,7 +306,7 @@ namespace NachoCore.Model
 
         public void DeleteAttachments ()
         {
-            var atts = McAttachment.QueryByItemId<McEmailMessage> (AccountId, Id);
+            var atts = McAttachment.QueryByItemId (this);
             foreach (var toNix in atts) {
                 toNix.Delete ();
             }

--- a/NachoClient.Android/NachoUI.Android/MessageViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/MessageViewFragment.cs
@@ -68,7 +68,7 @@ namespace NachoClient.AndroidClient
                 }
             }
 
-            var attachments = NcModel.Instance.Db.Table<McAttachment> ().Where (a => a.EmailMessageId == message.Id).ToList ();
+            var attachments = NcModel.Instance.Db.Table<McAttachment> ().Where (a => a.ItemId == message.Id && a.ClassCode == message.GetClassCode ()).ToList ();
 
             if (0 < attachments.Count) {
                 foreach (var a in attachments) {

--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -34,7 +34,6 @@ namespace NachoClient.iOS
         protected NachoFolders calendars;
         protected string TempPhone = "";
         protected int calendarIndex = 0;
-        List<McAttachment> attachments = new List<McAttachment> ();
 
         protected UIView EventInfoView;
 
@@ -363,7 +362,7 @@ namespace NachoClient.iOS
             if (segue.Identifier.Equals ("EditEventToAttachment")) {
                 var dc = (EventAttachmentViewController)segue.DestinationViewController;
                 ExtractValues ();
-                dc.SetOwner (this, attachments, c, true);
+                dc.SetOwner (this, c.attachments, c, true);
                 return;
             }
             Log.Info (Log.LOG_UI, "Unhandled segue identifer {0}", segue.Identifier);
@@ -736,7 +735,7 @@ namespace NachoClient.iOS
             Util.AddArrowAccessory (SCREEN_WIDTH - 23, CELL_HEIGHT / 2 - 6, 12, attachmentsView);
 
             UILabel attachmentsDetailLabel = new UILabel ();
-            attachmentsDetailLabel.Text = "(" + attachments.Count + ")";
+            attachmentsDetailLabel.Text = "(" + c.attachments.Count + ")";
             attachmentsDetailLabel.Tag = ATTACHMENTS_DETAIL_TAG;
             attachmentsDetailLabel.SizeToFit ();
             attachmentsDetailLabel.TextAlignment = UITextAlignment.Right;
@@ -998,7 +997,7 @@ namespace NachoClient.iOS
 
             //attachments view
             var attachmentDetailLabelView = contentView.ViewWithTag (ATTACHMENTS_DETAIL_TAG) as UILabel;
-            attachmentDetailLabelView.Text = "(" + attachments.Count () + ")";
+            attachmentDetailLabelView.Text = "(" + c.attachments.Count + ")";
 
             //people view
             var peopleDetailLabelView = contentView.ViewWithTag (PEOPLE_DETAIL_TAG) as UILabel;
@@ -1265,7 +1264,7 @@ namespace NachoClient.iOS
         {
             //var tzid = RadioElementWithData.SelectedData (timezoneEntryElement);
             var iCalPart = CalendarHelper.iCalToMimePart (account, c, "Local");
-            var mimeBody = CalendarHelper.CreateMime (c.Description, iCalPart, attachments);
+            var mimeBody = CalendarHelper.CreateMime (c.Description, iCalPart, c.attachments);
 
             CalendarHelper.SendInvites (account, c, null, mimeBody);
         }
@@ -1282,7 +1281,7 @@ namespace NachoClient.iOS
 
         public void UpdateAttachmentList (List<McAttachment> attachments)
         {
-            this.attachments = attachments;
+            c.attachments = attachments;
         }
 
         public void DismissINachoAttachmentListChooser (INachoAttachmentListChooser vc)

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -629,16 +629,15 @@ namespace NachoClient.iOS
                 }
             }
 
-            //TODO 
             //get attachments out of an event
-            attachmentCount = 0;  //set to zero until we get the real count of attachments
+            attachmentCount = c.attachments.Count;
             var attachmentView = contentView.ViewWithTag (800) as UIView;
             if (0 == attachmentCount) {
                 attachmentView.Hidden = true;
                 line2.Hidden = true;
             } else {
                 var attachmentDetailLabelView = contentView.ViewWithTag (EVENT_ATTACHMENT_DETAIL_TAG) as UILabel;
-                //attachmentDetailLabelView.Text = "(" + c.attachments.Count() +  ")";
+                attachmentDetailLabelView.Text = "(" + attachmentCount +  ")";
                 attachmentDetailLabelView.SizeToFit ();
                 attachmentDetailLabelView.Frame = new RectangleF (SCREEN_WIDTH - attachmentDetailLabelView.Frame.Width - 34, 12.438f, attachmentDetailLabelView.Frame.Width, TEXT_LINE_HEIGHT);
                 attachmentView.Hidden = false;

--- a/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
@@ -845,7 +845,7 @@ namespace NachoClient.iOS
                 // to be done explicitly.  If all of the necessary attachments are available, go ahead and
                 // add them to the message now.  If any of the attachments need to be downloaded, then
                 // wait until later to add them.
-                var originalAttachments = McAttachment.QueryByItemId<McEmailMessage> (account.Id, referencedMessage.Id);
+                var originalAttachments = McAttachment.QueryByItemId (referencedMessage);
                 foreach (var attachment in originalAttachments) {
                     if (McAbstrFileDesc.FilePresenceEnum.Complete != attachment.FilePresence) {
                         attachmentNeedsDownloading = true;

--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -190,7 +190,7 @@ namespace NachoClient.iOS
         protected void FetchAttachments ()
         {
             var message = thread.SingleMessageSpecialCase ();
-            attachments = McAttachment.QueryByItemId<McEmailMessage> (message.AccountId, message.Id);
+            attachments = McAttachment.QueryByItemId (message);
         }
 
         protected void ReplyActionSheet ()
@@ -645,7 +645,7 @@ namespace NachoClient.iOS
         protected void ConfigureView ()
         {
             var message = thread.SingleMessageSpecialCase ();
-            attachments = McAttachment.QueryByItemId<McEmailMessage> (message.AccountId, message.Id);
+            attachments = McAttachment.QueryByItemId (message);
 
             // User image view
             var userImageView = view.ViewWithTag ((int)TagType.USER_IMAGE_TAG) as UIImageView;

--- a/Test.Android/AsStrategyTest.cs
+++ b/Test.Android/AsStrategyTest.cs
@@ -647,7 +647,8 @@ namespace Test.iOS
                 };
                 email.Insert ();
                 var att = new McAttachment () {
-                    EmailMessageId = email.Id,
+                    ItemId = email.Id,
+                    ClassCode = email.GetClassCode (),
                     AccountId = email.AccountId,
                     FilePresenceFraction = 0,
                     FileSize = 50000,
@@ -665,7 +666,7 @@ namespace Test.iOS
         {
             foreach (var att in Fetch_Atts) {
                 if (null != Fetch_Emails) {
-                    var email = Fetch_Emails.SingleOrDefault (x => x.Id == att.EmailMessageId);
+                    var email = Fetch_Emails.SingleOrDefault (x => x.Id == att.ItemId);
                     if (null != email) {
                         Fetch_Folder.Unlink (email);
                         email.Delete ();

--- a/Test.Android/Common/CommonUtils.cs
+++ b/Test.Android/Common/CommonUtils.cs
@@ -205,7 +205,8 @@ namespace Test.iOS
         {
             var att = new McAttachment {
                 AccountId = accountId,
-                EmailMessageId = item.Id,
+                ItemId = item.Id,
+                ClassCode = item.GetClassCode (),
             };
             att.SetDisplayName (displayName);
             att.Insert ();

--- a/Test.Android/McAttachmentTest.cs
+++ b/Test.Android/McAttachmentTest.cs
@@ -26,7 +26,8 @@ namespace Test.iOS
             };
             keeper1.Insert ();
             var keeper1att = new McAttachment () {
-                EmailMessageId = keeper1.Id,
+                ItemId = keeper1.Id,
+                ClassCode = keeper1.GetClassCode (),
                 AccountId = keeper1.AccountId,
                 FilePresenceFraction = 0,
                 FileSize = 50001,
@@ -44,7 +45,8 @@ namespace Test.iOS
             };
             keeper2.Insert ();
             var keeper2att = new McAttachment () {
-                EmailMessageId = keeper2.Id,
+                ItemId = keeper2.Id,
+                ClassCode = keeper2.GetClassCode (),
                 AccountId = keeper2.AccountId,
                 FilePresenceFraction = 0,
                 FileSize = 50002,
@@ -62,7 +64,8 @@ namespace Test.iOS
             };
             fallOff.Insert ();
             var fallOffatt = new McAttachment () {
-                EmailMessageId = fallOff.Id,
+                ItemId = fallOff.Id,
+                ClassCode = fallOff.GetClassCode (),
                 AccountId = fallOff.AccountId,
                 FilePresenceFraction = 0,
                 FileSize = 50000,
@@ -80,7 +83,8 @@ namespace Test.iOS
             };
             trash.Insert ();
             var trashatt = new McAttachment () {
-                EmailMessageId = trash.Id,
+                ItemId = trash.Id,
+                ClassCode = trash.GetClassCode (),
                 AccountId = trash.AccountId,
                 FilePresenceFraction = 0,
                 FileSize = 50000,
@@ -98,7 +102,8 @@ namespace Test.iOS
             };
             trash.Insert ();
             trashatt = new McAttachment () {
-                EmailMessageId = trash.Id,
+                ItemId = trash.Id,
+                ClassCode = trash.GetClassCode (),
                 AccountId = trash.AccountId,
                 FileSize = 50000,
                 FileSizeAccuracy = McAbstrFileDesc.FileSizeAccuracyEnum.Estimate,
@@ -115,7 +120,8 @@ namespace Test.iOS
             };
             trash.Insert ();
             trashatt = new McAttachment () {
-                EmailMessageId = trash.Id,
+                ItemId = trash.Id,
+                ClassCode = trash.GetClassCode (),
                 AccountId = trash.AccountId,
                 FileSize = 50000,
                 FileSizeAccuracy = McAbstrFileDesc.FileSizeAccuracyEnum.Estimate,
@@ -132,7 +138,8 @@ namespace Test.iOS
             };
             trash.Insert ();
             trashatt = new McAttachment () {
-                EmailMessageId = trash.Id,
+                ItemId = trash.Id,
+                ClassCode = trash.GetClassCode (),
                 AccountId = trash.AccountId,
                 FileSize = 50000,
                 FileSizeAccuracy = McAbstrFileDesc.FileSizeAccuracyEnum.Estimate,
@@ -149,7 +156,8 @@ namespace Test.iOS
             };
             trash.Insert ();
             trashatt = new McAttachment () {
-                EmailMessageId = trash.Id,
+                ItemId = trash.Id,
+                ClassCode = trash.GetClassCode (),
                 AccountId = trash.AccountId,
                 FileSize = 500000,
                 FileSizeAccuracy = McAbstrFileDesc.FileSizeAccuracyEnum.Estimate,
@@ -166,7 +174,8 @@ namespace Test.iOS
             };
             trash.Insert ();
             trashatt = new McAttachment () {
-                EmailMessageId = trash.Id,
+                ItemId = trash.Id,
+                ClassCode = trash.GetClassCode (),
                 AccountId = trash.AccountId,
                 FileSize = 50000,
                 FileSizeAccuracy = McAbstrFileDesc.FileSizeAccuracyEnum.Estimate,


### PR DESCRIPTION
When the event is created on the device, attachments cannot be synched with the server. So we don't even try. The attachments will still be visible on the device, and they will be visible to anyone invited to the meeting. They just aren't visible to other clients of the same account.

Most of the testing was of creating appointments and non-repeating meetings. That works well, except for the above mentioned limitation. Editing existing events has problems. The attachment viewer when viewing events doesn't work. These problems will be fixed later.
