### PR TITLE
Three bug fixes for calendar sync. Issues #518 and #520.

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -122,9 +122,6 @@ namespace NachoCore.ActiveSync
             if (cal.BusyStatusIsSet) {
                 xmlAppData.Add (new XElement (CalendarNs + Xml.Calendar.BusyStatus, (uint)cal.BusyStatus));
             }
-            if (cal.ResponseTypeIsSet) {
-                xmlAppData.Add (new XElement (CalendarNs + Xml.Calendar.ResponseType, (uint)cal.ResponseType));
-            }
             if (cal.MeetingStatusIsSet) {
                 xmlAppData.Add (new XElement (CalendarNs + Xml.Calendar.MeetingStatus, (uint)cal.MeetingStatus));
             }
@@ -155,9 +152,6 @@ namespace NachoCore.ActiveSync
                     xmlAttendee.Add (new XElement (CalendarNs + Xml.Calendar.Name, attendee.Name));
                     if (attendee.AttendeeTypeIsSet) {
                         xmlAttendee.Add (new XElement (CalendarNs + Xml.Calendar.AttendeeType, (uint)attendee.AttendeeType));
-                    }
-                    if (attendee.AttendeeStatusIsSet) {
-                        xmlAttendee.Add (new XElement (CalendarNs + Xml.Calendar.AttendeeStatus, (uint)attendee.AttendeeStatus));
                     }
                     xmlAttendees.Add (xmlAttendee);
                 }

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsMeetingResponseCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsMeetingResponseCommand.cs
@@ -21,7 +21,7 @@ namespace NachoCore.ActiveSync
         {
             var meetingResp = new XElement (m_ns + Xml.MeetingResp.MeetingResponse,
                                   new XElement (m_ns + Xml.MeetingResp.Request,
-                                      new XElement (m_ns + Xml.MeetingResp.UserResponse, PendingSingle.CalResponse),
+                                      new XElement (m_ns + Xml.MeetingResp.UserResponse, (uint)PendingSingle.CalResponse),
                                       new XElement (m_ns + Xml.MeetingResp.CollectionId, PendingSingle.ParentId),
                                       new XElement (m_ns + Xml.MeetingResp.RequestId, PendingSingle.ServerId)));
             var doc = AsCommand.ToEmptyXDocument ();


### PR DESCRIPTION
Stop sending the ResponseType element of events in command requests. That field should only be in responses.  (Section 2.2.2.38 in MS-ASCAL.)

Stop sending the AttendeeStatus element of Attendee elements in command requests. That field should only be in responses.  (Microsoft's documentation is unclear and incorrect for this element.)

For the UserResponse element of the MeetingResponse command, send the integer value of the enum (e.g. "1") rather than the symbolic name of the enum constant (e.g. "Accepted_1"). This was causing all MeetingResponse commands to fail.
