### PR TITLE
Send meeting response e-mail when responding to a meeting request

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -564,6 +564,7 @@ namespace NachoCore.ActiveSync
                     break;
                 case Xml.Calendar.ResponseRequested:
                     c.ResponseRequested = child.Value.ToBoolean ();
+                    c.ResponseRequestedIsSet = true;
                     break;
                 case Xml.Calendar.ResponseType:
                     c.ResponseType = child.Value.ParseInteger<NcResponseType> ();
@@ -848,6 +849,7 @@ namespace NachoCore.ActiveSync
                                 break;
                             case Xml.Email.ResponseRequested:
                                 e.ResponseRequested = meetingRequestPart.Value.ToBoolean ();
+                                e.ResponseRequestedIsSet = true;
                                 break;
                             case Xml.Email.Recurrences:
                                 if (meetingRequestPart.HasElements) {

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -1402,7 +1402,16 @@ namespace NachoClient.iOS
 
         protected void UpdateStatus (NcResponseType status)
         {
+            // MeetingResponse command to let the server know about our status
             BackEnd.Instance.RespondCalCmd (account.Id, c.Id, status);
+
+            if (c is McCalendar && c.ResponseRequestedIsSet && c.ResponseRequested) {
+                // Send an e-mail message to the organizer with the response.
+                var iCalPart = CalendarHelper.iCalResponseToMimePart (account, (McCalendar)c, "Local", status);
+                // TODO Give the user a chance to enter some text. For now, the message body is empty.
+                var mimeBody = CalendarHelper.CreateMime ("", iCalPart, new List<McAttachment> ());
+                CalendarHelper.SendMeetingResponse (account, (McCalendar)c, mimeBody, status);
+            }
         }
 
         public void UpdateAttendeeList (List<McAttendee> attendees)


### PR DESCRIPTION
Issue #524 

When the user accepts/declines a meeting from the calendar, and the organizer requested response, then a meeting response e-mail message will be sent to the organizer. This allows the user's status to be recorded in the organizer's copy of the meeting.

The user is not given the option to not send the message, or to add some custom text to the message. Those features will be covered later (if at all).

This e-mail message is not sent when responding to the meeting request from the inbox.  Meeting requests in the inbox have more problems than just the response e-mail message, so that will be covered in a separate update.
