### PR TITLE
Port recent event view changes to body calendar view.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -1263,7 +1263,7 @@ namespace NachoClient.iOS
         protected void SendInvites ()
         {
             //var tzid = RadioElementWithData.SelectedData (timezoneEntryElement);
-            var iCalPart = CalendarHelper.iCalToMimePart (account, c, "Local");
+            var iCalPart = CalendarHelper.iCalToMimePart (account, c);
             var mimeBody = CalendarHelper.CreateMime (c.Description, iCalPart, c.attachments);
 
             CalendarHelper.SendInvites (account, c, null, mimeBody);

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -1407,7 +1407,7 @@ namespace NachoClient.iOS
 
             if (c is McCalendar && c.ResponseRequestedIsSet && c.ResponseRequested) {
                 // Send an e-mail message to the organizer with the response.
-                var iCalPart = CalendarHelper.iCalResponseToMimePart (account, (McCalendar)c, "Local", status);
+                var iCalPart = CalendarHelper.iCalResponseToMimePart (account, (McCalendar)c, status);
                 // TODO Give the user a chance to enter some text. For now, the message body is empty.
                 var mimeBody = CalendarHelper.CreateMime ("", iCalPart, new List<McAttachment> ());
                 CalendarHelper.SendMeetingResponse (account, (McCalendar)c, mimeBody, status);


### PR DESCRIPTION
Two recent changes to the event view have been ported to BodyCalendarView:
(1) Accurately display the user's current status.
(2) Send a meeting response e-mail message when responding to a meeting.
These changes improve the way that meeting request message work when viewed in the Inbox or other message view.

(There is also some refactoring that should have happenid in my previous update.)
