### PR TITLE
Issue #517 Display calendar event descriptions that aren't plain text.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -47,6 +47,8 @@ namespace NachoClient.iOS
         protected UIImageView MapImage;
         protected MKMapView map;
 
+        BodyView descriptionView;
+
         UIView eventAttendeeView;
 
         UIView eventAlertsView;
@@ -102,7 +104,7 @@ namespace NachoClient.iOS
         const int EVENT_LOCATION_DETAIL_LABEL_TAG = 103;
         const int EVENT_WHEN_DETAIL_LABEL_TAG = 104;
         const int EVENT_WHEN_DURATION_TAG = 500;
-        const int EVENT_WHEN_RECURRENCE_TAG = 600;
+        const int EVENT_WHEN_RECURRENCE_TAG = 601;
         const int EVENT_PHONE_DETAIL_BUTTON_TAG = 105;
         const int EVENT_ATTENDEE_TAG = 106;
         const int EVENT_ATTENDEE_DETAIL_TAG = 110;
@@ -113,7 +115,7 @@ namespace NachoClient.iOS
         const int EVENT_LOCATION_TITLE_TAG = 301;
         const int EVENT_WHEN_TITLE_TAG = 302;
         const int EVENT_PHONE_TITLE_TAG = 303;
-        const int EVENT_ATTENDEE_TITLE_TAG = 304;
+        const int EVENT_ATTENDEE_TITLE_TAG = 308;
         const int EVENT_ALERT_TITLE_TAG = 305;
         const int EVENT_ATTACHMENT_TITLE_TAG = 306;
         const int EVENT_NOTE_TITLE_TAG = 307;
@@ -331,9 +333,18 @@ namespace NachoClient.iOS
             yOffset += 30;
 
             //desciption label
-            AddDetailTextLabel (25, yOffset, SCREEN_WIDTH - 50, 20, EVENT_DESCRIPTION_LABEL_TAG, contentView);
+            descriptionView = new BodyView (
+                new RectangleF (0, yOffset, SCREEN_WIDTH - 2 * BodyView.BODYVIEW_INSET, 10),
+                contentView);
+            descriptionView.Tag = EVENT_DESCRIPTION_LABEL_TAG;
+            // I'm not sure why 20 is the correct value for the left margin. But it causes the
+            // description to line up with the title.
+            descriptionView.LeftMargin = 20;
+            descriptionView.HorizontalScrollingEnabled = true;
+            descriptionView.VerticalScrollingEnabled = false;
+            contentView.Add (descriptionView);
 
-            yOffset += 20 + 20;
+            yOffset += 10 + 20;
 
             //location label, image and detail
             AddTextLabelWithImageView (45, yOffset, "Location", UIImage.FromBundle ("icn-mtng-location"), EVENT_LOCATION_TITLE_TAG, contentView);
@@ -555,11 +566,7 @@ namespace NachoClient.iOS
             titleLabelView.SizeToFit ();
 
             //description view
-            var descriptionLabelView = View.ViewWithTag (EVENT_DESCRIPTION_LABEL_TAG) as UILabel;
-            descriptionLabelView.Text = c.Description;
-            descriptionLabelView.Lines = 0;
-            descriptionLabelView.LineBreakMode = UILineBreakMode.WordWrap;
-            descriptionLabelView.SizeToFit ();
+            descriptionView.Configure (c);
 
             //location view
             var locationLabelView = View.ViewWithTag (EVENT_LOCATION_DETAIL_LABEL_TAG) as UILabel;
@@ -676,11 +683,10 @@ namespace NachoClient.iOS
             yOffset += tl.Frame.Height;
 
             yOffset += 5;
-            var dl = View.ViewWithTag (EVENT_DESCRIPTION_LABEL_TAG) as UILabel;
-            dl.Frame = new RectangleF (25, yOffset, SCREEN_WIDTH - 50, dl.Frame.Height);
-            yOffset += dl.Frame.Height;
+            descriptionView.Layout (0, yOffset, SCREEN_WIDTH - 2 * BodyView.BODYVIEW_INSET, 10);
+            yOffset += descriptionView.Frame.Height;
 
-            yOffset += 20;
+            yOffset += 10;
             var lt = View.ViewWithTag (EVENT_LOCATION_TITLE_TAG) as UIView;
             lt.Frame = new RectangleF (23, yOffset, SCREEN_WIDTH - 50, lt.Frame.Height);
             yOffset += lt.Frame.Height;

--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -619,6 +619,7 @@ namespace NachoClient.iOS
                 yOffset,
                 view.Frame.Width - 2 * BodyView.BODYVIEW_INSET,
                 view.Frame.Height - BodyView.BODYVIEW_INSET), view);
+            bodyView.LeftMargin = 15;
             bodyView.VerticalScrollingEnabled = false;
             bodyView.SpinnerCenteredOnParentFrame = true;
             bodyView.OnRenderStart = () => {

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -110,6 +110,8 @@ namespace NachoClient.iOS
         // If false, center on view frame
         public bool SpinnerCenteredOnParentFrame { get; set; }
 
+        public float LeftMargin { get; set; }
+
         protected UIView parentView;
         protected UIView messageView;
         protected UITapGestureRecognizer doubleTap;
@@ -138,6 +140,7 @@ namespace NachoClient.iOS
             HorizontalScrollingEnabled = true;
             VerticalScrollingEnabled = true;
             AutomaticallyScaleHtmlContent = true;
+            LeftMargin = 15.0f;
 
             this.parentView = parentView;
             BackgroundColor = SCROLLVIEW_BGCOLOR;
@@ -268,8 +271,7 @@ namespace NachoClient.iOS
 
         protected void RenderDisplayList (List<MimeEntity> list)
         {
-            for (var i = 0; i < list.Count; i++) {
-                var entity = list [i];
+            foreach (var entity in list) {
                 var part = (MimePart)entity;
                 if (part.ContentType.Matches ("text", "html")) {
                     RenderHtml (part);
@@ -277,6 +279,10 @@ namespace NachoClient.iOS
                 }
                 if (part.ContentType.Matches ("text", "calendar")) {
                     RenderCalendar (part);
+                    continue;
+                }
+                if (part.ContentType.Matches ("text", "rtf")) {
+                    RenderRtf (part);
                     continue;
                 }
                 if (part.ContentType.Matches ("text", "*")) {
@@ -297,9 +303,16 @@ namespace NachoClient.iOS
             RenderTextString (text);
         }
 
+        void RenderRtf (MimePart part)
+        {
+            var textPart = part as TextPart;
+            var text = textPart.Text;
+            RenderRtfString (text);
+        }
+
         UITextView RenderAttributedString (NSAttributedString attributedString)
         {
-            var label = new UITextView (new RectangleF (15.0f, 0.0f, 290.0f, 1.0f));
+            var label = new UITextView (new RectangleF (LeftMargin, 0.0f, 290.0f, 1.0f));
             label.Editable = false;
             #if (DEBUG_UI)
             label.BackgroundColor = A.Color_NachoBlue;
@@ -341,7 +354,7 @@ namespace NachoClient.iOS
         void RenderPartialDownloadMessage (string message)
         {
             var attributedString = new NSAttributedString (message);
-            var label = new UILabel (new RectangleF (15.0f, 0.0f, 290.0f, 1.0f));
+            var label = new UILabel (new RectangleF (LeftMargin, 0.0f, 290.0f, 1.0f));
             label.Lines = 0;
             label.Font = A.Font_AvenirNextDemiBold14;
             label.LineBreakMode = UILineBreakMode.WordWrap;

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
@@ -224,6 +224,7 @@ namespace NachoClient.iOS
             // Size fields will be recalculated after text is known
             var previewLabelView = new BodyView (new RectangleF (12, 70, viewWidth - 15 - 12, bottomY - 60), view);
             previewLabelView.Tag = PREVIEW_TAG;
+            previewLabelView.LeftMargin = 15;
             previewLabelView.UserInteractionEnabled = false;
             previewLabelView.OnRenderStart = () => {
             };


### PR DESCRIPTION
Until now, calendar event descriptions would only be displayed in the event
viewer if a plain text version were available.  But a plain text version of the
description is usually not available, so most events showed an empty
description.

To fix this, EventViewController was changed to use a BodyView instead of an
ordinary UILabel for displaying the description.  Body View had to be enhanced
to handle TNEF sections and RTF (since the Exchange server will agressively
reformat event descriptions into those formats).
