### PR TITLE
Fix display of HTML calendar event descriptions.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -62,6 +62,8 @@ namespace NachoClient.iOS
         UILabel messageLabel;
         UIButton changeResponseButton;
 
+        RecursionCounter deferLayout;
+
         UIColor separatorColor = A.Color_NachoBorderGray;
         protected static float SCREEN_WIDTH = UIScreen.MainScreen.Bounds.Width;
         protected int LINE_OFFSET = 30;
@@ -335,13 +337,16 @@ namespace NachoClient.iOS
             //desciption label
             descriptionView = new BodyView (
                 new RectangleF (0, yOffset, SCREEN_WIDTH - 2 * BodyView.BODYVIEW_INSET, 10),
-                contentView);
+                contentView, 20, 20);
             descriptionView.Tag = EVENT_DESCRIPTION_LABEL_TAG;
-            // I'm not sure why 20 is the correct value for the left margin. But it causes the
-            // description to line up with the title.
-            descriptionView.LeftMargin = 20;
             descriptionView.HorizontalScrollingEnabled = true;
             descriptionView.VerticalScrollingEnabled = false;
+            descriptionView.OnRenderStart = () => {
+                deferLayout.Increment ();
+            };
+            descriptionView.OnRenderComplete = () => {
+                deferLayout.Decrement ();
+            };
             contentView.Add (descriptionView);
 
             yOffset += 10 + 20;
@@ -565,9 +570,6 @@ namespace NachoClient.iOS
             titleLabelView.LineBreakMode = UILineBreakMode.WordWrap;
             titleLabelView.SizeToFit ();
 
-            //description view
-            descriptionView.Configure (c);
-
             //location view
             var locationLabelView = View.ViewWithTag (EVENT_LOCATION_DETAIL_LABEL_TAG) as UILabel;
             if (null != c.Location & "" != c.Location) {
@@ -669,10 +671,17 @@ namespace NachoClient.iOS
                 attachmentView.Hidden = false;
                 line2.Hidden = false;
             }
-                
+
+            deferLayout = new RecursionCounter (() => {
+                LayoutView ();
+            });
+            deferLayout.Increment ();
+
+            descriptionView.Configure (c);
+
             ConfigureRsvpBar ();
 
-            LayoutView ();
+            deferLayout.Decrement ();
         }
 
         public void LayoutView ()

--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -618,8 +618,8 @@ namespace NachoClient.iOS
                 BodyView.BODYVIEW_INSET,
                 yOffset,
                 view.Frame.Width - 2 * BodyView.BODYVIEW_INSET,
-                view.Frame.Height - BodyView.BODYVIEW_INSET), view);
-            bodyView.LeftMargin = 15;
+                view.Frame.Height - BodyView.BODYVIEW_INSET),
+                view);
             bodyView.VerticalScrollingEnabled = false;
             bodyView.SpinnerCenteredOnParentFrame = true;
             bodyView.OnRenderStart = () => {
@@ -627,8 +627,6 @@ namespace NachoClient.iOS
             };
             bodyView.OnRenderComplete = () => {
                 deferLayout.Decrement ();
-            };
-            bodyView.OnDownloadStart = () => {
             };
             view.AddSubview (bodyView);
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -29,10 +29,10 @@ namespace NachoClient.iOS
         public RenderComplete OnRenderComplete;
         protected UIView parentView;
 
-        public BodyWebView (UIView parentView) : base (parentView.Frame)
+        public BodyWebView (UIView parentView, float leftMargin) : base (parentView.Frame)
         {
             this.parentView = parentView;
-            ViewFramer.Create (this).Height (1);
+            ViewFramer.Create (this).X (leftMargin).Height (1);
             htmlBusy = new RecursionCounter (() => {
                 EvaluateJavascript (magic);
                 ViewFramer.Create (this)

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
@@ -224,14 +224,7 @@ namespace NachoClient.iOS
             // Size fields will be recalculated after text is known
             var previewLabelView = new BodyView (new RectangleF (12, 70, viewWidth - 15 - 12, bottomY - 60), view);
             previewLabelView.Tag = PREVIEW_TAG;
-            previewLabelView.LeftMargin = 15;
             previewLabelView.UserInteractionEnabled = false;
-            previewLabelView.OnRenderStart = () => {
-            };
-            previewLabelView.OnRenderComplete = () => {
-            };
-            previewLabelView.OnDownloadStart = () => {
-            };
             view.AddSubview (previewLabelView);
 
             // Chili image view


### PR DESCRIPTION
The detail view for events with HTML descriptions was causing a crash.  (HTML
event descriptions are rare, which is why this bug was not noticed yesterday.
The only way I can get one is to cancel a meeting.) Fix the code to not crash
and to display the description with the correct indentation.
