### PR TITLE
Fix event view scroll problem.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -330,6 +330,10 @@ namespace NachoClient.iOS
             label.AttributedText = attributedString;
             label.SizeToFit ();
             label.Tag = (int)TagType.MESSAGE_PART_TAG;
+            // We don't need this view to scroll. This would result in a triple nesting of
+            // UIScrollView, which iOS doesn't handle well.  It handles two nested UIScrollViews,
+            // but seems to have problems with three.
+            label.ScrollEnabled = false;
             // We are using double tap for zoom toggling. So, we want to disable 
             // double tap to select action. A long tap can still select text.
             foreach (var gc in label.GestureRecognizers) {


### PR DESCRIPTION
Event views where the description is RTF (which is most of them) would
often have problems scrolling. If the user touched within the
description, iOS would try to scroll just the description rather than
the entire view, but that would have no effect because the description
is entirely visible (within its outer scroll view). To scroll the
entire event view, the user would have to touch outside the
description (which could be difficult if the description filled the
entire screen).

The problem is a bug in iOS. It handles nested UIScrollViews just fine
as long as they are only nested two deep. When a third UIScrollView is
added to the hierarchy, iOS behaves badly.

The fix is to disable scrolling in the innermost UITextView, which is
derived from UIScrollView.  There are still three nested UIScrollView
objects in the hierarchy, but only two of them are potentially
scrollable, thus avoiding the iOS bug.
