### PR TITLE
Fix a bug where a download complete does not stop the spinner.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -223,20 +223,24 @@ namespace NachoClient.iOS
 
         private void ProcessDownloadComplete (bool succeed)
         {
-            var currentView = carouselView.CurrentItemView;
-            if (null == currentView) {
-                return;
-            }
-            var bodyView = currentView.ViewWithTag (HotListCarouselDataSource.PREVIEW_TAG) as BodyView;
-            NcAssert.True (null != bodyView);
+            var visibleIndices = carouselView.IndexesForVisibleItems;
+            foreach (NSNumber nsIndex in visibleIndices) {
+                int index = nsIndex.IntValue;
+                var currentView = carouselView.ItemViewAtIndex (index);
+                if (null == currentView) {
+                    continue;
+                }
+                var bodyView = currentView.ViewWithTag (HotListCarouselDataSource.PREVIEW_TAG) as BodyView;
+                NcAssert.True (null != bodyView);
 
-            // To avoid unnecessary reload, we only reload if the current item was downloading
-            // and the body is now completely downloaded.
-            if (!bodyView.WasDownloadStartedAndNowComplete ()) {
-                return;
+                // To avoid unnecessary reload, we only reload if the current item was downloading
+                // and the body is now completely downloaded.
+                if (!bodyView.WasDownloadStartedAndNowComplete ()) {
+                    continue;
+                }
+                bodyView.DownloadComplete (succeed);
+                carouselView.ReloadItemAtIndex (carouselView.CurrentItemIndex, true);
             }
-            bodyView.DownloadComplete (succeed);
-            carouselView.ReloadItemAtIndex (carouselView.CurrentItemIndex, true);
         }
 
         /// <summary>


### PR DESCRIPTION
iCarousel currently is configured to show 16 visible items even though there is only one item being shown on screen. (That is referred as the current item index in iCarousel.) This allows us to using the # of visible items as a pre-rendering mechanism. Scrolling 1 of 16 visible item into screen does not require any hot item data source delegate involvement at all.

Here is an example how the bug can show up. When Nacho mail launches, a sync shows that two new hot emails are available. They are created as visible items 0 and 1 with item 0 being the current index. When 0 is downloaded, ProcessDownloadComplete() see this is the current index and reload that item which causes the spinner to be stopped. But when 1 is downloaded, it is not the current index (even though it is one of the visible indices) and it is not reloaded. This leaves the spinner to run. Later when we scroll to item 1, it will continue to spin since it never calls ViewForItemAtIndex() to re-render the message.

The fix is to apply the reload avoidance logic for all visible items not just the current index.
