### PR TITLE
Handle meeting response and meeting cancellation messages.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
+++ b/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
@@ -470,14 +470,21 @@ namespace NachoCore.Utils
         }
 
         /// <summary>
-        /// Renders the best alternative.
-        /// http://en.wikipedia.org/wiki/MIME#Alternative
+        /// Pick the best alternative to be displayed, which is always supposed to be
+        /// the last one in the list.
         /// </summary>
+        /// <description>
+        /// If the best alternative is a calendar entry, then also select the next best
+        /// item, since we want to display that one as well.
+        /// </description>
         protected static void MimeBestAlternativeDisplayList (Multipart multipart, ref List<MimeEntity> list)
         {
-            var e = multipart.Last ();
-            MimeEntityDisplayList (e, ref list);
-
+            var last = multipart.Last ();
+            MimeEntityDisplayList (last, ref list);
+            if (1 < multipart.Count && last.ContentType.Matches ("text", "calendar")) {
+                var nextToLast = multipart [multipart.Count - 2];
+                MimeEntityDisplayList (nextToLast, ref list);
+            }
         }
 
         private static void FixTnefMessage (MimeMessage tnefMessage)


### PR DESCRIPTION
Do the right thing with meeting response and meeting cancellation
messages.  The code for displaying the details of the message is
shared with meeting requests and is mostly unchanged.  What is
different is the action bar.  Instead of three buttons for Accept,
Tentative, and Decline, meeting responses display the attendee's
response (with no actions available), and meeting cancellations have a
"Remove from calendar" button.

This update focuses on correct functionality and on displaying the
correct information.  It does not focus on getting the UI exactly
right.  That will be done separately.
