### PR TITLE
Archive locks up the app - Fix

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
@@ -272,9 +272,10 @@ namespace NachoClient.iOS
                 return;
             }
             var message = messageThread.SingleMessageSpecialCase ();
-            if (null != message) {
-                message.ToggleHotOrNot ();
+            if (null == message) {
+                return;
             }
+            message.ToggleHotOrNot ();
             owner.priorityInbox.Refresh ();
             owner.ReloadHotListData ();
         }


### PR DESCRIPTION
-Added protection against Delete, Archive, ToggleHotOrNot on an email message that is null

In the NachoNow view a message may appear to be in the list, which allows you to perform actions on it, when in reality the BE may have already removed or modified the message.
