### PR TITLE
Fix message view crash when newest is deleted and one new one arrives

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcMessageThreads.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcMessageThreads.cs
@@ -36,7 +36,7 @@ namespace NachoCore.Brain
             for (int n = 0; n < oldList.Count; n++) {
                 var message = oldList [n].GetEmailMessage (0);
                 if (null == message) {
-                    return false;
+                    return true;
                 }
                 if (message.Id != newList [n].Id) {
                     return true;


### PR DESCRIPTION
The following scenario results in a crash:
1. User opens the Inbox view
2. User switches to a different view.
3. A different client deletes the newest e-mail message.
4. A new e-mail message arrives.
5. The user switches back to the Inbox view.

The bug was in NcMessageThreads.AreDifferent(), which was reporting
that the two lists were identical. This was causing
MessageListViewController to continue using the old list of messages,
which still had the deleted message in it.
