### PR TITLE
Don't cut off the bottom of messages with attachments.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -910,7 +910,7 @@ namespace NachoClient.iOS
             float width = scrollView.Frame.Width - 2 * VIEW_INSET;
             float height;
 
-            height = separator1YOffset;
+            height = separator2YOffset;
             height += bodyView.Frame.Height * bodyView.ZoomScale;
             height += 2 * VIEW_INSET;
             height = Math.Max (height, scrollView.Frame.Height);


### PR DESCRIPTION
When a message had attachments and was longer than one screen, the
message detail view would cut off the very bottom of the message. The
problem was that one of the height calculations was using the location
of the separator above the attachments section instead of the
separator below the attachments section.
