### PR TITLE
For hot list, disable extending of web view to content size to reduce memory consumption

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -218,6 +218,7 @@ namespace NachoClient.iOS
                 webView.Dispose ();
             }
             webView = new BodyWebView (this, htmlLeftMargin);
+            webView.ScrollingEnabled = (HorizontalScrollingEnabled && VerticalScrollingEnabled);
 
             if (item.IsDownloaded ()) {
                 loadState = LoadState.IDLE;

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -24,20 +24,22 @@ namespace NachoClient.iOS
             document.getElementsByTagName('head')[0].appendChild(viewPortTag);
         ";
 
+        public bool ScrollingEnabled;
+
         protected RecursionCounter htmlBusy;
         public RenderStart OnRenderStart;
         public RenderComplete OnRenderComplete;
-        protected UIView parentView;
 
         public BodyWebView (UIView parentView, float leftMargin) : base (parentView.Frame)
         {
-            this.parentView = parentView;
             ViewFramer.Create (this).X (leftMargin).Height (1);
             htmlBusy = new RecursionCounter (() => {
                 EvaluateJavascript (magic);
-                ViewFramer.Create (this)
+                if (!ScrollingEnabled) {
+                    ViewFramer.Create (this)
                     .Width (ScrollView.ContentSize.Width)
                     .Height (ScrollView.ContentSize.Height);
+                }
                 // Adjust scroll view minimum zoom scale based on the content. Make sure 
                 // that we cannot pinch (zoom out) to the point that the content is narrower
                 // than 95% of the device screen width.


### PR DESCRIPTION
Random scrolling in hot list kills the app because it was consuming too much memory. That happens because BodyWebView was extending the frame size to content size so that it can defer the scrolling to the body view's scroll view. This has the undesirable effect of using a lot of memory to hold a full render of the entire body.

For hot list, we only need a portion of body for a preview. So, scrolling in both directions are enabled but user interaction is disabled. So, we disable extending of web view when scrolling in both directions are extended.

This is only a partial fix as message view still has a problem. It will be fix in a later commit.
