### PR TITLE
Fix for "Effed up rendering of Hockey-App email"

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -213,14 +213,18 @@ namespace NachoClient.iOS
             }
             if (NcResult.SubKindEnum.Info_EmailMessageBodyDownloadSucceeded == s.Status.SubKind) {
                 Log.Info (Log.LOG_EMAIL, "EmailMessageBodyDownloadSucceeded");
-                bodyView.DownloadComplete (true);
-                ConfigureView ();
-                MarkAsRead();
+                if (bodyView.WasDownloadStartedAndNowComplete ()) {
+                    bodyView.DownloadComplete (true);
+                    ConfigureView ();
+                    MarkAsRead ();
+                }
             }
             if (NcResult.SubKindEnum.Error_EmailMessageBodyDownloadFailed == s.Status.SubKind) {
                 Log.Info (Log.LOG_EMAIL, "EmailMessageBodyDownloadFailed");
-                bodyView.DownloadComplete (false);
-                ConfigureView ();
+                if (bodyView.WasDownloadStartedAndNowComplete ()) {
+                    bodyView.DownloadComplete (false);
+                    ConfigureView ();
+                }
             }
         }
 


### PR DESCRIPTION
Jeff reported this issue. When he was in message view, the spinner is on and he saw it flashing between spinner, blanking screen repeatedly and eventually with the body shown.

I think what happened is due to the status indication handler not discriminating for whom the download complete is. Suppose emails A, B, and C are queued for downloaded and he opens up email C. It started with a spinner since it wasn't downloaded. Then A completes and the status handler stop the spinner, reconfigure the body view. But since C is still not downloaded, it restarts the spinner. This happened again for B and eventually when C is downloaded and ConfigureView() is called 3rd time, it presented the view.

The fix is to only update the body in message view if the download is for that particular message to avoid erroneous updates.
