### PR TITLE
Need to scale up BodyWebView frame when it signals BodyView to scale down the content subviews.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -35,11 +35,6 @@ namespace NachoClient.iOS
             ViewFramer.Create (this).X (leftMargin).Height (1);
             htmlBusy = new RecursionCounter (() => {
                 EvaluateJavascript (magic);
-                if (!ScrollingEnabled) {
-                    ViewFramer.Create (this)
-                    .Width (ScrollView.ContentSize.Width)
-                    .Height (ScrollView.ContentSize.Height);
-                }
                 // Adjust scroll view minimum zoom scale based on the content. Make sure 
                 // that we cannot pinch (zoom out) to the point that the content is narrower
                 // than 95% of the device screen width.
@@ -48,6 +43,17 @@ namespace NachoClient.iOS
                     minZoomScale = 1.0f;
                 } else {
                     minZoomScale = (0.95f * parentView.Bounds.Width) / ScrollView.ContentSize.Width;
+                }
+                if (!ScrollingEnabled) {
+                    ViewFramer.Create (this)
+                        .Width (ScrollView.ContentSize.Width)
+                        .Height (ScrollView.ContentSize.Height);
+                } else {
+                    // Make frame bigger so that after body view scroll view scale the 
+                    // content down, the frame will still be the original size.
+                    ViewFramer.Create (this)
+                        .Width (Frame.Width / minZoomScale)
+                        .Height (Frame.Height / minZoomScale);
                 }
                 OnRenderComplete (minZoomScale);
             });


### PR DESCRIPTION
Hot list item that are HTML and needs scaling down to fit into the frame look extra narrow.

After HTML rendering is finished, it measures the content size and if it is wider than the frame, it makes a callback with a proper scale that will fit the content (width wise) in the frame. In order to make sure that content still covers the width of the frame after scaling down, we must compensate by the inverse of that scaling factor before the callback.
