### PR TITLE
Use the download command token to check if the spinner should be stop

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -212,17 +212,17 @@ namespace NachoClient.iOS
                 return;
             }
             if (NcResult.SubKindEnum.Info_EmailMessageBodyDownloadSucceeded == s.Status.SubKind) {
-                Log.Info (Log.LOG_EMAIL, "EmailMessageBodyDownloadSucceeded");
-                if (bodyView.WasDownloadStartedAndNowComplete ()) {
-                    bodyView.DownloadComplete (true);
+                var token = s.Tokens.FirstOrDefault ();
+                Log.Info (Log.LOG_EMAIL, "EmailMessageBodyDownloadSucceeded {0}", token);
+                if (bodyView.DownloadComplete (true, token)) {
                     ConfigureView ();
                     MarkAsRead ();
                 }
             }
             if (NcResult.SubKindEnum.Error_EmailMessageBodyDownloadFailed == s.Status.SubKind) {
-                Log.Info (Log.LOG_EMAIL, "EmailMessageBodyDownloadFailed");
-                if (bodyView.WasDownloadStartedAndNowComplete ()) {
-                    bodyView.DownloadComplete (false);
+                var token = s.Tokens.FirstOrDefault ();
+                Log.Info (Log.LOG_EMAIL, "EmailMessageBodyDownloadFailed {0}", token);
+                if (bodyView.DownloadComplete (false, token)) {
                     ConfigureView ();
                 }
             }

--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -200,12 +200,14 @@ namespace NachoClient.iOS
                 RefreshPriorityInboxIfVisible ();
             }
             if (NcResult.SubKindEnum.Info_EmailMessageBodyDownloadSucceeded == s.Status.SubKind) {
-                Log.Info (Log.LOG_UI, "NachoNowViewController: mailMessageBodyDownloadSucceeded {0}", s.Tokens.FirstOrDefault ().ToString ());
-                ProcessDownloadComplete (true);
+                var token = s.Tokens.FirstOrDefault ();
+                Log.Info (Log.LOG_UI, "NachoNowViewController: mailMessageBodyDownloadSucceeded {0}", token.ToString ());
+                ProcessDownloadComplete (true, token);
             }
             if (NcResult.SubKindEnum.Error_EmailMessageBodyDownloadFailed == s.Status.SubKind) {
-                Log.Info (Log.LOG_UI, "NachoNowViewController: mailMessageBodyDownloadFailed {0}", s.Tokens.FirstOrDefault ().ToString ());
-                ProcessDownloadComplete (false);
+                var token = s.Tokens.FirstOrDefault ();
+                Log.Info (Log.LOG_UI, "NachoNowViewController: mailMessageBodyDownloadFailed {0}", token.ToString ());
+                ProcessDownloadComplete (false, token);
             }
         }
 
@@ -246,7 +248,7 @@ namespace NachoClient.iOS
             }
         }
 
-        private void ProcessDownloadComplete (bool succeed)
+        private void ProcessDownloadComplete (bool succeed, string token)
         {
             var visibleIndices = carouselView.IndexesForVisibleItems;
             foreach (NSNumber nsIndex in visibleIndices) {
@@ -260,10 +262,9 @@ namespace NachoClient.iOS
 
                 // To avoid unnecessary reload, we only reload if the current item was downloading
                 // and the body is now completely downloaded.
-                if (!bodyView.WasDownloadStartedAndNowComplete ()) {
+                if (!bodyView.DownloadComplete (succeed, token)) {
                     continue;
                 }
-                bodyView.DownloadComplete (succeed);
                 carouselView.ReloadItemAtIndex (index, true);
             }
         }

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -569,10 +569,14 @@ namespace NachoClient.iOS
             }
         }
 
-        public void DownloadComplete (bool succeed)
+        public bool DownloadComplete (bool succeed, string token)
         {
+            if (token != downloadToken) {
+                return false; // indication for a different message
+            }
             loadState = succeed ? LoadState.IDLE : LoadState.ERROR;
             spinner.StopAnimating ();
+            return true;
         }
 
         public bool WasDownloadStartedAndNowComplete ()


### PR DESCRIPTION
Download spinner does not stop when download fails. This happens because WasStartedAndNowComplete() return false when download stops due to failure. (Because BodyState never advances)

The fix is to pass the download token into BodyView.DownloadComplete() and use it t compare against the saved token. If same, stop spinner. Return true if tokens match, false otherwise for UI to know which item to reload.
