### PR TITLE
Avoid error message erroneously displayed in a race

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -546,7 +546,8 @@ namespace NachoClient.iOS
                 if ((null == newAbstrItem) || newAbstrItem.IsDownloaded ()) {
                     // Download must have complete in the window from it was checked to
                     // download command here is issued. Must have a status indication
-                    // pending to stop the spinner. Just need to not print error message
+                    // pending to stop the spinner or remove the item from UI. Just need
+                    // to not print error message
                     return;
                 }
                 // Duplicate download command returns the first (highest priority)


### PR DESCRIPTION
From message is checked that it needs download to the download command, there is a small window where BE can finish downloading the message (or delete it). Just need to not display the error message and a status indication will update it properly.
