### PR TITLE
Hot or Not Toggle - Modified Unit Test for McEmailMessage

### DIFF
--- a/Test.Android/McEmailMessageTest.cs
+++ b/Test.Android/McEmailMessageTest.cs
@@ -99,8 +99,6 @@ namespace Test.Common
             addresses [8] = SetupAddress ("ivan@company.net", 3, 1, false);
             addresses [9] = SetupAddress ("jolene@company.net", 5, 5, false);
 
-
-
             McEmailMessage[] messages = new McEmailMessage[10];
             messages [0] = SetupMessage (addresses [0], new DateTime (2014, 8, 15, 1, 23, 0));
             messages [1] = SetupMessage (addresses [1], new DateTime (2014, 8, 15, 2, 0, 0));


### PR DESCRIPTION
Updated the QueryActiveMessageItemsByScore unit test to include two new cases: 
Message has a HotScore below the threshold, but has a UserAction = 1
Message has a HotScore above the threshold, but has a UserAction = -1. 

-Also noticed a couple mistakes in the unit test and fixed those.
