### PR TITLE
Fix couple bugs in BodyView

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -940,7 +940,7 @@ namespace NachoClient.iOS
 
             scrollView.ContentSize = new SizeF (
                 Math.Max (view.Frame.Width, bodyView.ContentSize.Width + 12.0f),
-                separator2YOffset + bodyView.ContentSize.Height
+                separator2YOffset + bodyView.ContentSize.Height + view.Frame.Height
             );
         }
 
@@ -960,7 +960,7 @@ namespace NachoClient.iOS
             // increase the height to prevent vertical scroll bar from showing up.
             float height = View.Frame.Height;
             height -= 2 * BodyView.BODYVIEW_INSET;
-            var separator = view.ViewWithTag ((int)TagType.SEPARATOR1_TAG);
+            var separator = view.ViewWithTag ((int)TagType.SEPARATOR2_TAG);
             height -= separator.Frame.Bottom;
             if (null != attachmentListView) {
                 height -= attachmentListView.Frame.Height;

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -105,9 +105,6 @@ namespace NachoClient.iOS
             }
             set {
                 ShowsHorizontalScrollIndicator = value;
-                if (!VerticalScrollingEnabled && !HorizontalScrollingEnabled) {
-                    //ScrollEnabled = false;
-                }
             }
         }
 
@@ -117,9 +114,6 @@ namespace NachoClient.iOS
             }
             set {
                 ShowsVerticalScrollIndicator = value;
-                if (!VerticalScrollingEnabled && !HorizontalScrollingEnabled) {
-                    //ScrollEnabled = false;
-                }
             }
         }
 
@@ -242,7 +236,6 @@ namespace NachoClient.iOS
                 webView.Dispose ();
             }
             webView = new BodyWebView (this, htmlLeftMargin);
-            webView.ScrollingEnabled = (HorizontalScrollingEnabled && VerticalScrollingEnabled);
 
             if (item.IsDownloaded ()) {
                 loadState = LoadState.IDLE;

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -24,8 +24,6 @@ namespace NachoClient.iOS
             document.getElementsByTagName('head')[0].appendChild(viewPortTag);
         ";
 
-        public bool ScrollingEnabled;
-
         protected RecursionCounter htmlBusy;
         public RenderStart OnRenderStart;
         public RenderComplete OnRenderComplete;
@@ -70,7 +68,7 @@ namespace NachoClient.iOS
                 OnRenderComplete (1.0f);
             });
 
-            UserInteractionEnabled = false;
+            ScrollView.ScrollEnabled = false;
             ScrollView.Bounces = false;
             ScrollView.MultipleTouchEnabled = false;
             ContentMode = UIViewContentMode.ScaleAspectFit;


### PR DESCRIPTION
- Disable web view's scroll view instead of user interaction so that user can select (and copy) content in HTML emails.
- Add extra height to content size so that the end of the email is not truncated. Note that it seems like UIWebView.ContentSize is not accurate and in some mail it is a little bit short.
