### PR TITLE
Add our own web cache to block read and write for Parse API.

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -202,6 +202,8 @@ namespace NachoClient.iOS
         {
             Log.Info (Log.LOG_LIFECYCLE, "FinishedLaunching: Called");
             StartUIMonitor ();
+            const uint MB = 1000 * 1000; // MB not MiB
+            WebCache.Configure (1 * MB, 50 * MB);
             NcApplication.Instance.StartClass1Services ();
             Log.Info (Log.LOG_LIFECYCLE, "FinishedLaunching: StartClass1Services complete");
 

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1149,6 +1149,7 @@
     <Compile Include="NachoUI.iOS\Support\BodyTextView.cs" />
     <Compile Include="NachoUI.iOS\Support\BodyImageView.cs" />
     <Compile Include="NachoCore\Utils\ScoringHelpers.cs" />
+    <Compile Include="WebCache.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/NachoClient.iOS/WebCache.cs
+++ b/NachoClient.iOS/WebCache.cs
@@ -12,7 +12,11 @@ namespace NachoClient.iOS
 
         public WebCache (uint memoryCapacity, uint diskCapcity) : base (memoryCapacity, diskCapcity, "NachoCache")
         {
-            NSUrlCache.SharedCache = this;
+        }
+
+        public static void Configure (uint memoryCapacity, uint diskCapacity)
+        {
+            NSUrlCache.SharedCache = new WebCache (memoryCapacity, diskCapacity);
         }
 
         public override NSCachedUrlResponse CachedResponseForRequest (NSUrlRequest request)


### PR DESCRIPTION
Parse iOS SDK uses NSURLConnection (or NSURLSession) to do its web API and the result are being cached into the shared NSURLCache. It does not consume a lot of storage but it does result in a lot of extra sqlite db ops.

So, create our own web cache object. Return null for read and early exit for write. (A previous version of WebCache.cs was committed previously by mistake. Please look a the file to see the whole thing.)
