### PR TITLE
Add an option to adjust body view frame (and its subviews) for event view.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -690,7 +690,7 @@ namespace NachoClient.iOS
             yOffset += tl.Frame.Height;
 
             yOffset += 5;
-            descriptionView.Layout (0, yOffset, SCREEN_WIDTH - 2 * BodyView.BODYVIEW_INSET, 10);
+            descriptionView.Layout (0, yOffset, SCREEN_WIDTH - 2 * BodyView.BODYVIEW_INSET, 10, true);
             yOffset += descriptionView.Frame.Height;
 
             yOffset += 10;

--- a/NachoClient.iOS/NachoUI.iOS/Support/ViewHelper.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/ViewHelper.cs
@@ -276,6 +276,13 @@ namespace NachoClient.iOS
             return MayUpdate ();
         }
 
+        public ViewFramer Size (SizeF size)
+        {
+            Frame.Width = size.Width;
+            Frame.Height = size.Height;
+            return MayUpdate ();
+        }
+
         public ViewFramer Update ()
         {
             View.Frame = Frame;


### PR DESCRIPTION
This fixes the regression of event description becomes missing. (It actually brings back the old problem of scaling view frame to content size. But the event description should be so small that the problem is only theoretical.)
