### PR TITLE
In ProcessDownloadComplete, ignore placeholder views using a few

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -253,15 +253,19 @@ namespace NachoClient.iOS
             var visibleIndices = carouselView.IndexesForVisibleItems;
             foreach (NSNumber nsIndex in visibleIndices) {
                 int index = nsIndex.IntValue;
+                // Ignore placeholders
+                if ((0 > index) || (carouselView.NumberOfItems <= index)) {
+                    continue;
+                }
                 var currentView = carouselView.ItemViewAtIndex (index);
                 if (null == currentView) {
                     continue;
                 }
-                var bodyView = currentView.ViewWithTag (HotListCarouselDataSource.PREVIEW_TAG) as BodyView;
-                if (null == bodyView) {
-                    NcAssert.True (HotListCarouselDataSource.PLACEHOLDER_TAG == currentView.Tag);
-                    continue; // might be a placeholder view
+                if (HotListCarouselDataSource.PLACEHOLDER_TAG == currentView.Tag) {
+                    continue;
                 }
+                var bodyView = currentView.ViewWithTag (HotListCarouselDataSource.PREVIEW_TAG) as BodyView;
+                NcAssert.True (null != bodyView);
                 // To avoid unnecessary reload, we only reload if the current item was downloading
                 // and the body is now completely downloaded.
                 if (!bodyView.DownloadComplete (succeed, token)) {

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
@@ -244,7 +244,7 @@ namespace NachoClient.iOS
             view.AddSubview (toolbar);
 
             // more icon view
-            var moreView = new UIView(new RectangleF(17, frame.Height - 44 - 14 - 13, 18, 10));
+            var moreView = new UIView (new RectangleF (17, frame.Height - 44 - 14 - 13, 18, 10));
             moreView.BackgroundColor = UIColor.White;
             moreView.Layer.CornerRadius = 2;
             view.AddSubview (moreView);
@@ -278,7 +278,7 @@ namespace NachoClient.iOS
             if (null == message) {
                 return;
             }
-            NachoCore.Utils.ScoringHelpers.ToggleHotOrNot(message);
+            NachoCore.Utils.ScoringHelpers.ToggleHotOrNot (message);
             owner.priorityInbox.Refresh ();
             owner.ReloadHotListData ();
         }
@@ -369,7 +369,7 @@ namespace NachoClient.iOS
         /// Populate message cells with data, adjust sizes and visibility
         /// </summary>
         protected void ConfigureView (UIView view, int messageThreadIndex)
-        {           
+        { 
             // Save thread index
             view.Tag = messageThreadIndex;
             var messageThread = owner.priorityInbox.GetEmailThread (messageThreadIndex);
@@ -384,7 +384,6 @@ namespace NachoClient.iOS
                 HandleUnavailableMessage (view);
                 return;
             }
-
 
             var viewWidth = view.Frame.Width;
 
@@ -455,7 +454,7 @@ namespace NachoClient.iOS
             var attachmentImageView = view.ViewWithTag (ATTACHMENT_TAG) as UIImageView;
             attachmentImageView.Hidden = !message.cachedHasAttachments;
             var attachmentImageRect = attachmentImageView.Frame;
-            attachmentImageRect.X = receivedLabelView.Frame.Right + 10;;
+            attachmentImageRect.X = receivedLabelView.Frame.Right + 10;
             attachmentImageView.Frame = attachmentImageRect;
 
             // Chili image view - nothing to do. It is also shown
@@ -503,9 +502,9 @@ namespace NachoClient.iOS
                 v.AddSubview (l);
                 view = v;
             }
+            NcAssert.True (PLACEHOLDER_TAG == view.Tag);
             var label = (UILabel)view.ViewWithTag (1);
             label.Text = "No hot items!";
-
             return view;
         }
     }
@@ -527,7 +526,7 @@ namespace NachoClient.iOS
         public override void DidSelectItemAtIndex (iCarousel carousel, int index)
         {
             // Ignore placeholders
-            if ((0 > index) || (owner.priorityInbox.Count () <= index)) {
+            if ((0 > index) || (carousel.NumberOfItems <= index)) {
                 return;
             }
             var messageThread = owner.priorityInbox.GetEmailThread (index);


### PR DESCRIPTION
In DownloadComplete, we're looking thru all of the visible views for items that might need updating.  This change will ignore the placeholder views, checking first the index and the view tag.  The tag check isn't strictly needed according to the iCarousel docs, and if the index check above fails then we'll have trouble in DidSelectItemAtIndex too, but I left it in as a reminder about how we are tagging views.
