### PR TITLE
Fix for #594

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
@@ -19,7 +19,7 @@ namespace NachoClient.iOS
     public class HotListCarouselDataSource : iCarouselDataSource
     {
         public const int PLACEHOLDER_TAG = -1;
-        protected const int USER_IMAGE_TAG = -11;
+        protected const int USER_IMAGE_TAG = -101;
         protected const int FROM_TAG = -102;
         protected const int SUBJECT_TAG = -103;
         public const int PREVIEW_TAG = -104;


### PR DESCRIPTION
The root cause of the problem is that the hot list data source item tag can alias with the user image view tag (which is 101) if the hot list is long enough.

The hot list item view tag is the message list index. If there are 102 items in the hot list, the last one's tag is 101 which is the same as the user image subview (underneath it). ViewWithTag() searches first the view itself before moving on to the subviews. So, for the last hot list item, it returns itself which is a SwipeActionView and when casted as UIImageView via "as", it returns null.

The solution is to make all subview tags negative so they can't alias.
