### PR TITLE
Avoid memory leaks in BodyView and related classes.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyImageView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyImageView.cs
@@ -32,19 +32,20 @@ namespace NachoClient.iOS
 
         public void Configure (MimePart part)
         {
-            var image = PlatformHelpers.RenderImage (part);
+            using (var image = PlatformHelpers.RenderImage (part)) {
 
-            if (null == image) {
-                Log.Error (Log.LOG_UI, "Unable to render {0}", part.ContentType);
-                // TODO - maybe put a bad image icon here?
-                return;
+                if (null == image) {
+                    Log.Error (Log.LOG_UI, "Unable to render {0}", part.ContentType);
+                    // TODO - maybe put a bad image icon here?
+                    return;
+                }
+
+                float width = Frame.Width;
+                float height = image.Size.Height * (width / image.Size.Width);
+                Image = image.Scale (new SizeF (width, height));
+
+                _contentSize = new SizeF (width, height);
             }
-
-            float width = Frame.Width;
-            float height = image.Size.Height * (width / image.Size.Width);
-            Image = image.Scale (new SizeF (width, height));
-
-            _contentSize = new SizeF (width, height);
         }
 
         public void ScrollTo (PointF upperLeft)

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -135,7 +135,9 @@ namespace NachoClient.iOS
         protected UIView parentView;
         protected UIView messageView;
         protected UIActivityIndicatorView spinner;
-        protected BodyWebView webView;
+
+        protected UITapGestureRecognizer partialDownloadGestureRecognizer;
+        protected UIGestureRecognizer.Token partialDownloadGestureRecognizerToken;
 
         protected LoadState loadState;
         protected McAbstrItem abstrItem;
@@ -177,15 +179,13 @@ namespace NachoClient.iOS
             MinimumZoomScale = 1.0f;
             MaximumZoomScale = 1.0f;
 
-            ViewForZoomingInScrollView = delegate {
-                return messageView;
-            };
             // TODO - Scrolling and zooming was originally planned but after
             // the 2nd version of BodyView, the scrolling is either entirely disabled
             // (in hot list) or completely delegated to the parent view (message view).
             // Hence, the base class UIScrollView is no longer used. It is conceivable
             // that we enable scrolling (and zooming) for hot list eventually so this
             // is kept around but disabled for now.
+            ViewForZoomingInScrollView = GetMessageView;
             DidZoom += OnDidZoom;
             ZoomingStarted += OnZoomingStarted;
             ZoomingEnded += OnZoomingEnded;
@@ -206,6 +206,13 @@ namespace NachoClient.iOS
 
         public bool Configure (McAbstrItem item)
         {
+            // Clear out the existing BodyView
+            for (int i = messageView.Subviews.Length - 1; i >= 0; --i) {
+                var subview = messageView.Subviews [i];
+                subview.RemoveFromSuperview ();
+                ViewHelper.DisposeViewHierarchy (subview);
+            }
+
             abstrItem = item;
             downloadToken = null;
             loadState = LoadState.IDLE;
@@ -215,21 +222,6 @@ namespace NachoClient.iOS
             center.X -= Frame.X;
             center.Y -= Frame.Y;
             spinner.Center = center;
-
-            // TODO: Revisit
-            for (int i = messageView.Subviews.Length - 1; i >= 0; i--) {
-                messageView.Subviews [i].RemoveFromSuperview ();
-            }
-
-            // Web view consumes a lot of memory.
-            // We manually dispose it to force all ObjCobjects to be freed.
-            if (null != webView) {
-                if (webView.IsLoading) {
-                    webView.StopLoading ();
-                }
-                webView.Dispose ();
-            }
-            webView = new BodyWebView (messageView, htmlLeftMargin);
 
             // If the body isn't downloaded,
             // start the download and return.
@@ -272,12 +264,25 @@ namespace NachoClient.iOS
                 break;
             }
 
-            //if (null != message.MeetingRequest && !calendarRendered) {
-            //    var UID = Util.GlobalObjIdToUID (message.MeetingRequest.GlobalObjId);
-            //    MakeStyledCalendarInvite (UID, message.Subject, message.MeetingRequest.AllDayEvent, message.MeetingRequest.StartTime, message.MeetingRequest.EndTime, message.MeetingRequest.Location, view);
-            //}
-
             return true;
+        }
+
+        protected override void Dispose (bool disposing)
+        {
+            ViewForZoomingInScrollView = null;
+            DidZoom -= OnDidZoom;
+            ZoomingStarted -= OnZoomingStarted;
+            ZoomingEnded -= OnZoomingEnded;
+            if (null != partialDownloadGestureRecognizer) {
+                partialDownloadGestureRecognizer.RemoveTarget (partialDownloadGestureRecognizerToken);
+                partialDownloadGestureRecognizer = null;
+            }
+            base.Dispose (disposing);
+        }
+
+        private UIView GetMessageView (UIScrollView scrollView)
+        {
+            return messageView;
         }
 
         private void OnDidZoom (object sender, EventArgs e)
@@ -411,13 +416,14 @@ namespace NachoClient.iOS
             label.UserInteractionEnabled = true;
 
             // Detect tap of the partially download mesasge label
-            var singletap = new UITapGestureRecognizer ();
-            singletap.NumberOfTapsRequired = 1;
-            singletap.AddTarget (this, new MonoTouch.ObjCRuntime.Selector ("DownloadMessage:"));
-            singletap.ShouldRecognizeSimultaneously = delegate {
+            partialDownloadGestureRecognizer = new UITapGestureRecognizer ();
+
+            partialDownloadGestureRecognizer.NumberOfTapsRequired = 1;
+            partialDownloadGestureRecognizerToken = partialDownloadGestureRecognizer.AddTarget (OnDownloadMessage);
+            partialDownloadGestureRecognizer.ShouldRecognizeSimultaneously = delegate {
                 return false;
             };
-            label.AddGestureRecognizer (singletap);
+            label.AddGestureRecognizer (partialDownloadGestureRecognizer);
 
             messageView.AddSubview (label);
         }
@@ -454,6 +460,7 @@ namespace NachoClient.iOS
 
         void RenderHtmlString (string html)
         {
+            var webView = new BodyWebView (messageView, htmlLeftMargin);
             webView.OnRenderStart = () => {
                 if (null != OnRenderStart) {
                     OnRenderStart ();
@@ -471,7 +478,7 @@ namespace NachoClient.iOS
         /// TODO: Guard against malformed calendars
         public void RenderCalendar (MimePart part)
         {
-            var calView = new BodyCalendarView (this);
+            var calView = new BodyCalendarView (Frame.Width);
             calView.Configure (part);
             messageView.AddSubview (calView);
         }
@@ -552,14 +559,13 @@ namespace NachoClient.iOS
                 // download's token. So, a null really means something has gone wrong.
                 Log.Warn (Log.LOG_UI, "Fail to start download for message {0} in account {1}",
                     abstrItem.Id, abstrItem.AccountId);
-                RenderPartialDownloadMessage ("[ Message preview only. Tap here to download ]");
+                RenderPartialDownloadMessage ("[ Message preview only. Tap here to download. ]");
                 RenderTextString (abstrItem.GetBodyPreviewOrEmpty ());
                 return;
             }
         }
 
-        [MonoTouch.Foundation.Export ("DownloadMessage:")]
-        public void OnDownloadMessage (UIGestureRecognizer sender)
+        public void OnDownloadMessage ()
         {
             IndicateDownloadStarted ();
             StartDownload ();

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -100,6 +100,16 @@ namespace NachoClient.iOS
             }
         }
 
+        protected override void Dispose (bool disposing)
+        {
+            if (IsLoading) {
+                StopLoading ();
+            }
+            zoomRecognizer.Cleanup ();
+            RemoveGestureRecognizer (zoomRecognizer);
+            base.Dispose (disposing);
+        }
+
         private void OnLoadStarted (object sender, EventArgs e)
         {
             htmlBusy.Increment ();

--- a/NachoClient.iOS/NachoUI.iOS/Support/IBodyRender.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/IBodyRender.cs
@@ -32,6 +32,8 @@ namespace NachoClient.iOS
 
         public Action OnTap;
 
+        private UIGestureRecognizer.Token onTappedToken;
+
         public BodyRenderZoomRecognizer (UIScrollView view) : base ()
         {
             zoomIn = true;
@@ -42,7 +44,7 @@ namespace NachoClient.iOS
                 (UIGestureRecognizer gestureRecognizer, UIGestureRecognizer otherGestureRecognizer) => {
                 return true;
             };
-            AddTarget (onTapped);
+            onTappedToken = AddTarget (onTapped);
         }
 
         public void Configure ()
@@ -56,6 +58,11 @@ namespace NachoClient.iOS
             ZoomInScale = Math.Max (0.7f, ZoomInScale);
 
             ZoomOutScale = 2.0f * ZoomInScale;
+        }
+
+        public void Cleanup ()
+        {
+            RemoveTarget (onTappedToken);
         }
 
         private void onTapped ()

--- a/NachoClient.iOS/NachoUI.iOS/ViewControllers/NcUIViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ViewControllers/NcUIViewController.cs
@@ -95,82 +95,6 @@ namespace NachoClient.iOS
 
         protected abstract void Cleanup ();
 
-        protected static void DisposeViewHierarchy (UIView view)
-        {
-            // This code comes from a StackOverflow question, and was provided by
-            // Herman Schoenfeld.  I have made some slight modifications.
-            // http://stackoverflow.com/questions/25532870/xamarin-ios-memory-leaks-everywhere
-            try {
-                if (null == view || IntPtr.Zero == view.Handle) {
-                    return;
-                }
-                bool skipDispose = false;
-                if (null != view.Subviews) {
-                    foreach (var subview in view.Subviews) {
-                        try {
-                            DisposeViewHierarchy (subview);
-                        } catch (Exception e) {
-                            Log.Error(Log.LOG_UI, "Exception while disposing of view hierarchy: {0}", e.ToString());
-                        }
-                    }
-                }
-                if (view is UIActivityIndicatorView) {
-                    var indicatorView = view as UIActivityIndicatorView;
-                    if (indicatorView.IsAnimating) {
-                        indicatorView.StopAnimating();
-                    }
-                } else if (view is UITableView) {
-                    var tableView = view as UITableView;
-                    if (null != tableView.DataSource) {
-                        tableView.DataSource.Dispose();
-                    }
-                    tableView.Source = null;
-                    tableView.Delegate = null;
-                    tableView.DataSource = null;
-                    tableView.WeakDelegate = null;
-                    tableView.WeakDataSource = null;
-                    if (null != tableView.VisibleCells) {
-                        foreach (var cell in tableView.VisibleCells) {
-                            DisposeViewHierarchy(cell);
-                        }
-                    }
-                } else if (view is UICollectionView) {
-                    // UICollectionViewController with throw if its view is disposed before the controller.
-                    skipDispose = true;
-                    var collectionView = view as UICollectionView;
-                    if (null != collectionView.DataSource) {
-                        collectionView.DataSource.Dispose();
-                    }
-                    collectionView.Source = null;
-                    collectionView.Delegate = null;
-                    collectionView.DataSource = null;
-                    collectionView.WeakDelegate = null;
-                    collectionView.WeakDataSource = null;
-                    if (null != collectionView.VisibleCells) {
-                        foreach (var cell in collectionView.VisibleCells) {
-                            DisposeViewHierarchy(cell);
-                        }
-                    }
-                } else if (view is UIWebView) {
-                    var webView = view as UIWebView;
-                    if (webView.IsLoading) {
-                        webView.StopLoading();
-                    }
-                    webView.LoadHtmlString(string.Empty, null);
-                    webView.Delegate = null;
-                    webView.WeakDelegate = null;
-                }
-                if (null != view.Layer) {
-                    view.Layer.RemoveAllAnimations();
-                }
-                if (!skipDispose) {
-                    view.Dispose();
-                }
-            } catch (Exception e) {
-                Log.Error (Log.LOG_UI, "Exception while disposing of view hierarchy: {0}", e.ToString ());
-            }
-        }
-
         public override void ViewDidLoad ()
         {
             base.ViewDidLoad ();
@@ -190,7 +114,7 @@ namespace NachoClient.iOS
             base.ViewDidDisappear (animated);
             if (this.IsViewLoaded && null == this.NavigationController) {
                 Cleanup ();
-                DisposeViewHierarchy (View);
+                ViewHelper.DisposeViewHierarchy (View);
                 View = null;
             }
         }


### PR DESCRIPTION
The BodyView classes have been changed to not leak memory. Event
handlers and gesture recognizers are unregistered when the objects are
disposed. The biggest changes were to class BodyCalendarView, which
needed to be cleaned up and reorganized somewhat to comply with the
memory leak guidelines.
