### PR TITLE
Fix bursts of disposed contact gleaner timers

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -53,6 +53,7 @@ namespace NachoCore.Brain
         private DateTime LastEmailMessageScoreUpdate;
 
         private DateTime LastPeriodicGlean;
+        private DateTime LastPeriodicGleanRestart;
 
         public NcBrain ()
         {
@@ -395,7 +396,10 @@ namespace NachoCore.Brain
             if (NcResult.SubKindEnum.Info_BackgroundAbateStopped != eventArgs.Status.SubKind) {
                 return;
             }
-            if ((double)NcContactGleaner.GLEAN_PERIOD < (DateTime.Now - LastPeriodicGlean).TotalSeconds) {
+            DateTime now = DateTime.Now;
+            if (((double)NcContactGleaner.GLEAN_PERIOD < (now - LastPeriodicGlean).TotalSeconds) &&
+                (LastPeriodicGleanRestart < LastPeriodicGlean)) {
+                LastPeriodicGleanRestart = now;
                 NcContactGleaner.Stop ();
                 NcContactGleaner.Start ();
             }


### PR DESCRIPTION
Steve has seen a long burst of contact gleaner timer warnings:

2014-10-16  22:48:38.136    INFO    message NcTimer 3272/NcContactGleaner fired after Dispose.
2014-10-16  22:48:38.147    INFO    message NcTimer 3276/NcContactGleaner fired after Dispose.
2014-10-16  22:48:38.351    INFO    message NcTimer 1513/NcContactGleaner fired after Dispose.
2014-10-16  22:48:38.351    INFO    message NcTimer 1513/NcContactGleaner fired after Dispose.
2014-10-16  22:48:38.394    INFO    message NcTimer 2993/NcContactGleaner fired after Dispose.

Gleaner timer is restarted only in two scenarios:
1. the app is foreground
2. the abatement stops and it has been longer than GLEAN_PERIOD.

The 2nd case is intended to catch up if we miss a glean due to abatement. This can happen if there is a slowdown and we keep scrolling. Then the timer will be restarted many times (because the slowdown prevents it from updating the last glean time).

The fix is to keep track of the last time gleaner timer is restarted and do not restart if it is restarted after the last glean time.
