### PR TITLE
Improve time zone support and handling of all-day events.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -1196,8 +1196,14 @@ namespace NachoClient.iOS
             c.Subject = titleField.Text;
             c.Description = descriptionTextView.Text;
             c.AllDayEvent = allDayEvent;
-            c.StartTime = startDate;
-            c.EndTime = endDate;
+            if (allDayEvent) {
+                // An all-day event is supposed to run midnight to midnight in the local time zone.
+                c.StartTime = startDate.ToLocalTime ().Date.ToUniversalTime ();
+                c.EndTime = endDate.ToLocalTime ().AddDays (1.0).Date.ToUniversalTime ();
+            } else {
+                c.StartTime = startDate;
+                c.EndTime = endDate;
+            }
             // c.attendees is already set via PullAttendees
             //c.Phone = phoneDetailLabel.Text;
             c.Location = locationField.Text;
@@ -1219,11 +1225,8 @@ namespace NachoClient.iOS
                 c.ResponseRequestedIsSet = true;
             }
 
-            // Timezone hardcoded
-            var l = TimeZoneInfo.Local;
-            var tzi = l;
-            var tz = new AsTimeZone (tzi, c.StartTime);
-            c.TimeZone = tz.toEncodedTimeZone ();
+            // The event always uses the local time zone.
+            c.TimeZone = new AsTimeZone (CalendarHelper.SimplifiedLocalTimeZone (), c.StartTime).toEncodedTimeZone ();
 
             if (String.IsNullOrEmpty (c.UID)) {
                 c.UID = System.Guid.NewGuid ().ToString ().Replace ("-", null).ToUpper ();


### PR DESCRIPTION
Better handling of all-day events, both creating them and displaying
them.  All-day events that are created in Nacho Mail now run from
midnight to midnight (local time), as they are supposed to.  All-day
events no longer spill over into an extra day, but are shown only on
the day (or days) that they are supposed to, even if they were created
in a different time zone.  (The display of all-day events was only
fixed in the calendar view.  They are still not quite right in the
event detail view or in meeting request messages for all-day
meetings.)

Improve the time zone support.  The time zone information baked into
the event that comes from Exchange is now parsed.  (Currently it is
only used for all-day events. Using it for recurring events will come
later, but the necessary infrastructure is there.)  The time zone
information that Nacho Mail inserts into calendar events that it
creates is more accurate.
