### PR TITLE
Fix for #603

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcQueue.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcQueue.cs
@@ -17,12 +17,7 @@ namespace NachoCore.Utils
         private object Lock;
         private SemaphoreSlim ProducedCount;
 
-        private CancellationToken _Token;
-        public CancellationToken Token {
-            set {
-                _Token = value;
-            }
-        }
+        public CancellationToken Token { get; set; }
 
         private ulong _NumEnqueue;
         public ulong NumEnqueue {
@@ -103,7 +98,7 @@ namespace NachoCore.Utils
 
         public T Dequeue ()
         {
-            ProducedCount.Wait (_Token);
+            ProducedCount.Wait (Token);
             lock (Lock) {
                 T obj = (T)_Queue.Dequeue ();
                 _NumDequeueBytes += obj.GetSize ();

--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -695,10 +695,12 @@ namespace NachoCore.Utils
             if (!ENABLED) {
                 return;
             }
-            NcTask.Run (() => {
-                EventQueue.Token = NcTask.Cts.Token;
-                Process<T> ();
-            }, "Telemetry");
+            if (EventQueue.Token != NcTask.Cts.Token) {
+                NcTask.Run (() => {
+                    EventQueue.Token = NcTask.Cts.Token;
+                    Process<T> ();
+                }, "Telemetry");
+            }
         }
 
         /// Send a SHA1 hash of the email address of all McAccounts (that have an email addresss)
@@ -768,7 +770,8 @@ namespace NachoCore.Utils
                     }
 
                     if (null != dbEvent) {
-                        dbEvent.Delete ();
+                        var rowsDeleted = dbEvent.Delete ();
+                        NcAssert.True (1 == rowsDeleted);
                         eventDeleted = (eventDeleted + 1) & 0xfff;
                         if (0 == eventDeleted) {
                             // 4K events deleted. Try to vacuum


### PR DESCRIPTION
Telemetry is started by class 4 late show event but stopped by NcTask.StopService(). So, if one background the app and quickly foreground it before NcTask.StopService() is called, he gets 2 telemetry threads running. This is how two identical events are added.

This is found during investigation of UI pause. Having extra threads (you can have many if you repeat these steps) can lead to extra db operations (at a rate of limited by CPU) that can lead to high CPU and UI pauses.
