### PR TITLE
Fix for #699

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/NachoTabBarController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoTabBarController.cs
@@ -22,6 +22,7 @@ namespace NachoClient.iOS
 
             TabBar.BarTintColor = UIColor.White;
             TabBar.TintColor = A.Color_NachoIconGray;
+            TabBar.SelectedImageTintColor = A.Color_NachoGreen;
             TabBar.Translucent = false;
 
             MoreNavigationController.NavigationBar.TintColor = A.Color_NachoBlue;
@@ -95,8 +96,8 @@ namespace NachoClient.iOS
         {
             foreach (var vc in ViewControllers) {
                 if (typeName == GetTabBarItemTypeName (vc)) {
-                    using (var image = UIImage.FromBundle (imageName).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal)) {
-                        using (var selectedImage = UIImage.FromBundle (selectedImageName).ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal)) {
+                    using (var image = UIImage.FromBundle (imageName).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)) {
+                        using (var selectedImage = UIImage.FromBundle (selectedImageName).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)) {
                             var item = new UITabBarItem (title, image, selectedImage);
                             vc.TabBarItem = item;
                         }


### PR DESCRIPTION
For our buttons, we supply the selected and unselected image with the dark green tinted applied in the image itself. But since the more tab is provided by iOS and by us. It does not have the tint we want. The solution is to use the selected tint color. This has the side effect to making the text dark green as well when the tab is selected.

I cannot tell if the dark green of selected images is the exact same as NachoGreen. So, I change the image render mode to template so that all icons will have the same selected tint.

Specify the selected tint color. Make all selected image to use that color.
