### PR TITLE
Fix the gmail CID problem

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -476,7 +476,8 @@ namespace NachoClient.iOS
                 }
             };
             messageView.Add (webView);
-            webView.LoadHtmlString (html);
+            var url = String.Format ("cid://{0}", abstrItem.BodyId);
+            webView.LoadHtmlContent (html, NSUrl.FromString (url));
         }
 
         /// TODO: Guard against malformed calendars

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -153,7 +153,7 @@ namespace NachoClient.iOS
             // always call SizeToFit(). So, we need to disable it.
         }
 
-        public void LoadHtmlString (string html)
+        public void LoadHtmlContent (string html, NSUrl baseUrl)
         {
             NcAssert.True ((null != OnRenderStart) && (null != OnRenderComplete));
 
@@ -164,7 +164,7 @@ namespace NachoClient.iOS
             string disable_js = "<meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'none'\">";
             string wrap_pre = "<style>pre { white-space: pre-wrap;}</style>";
             html = disable_js + wrap_pre + html;
-            LoadHtmlString (html, null);
+            LoadHtmlString (html, baseUrl);
         }
 
         public void ScrollTo (PointF upperLeft)

--- a/NachoClient.iOS/WebCache.cs
+++ b/NachoClient.iOS/WebCache.cs
@@ -21,10 +21,10 @@ namespace NachoClient.iOS
 
         public override NSCachedUrlResponse CachedResponseForRequest (NSUrlRequest request)
         {
-            NSCachedUrlResponse response = base.CachedResponseForRequest (request);
             if (request.ToString().StartsWith (parseUrl)) {
                 return null;
             }
+            NSCachedUrlResponse response = base.CachedResponseForRequest (request);
             return response;
         }
 


### PR DESCRIPTION
- Encode the McBody id into the base (CID) URL of a BodyWebView.
- Handle specially encoded CID URL. Use the given McBody id if the CID dictionary does not have the MIME attachment.
- No need to read the URL cache if it is a Parse API URL.

While this does fix the logo.png problem, the body is MIME parsed an extra time. It seems a bit inefficient. Any suggestion to make it more efficient without sacrificing modularity?
