### PR TITLE
absorbing a DB busy inside a transaction can cause intervals of DB lockup

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McAbstrItem.cs
+++ b/NachoClient.Android/NachoCore/Model/McAbstrItem.cs
@@ -98,29 +98,26 @@ namespace NachoCore.Model
         {
             NcAssert.True (100000 > PendingRefCount);
             var returnVal = -1;
-            try {
-                NcModel.Instance.RunInTransaction (() => {
-                    McFolder.UnlinkAll (this);
-                    if (0 == PendingRefCount) {
-                        var result = base.Delete ();
-                        if (0 < BodyId) {
-                            var body = McBody.QueryById<McBody> (BodyId);
-                            if (null != body) {
-                                body.Delete ();
-                            }
+
+            NcModel.Instance.RunInTransaction (() => {
+                McFolder.UnlinkAll (this);
+                if (0 == PendingRefCount) {
+                    var result = base.Delete ();
+                    if (0 < BodyId) {
+                        var body = McBody.QueryById<McBody> (BodyId);
+                        if (null != body) {
+                            body.Delete ();
                         }
-                        DeleteAncillary ();
-                        returnVal = result;
-                    } else {
-                        IsAwaitingDelete = true;
-                        Update ();
-                        returnVal = 0;
                     }
-                });
-            } catch (SQLiteException ex) {
-                Log.Error (Log.LOG_EMAIL, "Deleting the item failed: {0} No changes were made to the DB.", ex.Message);
-                return -1;
-            }
+                    DeleteAncillary ();
+                    returnVal = result;
+                } else {
+                    IsAwaitingDelete = true;
+                    Update ();
+                    returnVal = 0;
+                }
+            });
+
             return returnVal;
         }
 

--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
@@ -697,38 +697,32 @@ namespace NachoCore.Model
         {
             int returnVal = -1; 
 
-            try {
-                if (0 == ScoreVersion) {
-                    // Try to use the contact score for initial email message score
-                    McEmailAddress emailAddress = GetFromAddress ();
-                    if (null != emailAddress) {
-                        Score = emailAddress.Score;
-                    }
+            if (0 == ScoreVersion) {
+                // Try to use the contact score for initial email message score
+                McEmailAddress emailAddress = GetFromAddress ();
+                if (null != emailAddress) {
+                    Score = emailAddress.Score;
                 }
-                NcModel.Instance.RunInTransaction (() => {
-                    returnVal = base.Insert ();
-                    InsertAncillaryData (NcModel.Instance.Db);
-                });
-            } catch (SQLiteException ex) {
-                Log.Error (Log.LOG_EMAIL, "Inserting the email failed: {0} No changes were made to the DB.", ex.Message);
             }
-                
+
+            NcModel.Instance.RunInTransaction (() => {
+                returnVal = base.Insert ();
+                InsertAncillaryData (NcModel.Instance.Db);
+            });
+              
             return returnVal;
         }
 
         public override int Update ()
         {
             int returnVal = -1;  
-            try {
-                NcModel.Instance.RunInTransaction (() => {
-                    returnVal = base.Update ();
-                    ReadAncillaryData ();
-                    DeleteAncillaryData (NcModel.Instance.Db);
-                    InsertAncillaryData (NcModel.Instance.Db);
-                });
-            } catch (SQLiteException ex) {
-                Log.Error (Log.LOG_EMAIL, "Updating the email failed: {0} No changes were made to the DB.", ex.Message);
-            }
+
+            NcModel.Instance.RunInTransaction (() => {
+                returnVal = base.Update ();
+                ReadAncillaryData ();
+                DeleteAncillaryData (NcModel.Instance.Db);
+                InsertAncillaryData (NcModel.Instance.Db);
+            });
 
             return returnVal;
         }

--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -297,7 +297,7 @@ namespace NachoCore.Model
             int rc = 0;
             if (IsInTransaction ()) {
                 // Do not loop-retry within the transaction. 
-                // If we are being given the busy, then rollback may be needed to release a SQLite lock.
+                // If we are being given the busy, then rollback is needed to release a SQLite lock.
                 rc = action ();
                 return rc;
             }
@@ -307,15 +307,15 @@ namespace NachoCore.Model
                     rc = action ();
                     return rc;
                 } catch (SQLiteException ex) {
-                    if (ex.Message.Contains ("Busy")) {
+                    if (SQLite3.Result.Busy == ex.Result) {
                         if (DateTime.UtcNow > whoa) {
-                            Log.Error (Log.LOG_DB, "Caught a Busy");
+                            Log.Error (Log.LOG_DB, "BusyProtect: Caught a Busy");
                             throw;
                         } else {
-                            Log.Warn (Log.LOG_DB, "Caught a Busy");
+                            Log.Warn (Log.LOG_DB, "BusyProtect: Caught a Busy");
                         }
                     } else {
-                        Log.Error (Log.LOG_DB, "Caught a non-Busy: {0}", ex);
+                        Log.Error (Log.LOG_DB, "BusyProtect: Caught a non-Busy: {0}", ex);
                         throw;
                     }
                 }
@@ -367,10 +367,10 @@ namespace NachoCore.Model
                         break;
                     } catch (SQLiteException ex) {
                         watch.Reset ();
-                        if (ex.Message.Contains ("Busy")) {
-                            Log.Warn (Log.LOG_DB, "Caught a Busy");
+                        if (SQLite3.Result.Busy == ex.Result) {
+                            Log.Warn (Log.LOG_DB, "RunInTransaction: Caught a Busy");
                         } else {
-                            Log.Error (Log.LOG_DB, "Caught a non-Busy: {0}", ex);
+                            Log.Error (Log.LOG_DB, "RunInTransaction: Caught a non-Busy: {0}", ex);
                             throw;
                         }
                     }


### PR DESCRIPTION
don't catch & absorb DB exceptions, unless you're going to make sure you're letting busy through.
as a design, let's assume that within 5s we can write the DB or we need to crash.
