### PR TITLE
The gleaner is crashing with file-not-found errors. When a body

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -33,9 +33,12 @@ namespace NachoCore.ActiveSync
                     item.BodyId = int.Parse (saveAttr.Value);
                     body = McBody.QueryById<McBody> (item.BodyId);
                     NcAssert.NotNull (body);
-                } else {
+                } else if (0 == item.BodyId) {
                     body = McBody.InsertFile (item.AccountId, bodyType, xmlData.Value); 
                     item.BodyId = body.Id;
+                } else {
+                    body = McBody.QueryById<McBody> (item.BodyId);
+                    body.UpdateData (xmlData.Value);
                 }
                 body.BodyType = bodyType;
                 if ((null != xmlTruncated) && ToBoolean (xmlTruncated.Value)) {

--- a/NachoClient.Android/NachoCore/Brain/NcContactGleaner.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcContactGleaner.cs
@@ -164,6 +164,14 @@ namespace NachoCore.Brain
                 MarkAsGleaned (emailMessage);
                 return;
             }
+            if (!File.Exists (path)) {
+                var e2 = McEmailMessage.QueryById<McEmailMessage> (emailMessage.Id);
+                var b2 = McBody.QueryById<McBody> (e2.BodyId);
+                Log.Error (Log.LOG_BRAIN, "Lost body: {0} == {1} and {2} == {3}", emailMessage.BodyId, body.Id, e2.BodyId, b2.Id);
+                // FIXME: Let's not crash at the moment
+                MarkAsGleaned (emailMessage);
+                return;
+            }
             using (var fileStream = new FileStream (path, FileMode.Open, FileAccess.Read)) {
                 MimeMessage mimeMsg;
                 try {


### PR DESCRIPTION
arrives, it was changing the body id of an item.  Now, the body
is re-used and updated with the content and body type.  Just in
case this isn't the problem, there's additional logging & debug
info in the gleaner if the file isn't visible. The gleaner will
act like everything is ok if the file isn't found (FIXME).
