### PR TITLE
fixes from bigfoot caught on tape

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
@@ -69,14 +69,7 @@ namespace NachoCore.ActiveSync
                     break;
 
                 case McPending.StateEnum.Dispatched:
-                    // Don't REALLY know that we killed this before the server saw it.
-                    // Command Cancel() moves pending(s) state to Deferred. Maybe many pending objs.
-                    StopCurrentOp ();
-                    pending = McPending.QueryById<McPending> (pending.Id);
-                    if (null != pending) {
-                        pending.ResolveAsCancelled (false);
-                    }
-                    Sm.PostEvent (Event.Create ((uint)SmEvt.E.TempFail, "CANCLDISP"));
+                    // TODO: find a way to remove this pending from PendingList for any re-try.
                     break;
 
                 case McPending.StateEnum.Deleted:

--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -29,16 +29,16 @@ namespace NachoCore
         {
             Foreground,
             Background,
-            QuickSync}
-
-        ;
+            QuickSync,
+        };
 
         private ExecutionContextEnum _ExecutionContext;
 
         public ExecutionContextEnum ExecutionContext {
             get { return _ExecutionContext; }
-            private set { 
+            set { 
                 _ExecutionContext = value; 
+                Log.Info (Log.LOG_LIFECYCLE, "ExecutionContext => {0}", value.ToString ());
                 InvokeStatusIndEvent (new StatusIndEventArgs () { 
                     Status = NachoCore.Utils.NcResult.Info (NcResult.SubKindEnum.Info_ExecutionContextChanged),
                     Account = ConstMcAccount.NotAccountSpecific,
@@ -234,7 +234,7 @@ namespace NachoCore
         // ALL CLASS-4 STARTS ARE DEFERRED BASED ON TIME.
         public void StartClass4Services ()
         {
-            _ExecutionContext = ExecutionContextEnum.Foreground;
+            ExecutionContext = ExecutionContextEnum.Foreground;
             MonitorStart (); // Has a deferred timer start inside.
             Log.Info (Log.LOG_LIFECYCLE, "{0} (build {1}) built at {2} by {3}",
                 BuildInfo.Version, BuildInfo.BuildNumber, BuildInfo.Time, BuildInfo.User);
@@ -263,7 +263,7 @@ namespace NachoCore
         public void StopClass4Services ()
         {
             Log.Info (Log.LOG_LIFECYCLE, "NcApplication: StopClass4Services called.");
-            _ExecutionContext = ExecutionContextEnum.Background;
+            ExecutionContext = ExecutionContextEnum.Background;
             MonitorStop ();
             if (Class4EarlyShowTimer.DisposeAndCheckHasFired ()) {
                 Log.Info (Log.LOG_LIFECYCLE, "NcApplication: Class4EarlyShowTimer.DisposeAndCheckHasFired.");
@@ -350,7 +350,9 @@ namespace NachoCore
 
         public void QuickSync (uint seconds)
         {
-            _ExecutionContext = ExecutionContextEnum.QuickSync;
+            if (ExecutionContextEnum.QuickSync != ExecutionContext) {
+                ExecutionContext = ExecutionContextEnum.QuickSync;
+            }
             // Needs Class-3 Services up. Cause accounts to do a quick check for new messages.
             // If start is called while wating for the QuickCheck, the system keeps going after the QuickCheck completes.
             BackEnd.Instance.QuickSync (seconds);

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -395,6 +395,10 @@ namespace NachoClient.iOS
             NcApplication.Instance.StartClass1Services ();
             Log.Info (Log.LOG_LIFECYCLE, "ReverseFinalShutdown: StartClass1Services complete");
             NcApplication.Instance.StartClass2Services ();
+            Log.Info (Log.LOG_LIFECYCLE, "ReverseFinalShutdown: StartClass2Services complete");
+            NcApplication.Instance.StartClass3Services ();
+            Log.Info (Log.LOG_LIFECYCLE, "ReverseFinalShutdown: StartClass3Services complete");
+
             FinalShutdownHasHappened = false;
             Log.Info (Log.LOG_LIFECYCLE, "ReverseFinalShutdown: Exit");
         }
@@ -406,7 +410,8 @@ namespace NachoClient.iOS
         {
             var timeRemaining = application.BackgroundTimeRemaining;
             Log.Info (Log.LOG_LIFECYCLE, "DidEnterBackground: time remaining: {0}", timeRemaining);
-            if (25.0 > timeRemaining) {
+            // XAMMIT: sometimes BackgroundTimeRemaining reads as MAXFLOAT.
+            if (25.0 > timeRemaining || 60*10 < timeRemaining) {
                 FinalShutdown (null);
             } else {
                 var secs = timeRemaining - 20.0;
@@ -514,6 +519,8 @@ namespace NachoClient.iOS
         public override void PerformFetch (UIApplication application, Action<UIBackgroundFetchResult> completionHandler)
         {
             Log.Info (Log.LOG_LIFECYCLE, "PerformFetch called.");
+            // Need to set ExecutionContext before Start of BE so that strategy can see it.
+            NcApplication.Instance.ExecutionContext = NcApplication.ExecutionContextEnum.QuickSync;
             if (FinalShutdownHasHappened) {
                 ReverseFinalShutdown ();
             }


### PR DESCRIPTION
a) there were two concurrent syncs running. traced back to an AsCommand getting "lost" and therefore not cancelled when we went into the background. On resume, the bugger re-activated. Only plausible scenario is a race condition where SetCmd is being executed by more than 1 thread at a time. All use of SetCmd is now behind the SM mutex.
b) "parked" state for top level SM. stays parked until lifecycle restarts it (app /ui API cannot cause it to reactivate).
c) change of ExecutionContext send status-ind as was expected.
d) BE was not getting restarted on resume from background until an app/ui API call.
e) Band-aid for XAMMIT where reading BackgroundTimeRemaining yields MAXFLOAT.
