### PR TITLE
Improve the display of message bodies and event bodies.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
+++ b/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
@@ -399,6 +399,15 @@ namespace NachoCore.Utils
                     MimeBestAlternativeDisplayList (multipart, ref list);
                     return;
                 }
+                if (multipart.ContentType.Matches ("multipart", "related") && 0 < multipart.Count) {
+                    // See https://tools.ietf.org/html/rfc2387
+                    // This isn't entirely correct. The multipart/related could have a "start"
+                    // parameter that points to the root entity that is not the first one.
+                    // But it is hard to write code to handle that without having a real life
+                    // message to test with.
+                    MimeEntityDisplayList (multipart [0], ref list);
+                    return;
+                }
                 foreach (var subpart in multipart) {
                     MimeEntityDisplayList (subpart, ref list);
                 }
@@ -500,6 +509,30 @@ namespace NachoCore.Utils
                     mixed.Add (alternative);
                 }
             }
+        }
+
+        public static MimePart EntityWithContentId (MimeMessage message, string contentId)
+        {
+            return EntityWithContentId (message.Body, contentId);
+        }
+
+        public static MimePart EntityWithContentId (MimeEntity root, string contentId)
+        {
+            if (null == root) {
+                return null;
+            }
+            if (root is MimePart && root.ContentId == contentId) {
+                return (MimePart)root;
+            }
+            if (root is Multipart) {
+                foreach (var subentity in (Multipart)root) {
+                    var match = EntityWithContentId (subentity, contentId);
+                    if (null != match) {
+                        return match;
+                    }
+                }
+            }
+            return null;
         }
 
         /// <summary>

--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -28,14 +28,13 @@ namespace NachoClient.iOS
         INachoMessageEditorParent, INachoFolderChooserParent, INachoCalendarItemEditorParent, 
         INcDatePickerDelegate, IUcAddressBlockDelegate, INachoDateControllerParent
     {
-
         // Model data
         public McEmailMessageThread thread;
         protected McAccount account;
         protected List<McAttachment> attachments;
 
         // UI elements for the main view
-        protected UIView view;
+        protected UIView headerView;
         protected AttachmentListView attachmentListView;
         protected UcAddressBlock toView;
         protected UcAddressBlock ccView;
@@ -57,14 +56,12 @@ namespace NachoClient.iOS
         #if DEBUG_UI
         const int VIEW_INSET = 4;
         const int ATTACHMENTVIEW_INSET = 10;
-        
-#else
+        #else
         const int VIEW_INSET = 2;
         const int ATTACHMENTVIEW_INSET = 15;
         #endif
 
         // UI helper objects
-        protected RecursionCounter deferLayout;
         protected bool expandedHeader = false;
         protected float expandedSeparatorYOffset;
         protected float compactSeparatorYOffset;
@@ -80,15 +77,12 @@ namespace NachoClient.iOS
             RECEIVED_DATE_TAG = 107,
             SEPARATOR1_TAG = 108,
             SEPARATOR2_TAG = 112,
-            SPINNER_TAG = BodyView.TagType.SPINNER_TAG,
             USER_LABEL_TAG = 110,
             USER_CHILI_TAG = 111,
-            MESSAGE_PART_TAG = BodyView.TagType.MESSAGE_PART_TAG,
-            CALENDAR_PART_TAG = BodyCalendarView.CALENDAR_PART_TAG,
+            BLANK_VIEW_TAG = 113,
             ATTACHMENT_VIEW_TAG = 301,
             ATTACHMENT_NAME_TAG = 302,
             ATTACHMENT_STATUS_TAG = 303,
-            DOWNLOAD_TAG = BodyView.TagType.DOWNLOAD_TAG,
             BLOCK_MENU_TAG = 1000,
         }
 
@@ -144,17 +138,14 @@ namespace NachoClient.iOS
 
             // Main view
 
-            view = new UIView (ViewHelper.InnerFrameWithInset (View.Frame, VIEW_INSET));
-            scrollView.AddSubview (view);
+            headerView = new UIView (new RectangleF (VIEW_INSET, 0, View.Frame.Width - 2 * VIEW_INSET, View.Frame.Height));
+            scrollView.AddSubview (headerView);
 
             #if DEBUG_UI
-            view.BackgroundColor = A.Color_NachoRed;
+            headerView.BackgroundColor = A.Color_NachoRed;
             scrollView.BackgroundColor = A.Color_NachoTeal;
             #endif
 
-            scrollView.DidZoom += ScrollViewDidZoom;
-            scrollView.MinimumZoomScale = 1.0f;
-            scrollView.MaximumZoomScale = 1.0f;
             scrollView.Bounces = false;
             scrollView.Scrolled += ScrollViewScrolled;
 
@@ -164,14 +155,14 @@ namespace NachoClient.iOS
             singleTapGesture.NumberOfTapsRequired = 1;
             singleTapGestureHandlerToken = singleTapGesture.AddTarget (HeaderSingleTapHandler);
             singleTapGesture.ShouldRecognizeSimultaneously = SingleTapGestureRecognizer;
-            view.AddGestureRecognizer (singleTapGesture);
+            headerView.AddGestureRecognizer (singleTapGesture);
 
             // User image
             var userImageView = new UIImageView (new RectangleF (15, 15, 40, 40));
             userImageView.Layer.CornerRadius = 20;
             userImageView.Layer.MasksToBounds = true;
             userImageView.Tag = (int)TagType.USER_IMAGE_TAG;
-            view.AddSubview (userImageView);
+            headerView.AddSubview (userImageView);
 
             // User label, to be used if no image is available
             var userLabelView = new UILabel (new RectangleF (15, 15, 40, 40));
@@ -182,7 +173,7 @@ namespace NachoClient.iOS
             userLabelView.Layer.CornerRadius = 20;
             userLabelView.Layer.MasksToBounds = true;
             userLabelView.Tag = (int)TagType.USER_LABEL_TAG;
-            view.AddSubview (userLabelView);
+            headerView.AddSubview (userLabelView);
 
             // Initial Y offsets for various elements. These will be adjusted when the
             // final layout is done.
@@ -195,7 +186,7 @@ namespace NachoClient.iOS
             fromLabelView.TextColor = A.Color_0F424C;
             fromLabelView.Tag = (int)TagType.FROM_TAG;
             fromLabelView.UserInteractionEnabled = true;
-            view.AddSubview (fromLabelView);
+            headerView.AddSubview (fromLabelView);
 
             yOffset += 20;
 
@@ -205,7 +196,7 @@ namespace NachoClient.iOS
             subjectLabelView.Font = A.Font_AvenirNextMedium14;
             subjectLabelView.TextColor = A.Color_0F424C;
             subjectLabelView.Tag = (int)TagType.SUBJECT_TAG;
-            view.AddSubview (subjectLabelView);
+            headerView.AddSubview (subjectLabelView);
 
             yOffset += 20;
 
@@ -215,12 +206,12 @@ namespace NachoClient.iOS
             receivedLabelView.TextColor = A.Color_9B9B9B;
             receivedLabelView.TextAlignment = UITextAlignment.Left;
             receivedLabelView.Tag = (int)TagType.RECEIVED_DATE_TAG;
-            view.AddSubview (receivedLabelView);
+            headerView.AddSubview (receivedLabelView);
 
             yOffset += 20;
 
             // "To" label
-            float blockWidth = view.Frame.Width - TOVIEW_LEFT_MARGIN;
+            float blockWidth = headerView.Frame.Width - TOVIEW_LEFT_MARGIN;
             toView = new UcAddressBlock (this, "To:", blockWidth);
             toView.SetCompact (false, -1);
             toView.SetEditable (false);
@@ -231,10 +222,10 @@ namespace NachoClient.iOS
                 .Y (yOffset)
                 .Width (blockWidth)
                 .Height (0);
-            view.AddSubview (toView);
+            headerView.AddSubview (toView);
 
             // "cc" label
-            blockWidth = view.Frame.Width - CCVIEW_LEFT_MARGIN;
+            blockWidth = headerView.Frame.Width - CCVIEW_LEFT_MARGIN;
             ccView = new UcAddressBlock (this, "Cc:", blockWidth);
             ccView.SetCompact (false, -1);
             ccView.SetEditable (false);
@@ -245,68 +236,61 @@ namespace NachoClient.iOS
                 .Y (yOffset)
                 .Width (blockWidth)
                 .Height (0);
-            view.AddSubview (ccView);
+            headerView.AddSubview (ccView);
 
             // Reminder image
             var reminderImageView = new UIImageView (new RectangleF (65, yOffset + 4, 12, 12));
             reminderImageView.Image = UIImage.FromBundle ("inbox-icn-deadline");
             reminderImageView.Tag = (int)TagType.REMINDER_ICON_TAG;
-            view.AddSubview (reminderImageView);
+            headerView.AddSubview (reminderImageView);
 
             // Reminder label
             var reminderLabelView = new UILabel (new RectangleF (87, yOffset, 230, 20));
             reminderLabelView.Font = A.Font_AvenirNextRegular14;
             reminderLabelView.TextColor = A.Color_9B9B9B;
             reminderLabelView.Tag = (int)TagType.REMINDER_TEXT_TAG;
-            view.AddSubview (reminderLabelView);
+            headerView.AddSubview (reminderLabelView);
 
             // Chili image
             var chiliImageView = new UIImageView (new RectangleF (View.Frame.Width - 20 - 15, 14, 20, 20));
             chiliImageView.Image = UIImage.FromBundle ("icn-red-chili-small");
             chiliImageView.Tag = (int)TagType.USER_CHILI_TAG;
-            view.AddSubview (chiliImageView);
+            headerView.AddSubview (chiliImageView);
+
+            // A blank view below separator2, which covers up the To and CC fields
+            // when the headers are colapsed.  (The To and CC fields are often
+            // covered by the attachments view or the message body. But not always.)
+            var blankView = new UIView (new RectangleF (0, yOffset, View.Frame.Width, 0));
+            blankView.BackgroundColor = UIColor.White;
+            blankView.Tag = (int)TagType.BLANK_VIEW_TAG;
+            headerView.AddSubview (blankView);
 
             // Separator 1
             var separator1View = new UIView (new RectangleF (0, yOffset, 320, 1));
             separator1View.BackgroundColor = A.Color_NachoBorderGray;
             separator1View.Tag = (int)TagType.SEPARATOR1_TAG;
-            view.AddSubview (separator1View);
+            headerView.AddSubview (separator1View);
 
             // Attachments
             attachmentListView = new AttachmentListView (new RectangleF (
                 ATTACHMENTVIEW_INSET, yOffset + 1.0f,
-                view.Frame.Width - ATTACHMENTVIEW_INSET, 50));
+                headerView.Frame.Width - ATTACHMENTVIEW_INSET, 50));
             attachmentListView.OnAttachmentSelected = AttachmentsOnSelected;
             attachmentListView.OnStateChanged = AttachmentsOnStateChange;
             attachmentListView.Tag = (int)TagType.ATTACHMENT_VIEW_TAG;
-            view.AddSubview (attachmentListView);
+            headerView.AddSubview (attachmentListView);
 
             // Separater 2
             var separator2View = new UIView (new RectangleF (0, yOffset, 320, 1));
             separator2View.BackgroundColor = A.Color_NachoBorderGray;
             separator2View.Tag = (int)TagType.SEPARATOR2_TAG;
-            view.AddSubview (separator2View);
+            headerView.AddSubview (separator2View);
 
             yOffset += 1;
 
-            // Message body
-            bodyView = new BodyView (new RectangleF (
-                BodyView.BODYVIEW_INSET, yOffset,
-                view.Frame.Width - 2 * BodyView.BODYVIEW_INSET, view.Frame.Height - BodyView.BODYVIEW_INSET),
-                view);
-            bodyView.VerticalScrollingEnabled = false;
-            bodyView.HorizontalScrollingEnabled = false;
-            bodyView.SpinnerCenteredOnParentFrame = true;
-            bodyView.OnRenderStart = BodyViewOnRenderStart;
-            bodyView.OnRenderComplete = BodyViewOnRenderComplete;
-            view.AddSubview (bodyView);
-
-            // Spinner
-            var spinner = new UIActivityIndicatorView (UIActivityIndicatorViewStyle.Gray);
-            spinner.Center = View.Center;
-            spinner.HidesWhenStopped = true;
-            spinner.Tag = (int)TagType.SPINNER_TAG;
-            view.AddSubview (spinner);
+            // Message body, which is added to the scroll view, not the header view.
+            bodyView = BodyView.VariableHeightBodyView (new PointF (VIEW_INSET, yOffset), scrollView.Frame.Width - 2 * VIEW_INSET, scrollView.Frame.Size, LayoutView);
+            scrollView.AddSubview (bodyView);
 
             blockMenu = new UIBlockMenu (this, new List<UIBlockMenu.Block> () {
                 new UIBlockMenu.Block ("contact-quickemail", "Quick Reply", () => {
@@ -333,8 +317,8 @@ namespace NachoClient.iOS
             var message = thread.SingleMessageSpecialCase ();
             attachments = McAttachment.QueryByItemId (message);
 
-            var userImageView = view.ViewWithTag ((int)TagType.USER_IMAGE_TAG) as UIImageView;
-            var userLabelView = view.ViewWithTag ((int)TagType.USER_LABEL_TAG) as UILabel;
+            var userImageView = headerView.ViewWithTag ((int)TagType.USER_IMAGE_TAG) as UIImageView;
+            var userLabelView = headerView.ViewWithTag ((int)TagType.USER_LABEL_TAG) as UILabel;
             var userImage = Util.ImageOfSender (message.AccountId, Pretty.EmailString (message.From));
             if (null != userImage) {
                 userImageView.Hidden = false;
@@ -352,7 +336,7 @@ namespace NachoClient.iOS
 
             attachmentListView.Hidden = !HasAttachments;
 
-            var cursor = new VerticalLayoutCursor (view);
+            var cursor = new VerticalLayoutCursor (headerView);
             cursor.AddSpace (35); // for From and top inset
 
             var subjectLabelView = View.ViewWithTag ((int)TagType.SUBJECT_TAG) as UILabel;
@@ -364,7 +348,7 @@ namespace NachoClient.iOS
             cursor.LayoutView (subjectLabelView);
 
             var receivedLabelView = View.ViewWithTag ((int)TagType.RECEIVED_DATE_TAG) as UILabel;
-            receivedLabelView.Text = Pretty.FullDateString (message.DateReceived);
+            receivedLabelView.Text = Pretty.FullDateTimeString (message.DateReceived);
             cursor.LayoutView (receivedLabelView);
 
             // Reminder image view and label
@@ -402,8 +386,11 @@ namespace NachoClient.iOS
 
             expandedSeparatorYOffset = cursor.TotalHeight;
 
+            var blankView = View.ViewWithTag ((int)TagType.BLANK_VIEW_TAG);
+            ViewFramer.Create (blankView).Y (separator1YOffset).Height (expandedSeparatorYOffset - compactSeparatorYOffset);
+
             var separator1View = View.ViewWithTag ((int)TagType.SEPARATOR1_TAG);
-            separator1View.Frame = new RectangleF (0, compactSeparatorYOffset, view.Frame.Width, 1);
+            separator1View.Frame = new RectangleF (0, compactSeparatorYOffset, headerView.Frame.Width, 1);
 
             var chiliImageView = View.ViewWithTag ((int)TagType.USER_CHILI_TAG) as UIImageView;
             float chiliX;
@@ -422,18 +409,11 @@ namespace NachoClient.iOS
             fromLabelView.Text = Pretty.SenderString (message.From);
             fromLabelView.Font = (message.IsRead ? A.Font_AvenirNextDemiBold17 : A.Font_AvenirNextRegular17);
 
-            deferLayout = new RecursionCounter (() => {
-                LayoutView ();
-            });
-            deferLayout.Increment ();
-
             ConfigureAttachments ();
 
-            if (bodyView.Configure (message)) {
-                MarkAsRead ();
-            }
+            bodyView.Configure (message);
 
-            deferLayout.Decrement ();
+            LayoutView ();
         }
 
         protected override void Cleanup ()
@@ -441,7 +421,7 @@ namespace NachoClient.iOS
             // Remove all callbacks and handlers.
             singleTapGesture.RemoveTarget (singleTapGestureHandlerToken);
             singleTapGesture.ShouldRecognizeSimultaneously = null;
-            view.RemoveGestureRecognizer (singleTapGesture);
+            headerView.RemoveGestureRecognizer (singleTapGesture);
             scrollView.Scrolled -= ScrollViewScrolled;
             quickReplyButton.Clicked -= QuickReplyButtonClicked;
             blockMenuButton.Clicked -= BlockMenuButtonClicked;
@@ -449,7 +429,6 @@ namespace NachoClient.iOS
             archiveButton.Clicked -= ArchiveButtonClicked;
             deleteButton.Clicked -= DeleteButtonClicked;
             deadlineButton.Clicked -= DeadlineButtonClicked;
-            scrollView.DidZoom -= ScrollViewDidZoom;
             NcApplication.Instance.StatusIndEvent -= StatusIndicatorCallback;
 
             blockMenu.Cleanup ();
@@ -465,7 +444,7 @@ namespace NachoClient.iOS
             scrollView = null;
             blockMenu = null;
 
-            view = null;
+            headerView = null;
             attachmentListView = null;
             toView = null;
             ccView = null;
@@ -487,34 +466,23 @@ namespace NachoClient.iOS
 
         protected void LayoutView ()
         {
-            var separator1View = view.ViewWithTag ((int)TagType.SEPARATOR1_TAG);
+            var separator1View = headerView.ViewWithTag ((int)TagType.SEPARATOR1_TAG);
             ViewFramer.Create (separator1View).Y (separator1YOffset);
-            var separator2View = view.ViewWithTag ((int)TagType.SEPARATOR2_TAG);
+            var separator2View = headerView.ViewWithTag ((int)TagType.SEPARATOR2_TAG);
             ViewFramer.Create (separator2View).Y (separator2YOffset);
+            var blankView = headerView.ViewWithTag ((int)TagType.BLANK_VIEW_TAG);
+            ViewFramer.Create (blankView).Y (separator1YOffset);
 
             ViewFramer.Create (attachmentListView).Y (separator1YOffset + 1.0f);
 
-            // When setting the upper left corner, account for the X content offset
-            // in "view", and the Y content offset in "bodyView".
+            ViewFramer.Create(bodyView).Y(separator2YOffset + 1);
+            scrollView.ContentSize = new SizeF (Math.Max (headerView.Frame.Width, bodyView.Frame.Width) + 2 * VIEW_INSET, bodyView.Frame.Bottom);
 
-            float bodyHeight = View.Frame.Height;
-            bodyHeight -= 2 * BodyView.BODYVIEW_INSET;
-            bodyHeight -= separator2View.Frame.Bottom;
-            bodyHeight -= attachmentListView.Frame.Height;
-            float bodyY = Math.Max (scrollView.ContentOffset.Y, separator2YOffset + 1);
-            bodyView.Layout (VIEW_INSET, bodyY, view.Frame.Width - 2 * BodyView.BODYVIEW_INSET, bodyHeight);
-
-            float viewWidth = scrollView.Frame.Width - 2 * VIEW_INSET;
-            float viewHeight = separator2YOffset;
-            viewHeight += bodyView.Frame.Height;
-            viewHeight += 2 * VIEW_INSET;
-            viewHeight = Math.Max (viewHeight, scrollView.Frame.Height);
-            view.Frame = new RectangleF (
-                VIEW_INSET + scrollView.ContentOffset.X, VIEW_INSET,
-                viewWidth, viewHeight);
-            scrollView.ContentSize = new SizeF (
-                Math.Max (view.Frame.Width, bodyView.ContentSize.Width + 12.0f),
-                separator2YOffset + bodyView.ContentSize.Height);
+            // MarkAsRead() will change the message from unread to read only if the body has been
+            // completely downloaded, so it is safe to call it unconditionally.  We put the call
+            // here, rather than in ConfigureAndLayout(), to handle the case where the body is
+            // downloaded long after the message view has been opened.
+            MarkAsRead ();
 
             #if (DEBUG_UI)
             ViewHelper.DumpViews<TagType> (scrollView);
@@ -778,28 +746,20 @@ namespace NachoClient.iOS
 
         private void ScrollViewScrolled (object sender, EventArgs e)
         {
+            // When scrolling horizontally, keep the header on screen.
+            ViewFramer.Create (headerView).X (scrollView.ContentOffset.X + VIEW_INSET);
 
-            // Process vertical scrolling
-            PointF bodyViewOffset = new PointF (scrollView.ContentOffset.X, scrollView.ContentOffset.Y);
-            bodyViewOffset.Y -= separator2YOffset;
-            ViewFramer framer = ViewFramer.Create (bodyView);
-            if (0 < bodyViewOffset.Y) {
-                framer.Y (1.0f + separator2YOffset + bodyViewOffset.Y);
-            } else {
-                framer.Y (1.0f + separator2YOffset);
-            }
-            bodyView.ScrollTo (bodyViewOffset);
-
-            // Process horizontal scrolling
-            framer = ViewFramer.Create (view);
-            framer.X (scrollView.ContentOffset.X);
+            // Let the body view do its magic to keep the right stuff visible.
+            // Adjust the offsets from scrollView's coordinates to bodyView's coordinates.
+            bodyView.ScrollingAdjustment (new PointF (
+                scrollView.ContentOffset.X - bodyView.Frame.X, scrollView.ContentOffset.Y - bodyView.Frame.Y));
         }
 
         private void HeaderSingleTapHandler (NSObject sender)
         {
             var gesture = sender as UIGestureRecognizer;
             if (null != gesture) {
-                PointF touch = gesture.LocationInView (view);
+                PointF touch = gesture.LocationInView (headerView);
                 if (touch.Y <= separator1YOffset) {
                     expandedHeader = !expandedHeader;
                     LayoutView (true);
@@ -841,11 +801,6 @@ namespace NachoClient.iOS
             ShowDeadlineActionSheet ();
         }
 
-        private void ScrollViewDidZoom (object sender, EventArgs e)
-        {
-            Log.Info (Log.LOG_UI, "vertical scrollview did zoom");
-        }
-
         private bool SingleTapGestureRecognizer (UIGestureRecognizer a, UIGestureRecognizer b)
         {
             return true;
@@ -865,16 +820,6 @@ namespace NachoClient.iOS
             LayoutView (true);
         }
 
-        private void BodyViewOnRenderStart ()
-        {
-            deferLayout.Increment ();
-        }
-
-        private void BodyViewOnRenderComplete ()
-        {
-            deferLayout.Decrement ();
-        }
-
         private void StatusIndicatorCallback (object sender, EventArgs e)
         {
             var statusEvent = (StatusIndEventArgs)e;
@@ -882,21 +827,6 @@ namespace NachoClient.iOS
                 FetchAttachments ();
                 ConfigureAttachments ();
                 return;
-            }
-            if (NcResult.SubKindEnum.Info_EmailMessageBodyDownloadSucceeded == statusEvent.Status.SubKind) {
-                var token = statusEvent.Tokens.FirstOrDefault ();
-                Log.Info (Log.LOG_EMAIL, "EmailMessageBodyDownloadSucceeded {0}", token);
-                if (bodyView.DownloadComplete (true, token)) {
-                    ConfigureAndLayout ();
-                    MarkAsRead ();
-                }
-            }
-            if (NcResult.SubKindEnum.Error_EmailMessageBodyDownloadFailed == statusEvent.Status.SubKind) {
-                var token = statusEvent.Tokens.FirstOrDefault ();
-                Log.Info (Log.LOG_EMAIL, "EmailMessageBodyDownloadFailed {0}", token);
-                if (bodyView.DownloadComplete (false, token)) {
-                    ConfigureAndLayout ();
-                }
             }
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -230,16 +230,6 @@ namespace NachoClient.iOS
             if (NcResult.SubKindEnum.Info_EmailMessageScoreUpdated == s.Status.SubKind) {
                 RefreshPriorityInboxIfVisible ();
             }
-            if (NcResult.SubKindEnum.Info_EmailMessageBodyDownloadSucceeded == s.Status.SubKind) {
-                var token = s.Tokens.FirstOrDefault ();
-                Log.Info (Log.LOG_UI, "NachoNowViewController: mailMessageBodyDownloadSucceeded {0}", token.ToString ());
-                ProcessDownloadComplete (true, token);
-            }
-            if (NcResult.SubKindEnum.Error_EmailMessageBodyDownloadFailed == s.Status.SubKind) {
-                var token = s.Tokens.FirstOrDefault ();
-                Log.Error (Log.LOG_UI, "NachoNowViewController: mailMessageBodyDownloadFailed {0}", token.ToString ());
-                ProcessDownloadComplete (false, token);
-            }
         }
 
         protected void RefreshPriorityInboxIfVisible ()
@@ -276,33 +266,6 @@ namespace NachoClient.iOS
                 calendarNeedsRefresh = false;
                 calendarSource.Refresh ();
                 calendarTableView.ReloadData ();
-            }
-        }
-
-        private void ProcessDownloadComplete (bool succeed, string token)
-        {
-            var visibleIndices = carouselView.IndexesForVisibleItems;
-            foreach (NSNumber nsIndex in visibleIndices) {
-                int index = nsIndex.IntValue;
-                // Ignore placeholders
-                if ((0 > index) || (carouselView.NumberOfItems <= index)) {
-                    continue;
-                }
-                var currentView = carouselView.ItemViewAtIndex (index);
-                if (null == currentView) {
-                    continue;
-                }
-                if (HotListCarouselDataSource.PLACEHOLDER_TAG == currentView.Tag) {
-                    continue;
-                }
-                var bodyView = (BodyView)currentView.ViewWithTag (HotListCarouselDataSource.PREVIEW_TAG);
-                NcAssert.True (null != bodyView);
-                // To avoid unnecessary reload, we only reload if the current item was downloading
-                // and the body is now completely downloaded.
-                if (!bodyView.DownloadComplete (succeed, token)) {
-                    continue;
-                }
-                carouselView.ReloadItemAtIndex (index, true);
             }
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyImageView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyImageView.cs
@@ -12,51 +12,35 @@ namespace NachoClient.iOS
 {
     public class BodyImageView : UIImageView, IBodyRender
     {
-        protected SizeF _contentSize;
+        public BodyImageView (float Y, float preferredWidth, UIImage image)
+            : base (new RectangleF(0, Y, preferredWidth, 1))
+        {
+            if (image.Size.Width > preferredWidth) {
+                // Shrink the image so it fits in the given width
+                float newHeight = image.Size.Height * (preferredWidth / image.Size.Width);
+                Image = image.Scale (new SizeF (preferredWidth, newHeight));
+            } else {
+                Image = image;
+            }
+            ViewFramer.Create (this).Width (Image.Size.Width).Height (Image.Size.Height);
+        }
+
+        public UIView uiView ()
+        {
+            return this;
+        }
+
         public SizeF ContentSize {
             get {
-                return _contentSize;
+                return Image.Size;
             }
         }
 
-        public BodyImageView (IntPtr ptr) : base (ptr)
+        public void ScrollingAdjustment (RectangleF frame, PointF contentOffset)
         {
-        }
-
-        public BodyImageView (RectangleF frame) : base (frame)
-        {
-            ViewHelper.SetDebugBorder (this, UIColor.Orange);
-
-            Tag = (int)BodyView.TagType.MESSAGE_PART_TAG;
-        }
-
-        public void Configure (MimePart part)
-        {
-            using (var image = PlatformHelpers.RenderImage (part)) {
-
-                if (null == image) {
-                    Log.Error (Log.LOG_UI, "Unable to render {0}", part.ContentType);
-                    // TODO - maybe put a bad image icon here?
-                    return;
-                }
-
-                float width = Frame.Width;
-                float height = image.Size.Height * (width / image.Size.Width);
-                Image = image.Scale (new SizeF (width, height));
-
-                _contentSize = new SizeF (width, height);
-            }
-        }
-
-        public void ScrollTo (PointF upperLeft)
-        {
-            // Image view is not scrollable
-        }
-
-        public string LayoutInfo ()
-        {
-            return String.Format ("BodyImageView: offset=({0},{1})  frame=({2},{3})  content=({4},{5})",
-                Frame.X, Frame.Y, Frame.Width, Frame.Height, ContentSize.Width, ContentSize.Height);
+            // Image does not scroll or resize.
+            // The only thing that can be adjusted is the view's origin.
+            ViewFramer.Create (this).X (frame.X - contentOffset.X).Y (frame.Y - contentOffset.Y);
         }
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -10,128 +10,76 @@ namespace NachoClient.iOS
 {
     public class BodyWebView : UIWebView, IBodyRender
     {
-        public delegate void RenderStart ();
-        public delegate void RenderComplete (float minZoomScale);
+        private float preferredWidth;
+        private Action sizeChangedCallback;
 
-        const string magic = @"
+        private const string magic = @"
             var style = document.createElement(""style""); 
             document.head.appendChild(style); 
-            style.innerHTML = ""html{-webkit-text-size-adjust: auto; word-wrap: break-word;}"";
+            style.innerHTML = ""html{{-webkit-text-size-adjust: auto; word-wrap: break-word;}}"";
             var viewPortTag=document.createElement('meta');
             viewPortTag.id=""viewport"";
             viewPortTag.name = ""viewport"";
-            viewPortTag.content = ""width=device-width; initial-scale=1.0;"";
+            viewPortTag.content = ""width={0}; initial-scale=1.0;"";
             document.getElementsByTagName('head')[0].appendChild(viewPortTag);
         ";
+        private const string dispableJavaScript = "<meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'none'\">";
+        private const string wrapPre = "<style>pre { white-space: pre-wrap;}</style>";
 
-        protected BodyRenderZoomRecognizer zoomRecognizer;
-        protected RecursionCounter htmlBusy;
-        public RenderStart OnRenderStart;
-        public RenderComplete OnRenderComplete;
-
-        public SizeF ContentSize {
-            get {
-                return ViewHelper.ScaleSizeF (ScrollView.ZoomScale, ScrollView.ContentSize);
-            }
-            protected set {
-                ScrollView.ContentSize = value;
-            }
-        }
-
-        public BodyWebView (IntPtr ptr) : base (ptr)
+        public BodyWebView (float Y, float preferredWidth, Action sizeChangedCallback, string html, NSUrl baseUrl)
+            : base (new RectangleF(0, Y, preferredWidth, 1))
         {
-        }
-
-        public BodyWebView (UIView parentView, float leftMargin) : base ()
-        {
-            ViewHelper.SetDebugBorder (this, UIColor.Red);
-
-            zoomRecognizer = new BodyRenderZoomRecognizer (ScrollView);
-            zoomRecognizer.OnTap = () => {
-                if ((null != OnRenderStart) && (null != OnRenderComplete)) {
-                    OnRenderStart ();
-                    OnRenderComplete (1.0f);
-                }
-            };
-            AddGestureRecognizer (zoomRecognizer);
-
-            ViewFramer.Create (this)
-                .X (0)
-                .Y (0);
-
-            htmlBusy = new RecursionCounter (() => {
-                EvaluateJavascript (magic);
-
-                zoomRecognizer.Configure ();
-
-                ViewFramer.Create (this)
-                    .Size (parentView.Frame.Size);
-
-                // If the content is wider than the frame, try to scale it down
-                OnRenderComplete (1.0f);
-            });
+            this.preferredWidth = preferredWidth;
+            this.sizeChangedCallback = sizeChangedCallback;
 
             ScrollView.ScrollEnabled = false;
-            ScrollView.MinimumZoomScale = 0.5f;
-            ScrollView.MaximumZoomScale = 4.0f;
-            ScrollView.Bounces = false;
-            ScrollView.MultipleTouchEnabled = false;
-            ContentMode = UIViewContentMode.TopLeft;
-            ScalesPageToFit = true;
-            BackgroundColor = UIColor.White;
-            Tag = (int)BodyView.TagType.MESSAGE_PART_TAG;
-
-            LoadStarted += OnLoadStarted;
             LoadFinished += OnLoadFinished;
-            LoadError += OnLoadError;
             ShouldStartLoad += OnShouldStartLoad;
-            ScrollView.PinchGestureRecognizer.AddTarget (OnZoomChanged);
 
-            // Disable all UIWebView double tap recognizers
-            foreach (var gr in ScrollView.Subviews[0].GestureRecognizers) {
-                var tapGr = gr as UITapGestureRecognizer;
-                if (null == tapGr) {
-                    continue;
-                }
-                if ((2 != tapGr.NumberOfTapsRequired) || (1 != tapGr.NumberOfTouchesRequired)) {
-                    continue;
-                }
-                tapGr.Enabled = false;
-            }
+            LoadHtmlString (dispableJavaScript + wrapPre + html, baseUrl);
         }
 
         protected override void Dispose (bool disposing)
         {
-            if (IsLoading) {
-                StopLoading ();
-            }
-            zoomRecognizer.Cleanup ();
-            RemoveGestureRecognizer (zoomRecognizer);
+            StopLoading ();
+            LoadFinished -= OnLoadFinished;
+            ShouldStartLoad -= OnShouldStartLoad;
             base.Dispose (disposing);
         }
 
-        private void OnLoadStarted (object sender, EventArgs e)
+        public UIView uiView ()
         {
-            htmlBusy.Increment ();
+            return this;
+        }
+
+        public SizeF ContentSize {
+            get {
+                return ScrollView.ContentSize;
+            }
+        }
+
+        public void ScrollingAdjustment (RectangleF frame, PointF contentOffset)
+        {
+            if (frame.Width < preferredWidth) {
+                // Changing the width of the UIWebView will change the layout.
+                // Making the width more narrow can have disastrous effects.
+                float expandWidthBy = preferredWidth - frame.Width;
+                frame.X -= expandWidthBy;
+                contentOffset.X -= expandWidthBy;
+                frame.Width += expandWidthBy;
+            }
+            this.Frame = frame;
+            this.ScrollView.ContentOffset = contentOffset;
         }
 
         private void OnLoadFinished (object sender, EventArgs e)
         {
-            htmlBusy.Decrement ();
-        }
-
-        private void OnLoadError (object sender, UIWebErrorArgs e)
-        {
-            OnRenderComplete (0.0f);
-            Log.Error(Log.LOG_UI, "BodyWebView LoadError: {0}", e.Error);
-        }
-
-        private void OnZoomChanged ()
-        {
-            if ((null != OnRenderStart) && (null != OnRenderComplete)) {
-                ScrollView.SetZoomScale (ScrollView.PinchGestureRecognizer.Scale, false);
-                OnRenderStart ();
-                OnRenderComplete (1.0f);
+            EvaluateJavascript (string.Format(magic, preferredWidth));
+            // Force a re-layout of this web view now that the JavaScript magic has been applied.
+            ViewFramer.Create (this).Height (2);
+            // And force a re-layout of the entire BodyView now that the size of this web view is known.
+            if (null != sizeChangedCallback) {
+                sizeChangedCallback ();
             }
         }
 
@@ -143,39 +91,6 @@ namespace NachoClient.iOS
                 return false;
             }
             return true;
-        }
-
-        public override void SizeToFit ()
-        {
-            // Intentionally disable SizeToFit(). By allowing the base class SizeToFit() to
-            // take effect, it will create a UIWebView with its frame equal to the content size
-            // for large HTML email, it will consume a lot of memory. And ViewHelper.LayoutCursor
-            // always call SizeToFit(). So, we need to disable it.
-        }
-
-        public void LoadHtmlContent (string html, NSUrl baseUrl)
-        {
-            NcAssert.True ((null != OnRenderStart) && (null != OnRenderComplete));
-
-            htmlBusy.Reset ();
-            OnRenderStart ();
-
-            // Some CSS / CSP have to be added before render in order to be effective.
-            string disable_js = "<meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'none'\">";
-            string wrap_pre = "<style>pre { white-space: pre-wrap;}</style>";
-            html = disable_js + wrap_pre + html;
-            LoadHtmlString (html, baseUrl);
-        }
-
-        public void ScrollTo (PointF upperLeft)
-        {
-            ScrollView.SetContentOffset (upperLeft, false);
-        }
-
-        public string LayoutInfo ()
-        {
-            return String.Format ("BodyWebView: offset={0}  frame={1}  content={2}",
-                Pretty.PointF (Frame.Location), Pretty.SizeF (Frame.Size), Pretty.SizeF (ContentSize));
         }
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListCarouselDataSource.cs
@@ -70,8 +70,6 @@ namespace NachoClient.iOS
             } else {
                 // Make sure we're getting an item view
                 NcAssert.True (PLACEHOLDER_TAG != view.Tag);
-                var previewView = view.ViewWithTag (PREVIEW_TAG) as BodyView;
-                previewView.Initialize ();
             }
             ConfigureView (view, (int)index);
             return view;
@@ -168,8 +166,6 @@ namespace NachoClient.iOS
             messageHeaderView.SetAllBackgroundColors (UIColor.White);
             view.AddSubview (messageHeaderView);
 
-            var bottomY = frame.Height - 44; // toolbar height is 44
-
             // Reminder image view
             var reminderImageView = new UIImageView (new RectangleF (65, 75 + 4, 12, 12));
             reminderImageView.Image = UIImage.FromBundle ("inbox-icn-deadline");
@@ -185,9 +181,8 @@ namespace NachoClient.iOS
 
             // Preview label view
             // Size fields will be recalculated after text is known
-            var previewLabelView = new BodyView (new RectangleF (12, 70, viewWidth - 15 - 12, bottomY - 60), view);
+            var previewLabelView = BodyView.FixedSizeBodyView (new RectangleF (12, 70, viewWidth - 15 - 12, view.Frame.Height - 128));
             previewLabelView.Tag = PREVIEW_TAG;
-            previewLabelView.UserInteractionEnabled = false;
             view.AddSubview (previewLabelView);
 
             var toolbar = new MessageToolbar (new RectangleF (0, frame.Height - 44, frame.Width, 44));
@@ -383,16 +378,13 @@ namespace NachoClient.iOS
             }
 
             // Size of preview, depends on reminder view
-            var previewView = view.ViewWithTag (PREVIEW_TAG) as BodyView;
-            previewView.Hidden = false;
-
             var previewViewHeight = view.Frame.Height - 80 - previewViewAdjustment;
             previewViewHeight -= 44; // toolbar
             previewViewHeight -= 4; // padding
 
+            var previewView = view.ViewWithTag (PREVIEW_TAG) as BodyView;
             previewView.Configure (message);
-            ViewFramer.Create (previewView).Height (previewViewHeight);
-            previewView.Layout (previewView.Frame.X, previewView.Frame.Y + previewViewAdjustment, previewView.Frame.Width, previewViewHeight);
+            previewView.Resize (new RectangleF (12, 70 + previewViewAdjustment, previewView.Frame.Width, previewViewHeight));
         }
 
         public override uint NumberOfPlaceholdersInCarousel (iCarousel carousel)
@@ -509,7 +501,7 @@ namespace NachoClient.iOS
             if (null == previewLabelView) {
                 return;
             }
-            previewLabelView.Focus ();
+            previewLabelView.PrioritizeBodyDownload ();
         }
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/Support/IBodyRender.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/IBodyRender.cs
@@ -7,86 +7,12 @@ using MonoTouch.UIKit;
 
 namespace NachoClient.iOS
 {
-    // A BodyView consists of a list of render views arranged vertically.
-    // Each type of body render view must implement this interface
     public interface IBodyRender
     {
+        UIView uiView ();
+
         SizeF ContentSize { get; }
 
-        void ScrollTo (PointF upperLeftCorner);
-
-        string LayoutInfo ();
-    }
-
-    public class BodyRenderZoomRecognizer : UITapGestureRecognizer
-    {
-        private const float ZOOM_OUT_MARGIN = 3.0f;
-
-        private UIScrollView scrollView;
-
-        private bool zoomIn;
-
-        public float ZoomInScale { get; protected set; }
-
-        public float ZoomOutScale { get; protected set; }
-
-        public Action OnTap;
-
-        private UIGestureRecognizer.Token onTappedToken;
-
-        public BodyRenderZoomRecognizer (UIScrollView view) : base ()
-        {
-            zoomIn = true;
-            scrollView = view;
-            NumberOfTapsRequired = 2;
-            NumberOfTouchesRequired = 1;
-            ShouldRecognizeSimultaneously =
-                (UIGestureRecognizer gestureRecognizer, UIGestureRecognizer otherGestureRecognizer) => {
-                return true;
-            };
-            onTappedToken = AddTarget (onTapped);
-        }
-
-        public void Configure ()
-        {
-            // Try to set min zoom scale to the value that will fit the content to
-            // the width of the screen. But set a lower limit so that we don't shrink
-            // content to such small scale that nothing is readable anymore.
-            ZoomInScale = scrollView.Frame.Width / (scrollView.ContentSize.Width + (2 * ZOOM_OUT_MARGIN));
-            // Min zoom scale must be between 0.7 and 1.0
-            ZoomInScale = Math.Min (1.0f, ZoomInScale);
-            ZoomInScale = Math.Max (0.7f, ZoomInScale);
-
-            ZoomOutScale = 2.0f * ZoomInScale;
-        }
-
-        public void Cleanup ()
-        {
-            RemoveTarget (onTappedToken);
-        }
-
-        private void onTapped ()
-        {
-            if (null == scrollView) {
-                return;
-            }
-            scrollView.ContentOffset = new PointF ();
-            if (zoomIn) {
-                UIView.Animate (0.1f, 0.0f, UIViewAnimationOptions.CurveLinear, () => {
-                    scrollView.SetZoomScale (ZoomOutScale, false);
-                }, () => {
-                });
-            } else {
-                UIView.Animate (0.1f, 0.0f, UIViewAnimationOptions.CurveLinear, () => {
-                    scrollView.SetZoomScale (ZoomInScale, false);
-                }, () => {
-                });
-            }
-            zoomIn = !zoomIn;
-            if (null != OnTap) {
-                OnTap ();
-            }
-        }
+        void ScrollingAdjustment (RectangleF frame, PointF contentOffset);
     }
 }
-

--- a/NachoClient.iOS/NachoUI.iOS/Support/PlatformHelpers.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/PlatformHelpers.cs
@@ -36,19 +36,11 @@ namespace NachoClient
             var index = cid.Substring (2).IndexOf ('/');
             var value = cid.Substring (index + 3);
             var bodyId = Convert.ToInt32 (cid.Substring (2, index));
-            MimePart p = PlatformHelpers.SearchParts (value, cidPartDict);
-            if (null == p) {
-                // Can't find it in the cid dictionary, search the attachment parts in the body
-                McBody body = McBody.QueryById<McBody> (bodyId);
-                if (null != body) {
-                    var mime = MimeHelpers.LoadMessage (body);
-                    foreach (var part in MimeHelpers.AllAttachments(mime)) {
-                        if (value == part.ContentId) {
-                            p = (MimePart)part;
-                            break;
-                        }
-                    }
-                }
+            McBody body = McBody.QueryById<McBody> (bodyId);
+            MimePart p = null;
+            if (null != body) {
+                var mime = MimeHelpers.LoadMessage (body);
+                p = MimeHelpers.EntityWithContentId (mime, value);
             }
             if (null == p) {
                 Log.Error (Log.LOG_UTILS, "RenderContentId: MimeEntity is null: {0}", value);
@@ -61,21 +53,6 @@ namespace NachoClient
                 return RenderStringToImage (value);
             }
             return image;
-        }
-
-        static public void AddCidPartToDict (string cid, MimePart part)
-        {
-            cidPartDict [cid] = part;
-        }
-
-        static public MimePart SearchParts (string cid, Dictionary<string,MimePart> partsDict)
-        {
-            MimePart part;
-            if (partsDict.TryGetValue (cid, out part)) {
-                return part;
-            } else {
-                return null;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
Overhaul BodyView and its related classes. Simplify the design. The
trick of displaying at most one screen worth of a potentially large
view is preserved. The way that downloads of message bodies are
tracked has changed, so that all the tracking happens in BodyView.

Zooming of message bodies is disabled because I couldn't get it
working right. It will be dealt with later.

Fix #421
Fix #234
