### PR TITLE
Fix XML for event body types so they aren't rejected by the server.

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -173,7 +173,7 @@ namespace NachoCore.ActiveSync
                 var body = McBody.QueryById<McBody> (cal.BodyId);
                 NcAssert.True (null != body);
                 xmlAppData.Add (new XElement (AirSyncBaseNs + Xml.AirSyncBase.Body,
-                    new XElement (AirSyncBaseNs + Xml.AirSyncBase.Type, body.BodyType),
+                    new XElement (AirSyncBaseNs + Xml.AirSyncBase.Type, (uint)body.BodyType),
                     new XElement (AirSyncBaseNs + Xml.AirSyncBase.Data, body.GetContentsString ())));
             }
 


### PR DESCRIPTION
A recent change to how we keep track of body types resulted in sending
the enum symbol in the XML rather than its value.  For example, this
XML was being rejected by the server:
            (Body xmlns="AirSyncBase")
              (Type)PlainText_1(/Type)
              (Data /)
            (/Body)
This change restores the old behavior of sending:
            (Body xmlns="AirSyncBase")
              (Type)1(/Type)
              (Data /)
            (/Body)

Fix #712
