### PR TITLE
Make web views appear to load faster.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -448,7 +448,7 @@ namespace NachoClient.iOS
         private void RenderHtmlString (string html)
         {
             var webView = new BodyWebView (
-                yOffset, Frame.Width, LayoutAndNotifyParent,
+                yOffset, preferredWidth, visibleArea.Height, LayoutAndNotifyParent,
                 html, NSUrl.FromString (string.Format ("cid://{0}", item.BodyId)));
             AddSubview (webView);
             childViews.Add (webView);

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -26,8 +26,8 @@ namespace NachoClient.iOS
         private const string dispableJavaScript = "<meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'none'\">";
         private const string wrapPre = "<style>pre { white-space: pre-wrap;}</style>";
 
-        public BodyWebView (float Y, float preferredWidth, Action sizeChangedCallback, string html, NSUrl baseUrl)
-            : base (new RectangleF(0, Y, preferredWidth, 1))
+        public BodyWebView (float Y, float preferredWidth, float initialHeight, Action sizeChangedCallback, string html, NSUrl baseUrl)
+            : base (new RectangleF(0, Y, preferredWidth, initialHeight))
         {
             this.preferredWidth = preferredWidth;
             this.sizeChangedCallback = sizeChangedCallback;


### PR DESCRIPTION
Set the initial height of a BodyWebView to be one entire screen rather
than just one point.  This lets the use see the web content as it is
loading.  In the past, the web view remained just one point high (i.e.
completely invisible) until the web page had finished loading.  This
could cause very long delays for large messages before the user saw
anything interesting.  This change doesn't make the web view load any
faster, but it looks a lot faster to the user.

(The problem of loading slowly is not apparent on the simulator.  This
change was tested on an iPhone 4s device, where everything is slow.
The difference was dramatic.)

Fix #777 
