### PR TITLE
Enable zooming of BodyView.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -130,6 +130,10 @@ namespace NachoClient.iOS
             scrollView.BackgroundColor = UIColor.White;
             scrollView.KeyboardDismissMode = UIScrollViewKeyboardDismissMode.OnDrag;
             scrollView.Scrolled += ScrollViewScrolled;
+            scrollView.MinimumZoomScale = 0.2f;
+            scrollView.MaximumZoomScale = 5.0f;
+            scrollView.ZoomingEnded += ScrollViewZoomingEnded;
+            scrollView.ViewForZoomingInScrollView = ViewForZooming;
 
             contentView.BackgroundColor = UIColor.White;
 
@@ -567,6 +571,8 @@ namespace NachoClient.iOS
 
             // Remove event handlers
             scrollView.Scrolled -= ScrollViewScrolled;
+            scrollView.ZoomingEnded -= ScrollViewZoomingEnded;
+            scrollView.ViewForZoomingInScrollView = null;
             acceptButton.TouchUpInside -= AcceptButtonTouchUpInside;
             tentativeButton.TouchUpInside -= TentativeButtonTouchUpInside;
             declineButton.TouchUpInside -= DeclineButtonTouchUpInside;
@@ -1338,6 +1344,22 @@ namespace NachoClient.iOS
         private void ExtraAttendeesTouchUpInside (object sender, EventArgs e)
         {
             PerformSegue ("EventToEventAttendees", this);
+        }
+
+        private void ScrollViewZoomingEnded (object sender, EventArgs e)
+        {
+            // The body view needs to redo its layout to account for the new
+            // apparent screen size.
+            ScrollViewScrolled (null, null);
+            // iOS messes up the scroll view's ContentSize when zooming.
+            // Unfortunately, we have to re-layout the entire view to fix it.
+            LayoutView ();
+        }
+
+        private UIView ViewForZooming (UIScrollView sv)
+        {
+            // The description is the only thing that zooms.
+            return descriptionView;
         }
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/Support/ViewHelper.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/ViewHelper.cs
@@ -75,6 +75,32 @@ namespace NachoClient.iOS
             return InnerFrameWithInset (outerFrame, inset, InsetMode.BOTH, InsetMode.BOTH);
         }
 
+        public static bool IsZoomed (UIView view)
+        {
+            if (view.Transform.IsIdentity) {
+                return false;
+            }
+            var tx = view.Transform;
+            if (0 != tx.xy || 0 != tx.x0 || 0 != tx.yx || 0 != tx.y0) {
+                // A transformation other than zooming.
+                return false;
+            }
+            float ratio = tx.xx / tx.yy;
+            if (0.98f > ratio || 1.02f < ratio) {
+                // The x-scale and y-scale are not the same.
+                return false;
+            }
+            return true;
+        }
+
+        public static float ZoomScale (UIView view)
+        {
+            if (!IsZoomed (view)) {
+                return 1.0f;
+            }
+            return view.Transform.xx;
+        }
+
         private static string ViewInfo (UIView view, string tagName)
         {
             string result = view.GetType ().Name;
@@ -87,6 +113,9 @@ namespace NachoClient.iOS
                 var scroll = (UIScrollView)view;
                 result += string.Format (" Scrollable content: Offset {0} Size {1} ZoomScale {2}",
                     Pretty.PointF (scroll.ContentOffset), Pretty.SizeF (scroll.ContentSize), scroll.ZoomScale);
+            }
+            if (!view.Transform.IsIdentity) {
+                result += string.Format (" Transform {0}", view.Transform.ToString ());
             }
             return result;
         }


### PR DESCRIPTION
Make it possible to zoom a message body or event body.  Most of the
work happens in the view controller, because it owns the scroll view
where the zooming happens.  Class BodyView needed to be changed to be
aware of zooming because it has to adjust some of its dimensions by
the zoom scale factor.

Message view supports zooming by pinch gesture or by double tap.  When
using a pinch gesture to zoom out, sometimes only part of the body is
shown while the gesture is in progress, but the view fixes itself when
the gesture is complete.

Event view only supports pinch gestures, not double tapping.  The
layout is often messed up while the pinch gesture is in progress, but
it fixes itself when the gesture is complete.
