### PR TITLE
An interrupted download should not be a permanent error.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcResult.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcResult.cs
@@ -167,6 +167,7 @@ namespace NachoCore.Utils
             NoRecipient,
             ReplyNotAllowed,
             UnavoidableDelay,
+            InterruptedByAppExit,
         };
 
         public KindEnum Kind { get; set; }

--- a/NachoClient.iOS/NachoUI.iOS/Support/PlatformHelpers.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/PlatformHelpers.cs
@@ -146,6 +146,10 @@ namespace NachoClient
 
         public static string DownloadAttachment (McAttachment attachment)
         {
+            if (McAbstrFileDesc.FilePresenceEnum.Error == attachment.FilePresence) {
+                // Clear the error code so the download will be attempted again.
+                attachment.DeleteFile ();
+            }
             if (McAbstrFileDesc.FilePresenceEnum.None == attachment.FilePresence) {
                 return BackEnd.Instance.DnldAttCmd (attachment.AccountId, attachment.Id, true);
             } else if (McAbstrFileDesc.FilePresenceEnum.Partial == attachment.FilePresence) {


### PR DESCRIPTION
If the download of a body or an attachment was interrupted by the app
exiting, the command would be marked as failed and the McAbstrFileDesc
for the body or attachment would be set to the state of Error.
Failing the command is the correct thing to do, but setting the file
to Error was wrong, because the download command didn't really fail.

To fix this: Add a new reason to NcResult.WhyEnum:
InterruptedByAppExit.  When a command fails for this reason, set the
FilePresence of the McAbstrFileDesc to None rather than Error.
