### PR TITLE
Issue #793

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -84,12 +84,18 @@ namespace NachoCore.Brain
 
         public static void StopService ()
         {
-            NcBrain.SharedInstance.Enqueue (new NcBrainEvent (NcBrainEventType.TERMINATE));
+            NcBrain.SharedInstance.SignalTermination ();
         }
 
         public void Enqueue (NcBrainEvent brainEvent)
         {
             EventQueue.Enqueue (brainEvent);
+        }
+
+        public void SignalTermination ()
+        {
+            var brainEvent = new NcBrainEvent (NcBrainEventType.TERMINATE);
+            EventQueue.Undequeue (brainEvent);
         }
 
         public bool IsQueueEmpty ()


### PR DESCRIPTION
There are couple possibilities of why brain task does not exit in time:
1. Long db op. We need to find out why some db ops are taking a long time and fix in the db / model side.
2. The termination instruction is stuck behind other instructions / events in brain's queue. To fix this, we put the termination event at the head of the queue. Queue class doesn't support this operation. So, I implement it using List.
