### PR TITLE
UX 2.0: More tab

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/AccountSettingsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/AccountSettingsViewController.cs
@@ -763,6 +763,8 @@ namespace NachoClient.iOS
                 theServer.Update ();
                 theCred.Update ();
                 theConference.Update ();
+
+                NachoTabBarController.ReconfigureMoreTab ();
             }
         }
 


### PR DESCRIPTION
Change the "More" tab to (mostly) have the desired content and style.
The account information is now displayed at the top of the view, above
the table of other tabs. The table of other tabs now looks like a card
with margins and rounded corners. The color of the icons in the table
is now NachoGreen. The useless right arrow in each row of the table is
now hidden.

Work still to do: (1) Display the user's name in addition to the
account name and e-mail address. (2) Display the user's picture
instead of some initials. Both of these changes are waiting on some
other changes to the account information.
