### PR TITLE
Fix for #844

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -187,6 +187,14 @@ namespace NachoCore.Utils
                 var task = eventTable.PutItemAsync (eventItem);
                 task.Wait (NcTask.Cts.Token);
             }
+            catch (TaskCanceledException e) {
+                if (NcTask.Cts.Token.IsCancellationRequested) {
+                    throw;
+                }
+                // Otherwise, most likely HTTP client timeout
+                Console.WriteLine ("Task canceled exception {0}", e);
+                return false;
+            }
             catch (OperationCanceledException) {
                 // Since we are catching Exception below, we must catch and re-throw
                 // or this exception will be swallowed and telemetry task will not exit.
@@ -217,6 +225,14 @@ namespace NachoCore.Utils
             try {
                 var task = multiBatchWrite.ExecuteAsync (NcTask.Cts.Token);
                 task.Wait (NcTask.Cts.Token);
+            }
+            catch (TaskCanceledException e) {
+                if (NcTask.Cts.Token.IsCancellationRequested) {
+                    throw;
+                }
+                // Otherwise, most likely HTTP client timeout
+                Console.WriteLine ("Task canceled exception {0}", e);
+                return false;
             }
             catch (OperationCanceledException) {
                 // Since we are catching Exception below, we must catch and re-throw


### PR DESCRIPTION
When HTTP client times out, it throws a TaskCanceledException. But when a cancellation really occurs, the same exception is being thrown. TaskCanceledException is derived from OperationCanceledException which is caught and rethrown. So, when a HTTP client times out, TaskCanceledException is uncaught and the app crashes.

The fix is to catch TaskCanceledException and check if NcTask cancellation token requests cancellation. If not, treat it like a HTTP timeout by returning false from send functions. The telemetry loop will retry to send the event.
