### PR TITLE
Improve debugging for NcTask

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcTask.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcTask.cs
@@ -17,6 +17,21 @@ namespace NachoCore.Utils
 
         public static void StartService ()
         {
+            if (null != TaskMap) {
+                foreach (var pair in TaskMap) {
+                    try {
+                        var taskRef = pair.Key;
+                        if (!taskRef.IsAlive) {
+                            continue;
+                        }
+                        if (!((Task)taskRef.Target).IsCompleted) {
+                            Log.Error (Log.LOG_SYS, "Task {0} survives across shutdown", pair.Value);
+                        }
+                    } catch {
+                        // tasks may be going away as we iterate.
+                    }
+                }
+            }
             TaskMap = new ConcurrentDictionary<WeakReference, string> ();
             Cts = new CancellationTokenSource ();
         }
@@ -83,7 +98,7 @@ namespace NachoCore.Utils
                     var taskRef = pair.Key;
                     if (taskRef.IsAlive) {
                         if (!((Task)taskRef.Target).IsCompleted) {
-                            Log.Error (Log.LOG_SYS, "Task {0} still running", pair.Value);
+                            Log.Warn (Log.LOG_SYS, "Task {0} still running", pair.Value);
                         }
                         if (!((Task)taskRef.Target).IsCanceled) {
                             Log.Info (Log.LOG_SYS, "Task {0} cancelled", pair.Value);


### PR DESCRIPTION
In #793, we see these:

2014-11-05 02:36:45.572 ERROR message Task Brain57 still running
2014-11-05 02:36:45.575 INFO message Task Brain57 cancelled

2014-11-05 02:44:16.077 ERROR message Task Brain62 still running
2014-11-05 02:44:16.079 INFO message Task Brain62 cancelled

StopService() works as expected but there are false positives. So, we demote the check in StopService() to a warning and add a check in StartService() for any running task. (There should not be any.)
