### PR TITLE
Fix for #704. 

### DIFF
--- a/Test.Android/NcApplicationTest.cs
+++ b/Test.Android/NcApplicationTest.cs
@@ -48,9 +48,12 @@ namespace Test.Common
                 NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () { 
                     Status = NachoCore.Utils.NcResult.Info (NcResult.SubKindEnum.Info_BackgroundAbateStarted),
                     Account = ConstMcAccount.NotAccountSpecific,
+                    Tokens = new string[1] {
+                        DateTime.Now.ToString()
+                    }
                 });
             });
-            Assert.True (task.Wait (1000));
+            Assert.True (task.Wait (10 * 1000));
             while (!NcModel.Instance.RateLimiter.Enabled) {
                 ;
             }
@@ -82,9 +85,12 @@ namespace Test.Common
                 NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () { 
                     Status = NachoCore.Utils.NcResult.Info (NcResult.SubKindEnum.Info_BackgroundAbateStopped),
                     Account = ConstMcAccount.NotAccountSpecific,
+                    Tokens = new string[1] {
+                        DateTime.Now.ToString()
+                    }
                 });
             });
-            Assert.True (task.Wait (1000));
+            Assert.True (task.Wait (10 * 1000));
             while (NcModel.Instance.RateLimiter.Enabled) {
                 ;
             }


### PR DESCRIPTION
Fixes for two different tests:
- LogTest: Drain indirect queue messages before log tests. 
- NcApplicationTest: Provide a token for dummy event args to avoid an null object exception. Increase timeout to avoid false positive.
