### PR TITLE
Don't shut down back end after transition from PerformFetch to foregroun...

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ProtoControl.cs
@@ -71,6 +71,10 @@ namespace NachoCore
         {
         }
 
+        /// <summary>
+        /// QuickSync is obsolete, and is not used by AsProtoControl.  It will be
+        /// removed if the next protocol to be implemented doesn't need it either.
+        /// </summary>
         public virtual void QuickSync ()
         {
         }

--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -354,15 +354,15 @@ namespace NachoCore
             });
         }
 
-        public void QuickSync (uint seconds)
+        public void QuickSync ()
         {
             if (ExecutionContextEnum.QuickSync != ExecutionContext) {
                 ExecutionContext = ExecutionContextEnum.QuickSync;
             }
-            // Needs Class-3 Services up. Cause accounts to do a quick check for new messages.
-            // If start is called while wating for the QuickCheck, the system keeps going after the QuickCheck completes.
-            BackEnd.Instance.QuickSync (seconds);
+            // Class 3 services must have already been set up.
+            BackEnd.Instance.QuickSync ();
         }
+
         // method can be used to post to StatusIndEvent from outside NcApplication.
         public void InvokeStatusIndEvent (StatusIndEventArgs e)
         {


### PR DESCRIPTION
...d

Fix yet one more case of the spinner-of-death. If the app was brought
into the foreground while a PerformFetch operation was in progress,
then a timer was incorrectly left running. When the timer was fired,
it would shut down the back end. This would result in ActiveSync
commands being put on hold. The most obvious symptom of this is that
message body downloads would never finish, leaving the user to stare
at the spinner indefinitely.

The fix is to move the timer from class BackEnd to class AppDelegate,
and to change what the timer does when it fires.  There are also other
improvements in keeping track of the PerformFetch activity.

Fix #858
