### PR TITLE
2nd fix for #844

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading;
 
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DocumentModel;
@@ -106,8 +107,10 @@ namespace NachoCore.Utils
                         throw;
                     }
                     // Otherwise, most likely HTTP client timeout
+                    Thread.Sleep (5000);
                 } catch (AmazonServiceException e) {
                     Console.WriteLine ("AWS service exception {0}", e);
+                    Thread.Sleep (5000);
                 }
             }
         }


### PR DESCRIPTION
Add retry when getting Cognito ID and DynamoDB tables. When calling GetIdentityId() and LoadTable(), timeout and cancellation can happen. During those occasions, we need to catch TaskCanceledOperation and if there is no cancellation, treat it as a HTTP timeout and retry.
We also retry AmazonServiceException.

Some reformatting are included as I enabled reformat on save on Xamarin Studio.
