### PR TITLE
Fix for #872.

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -129,7 +129,8 @@ namespace NachoCore.Brain
         {
             // Look for a list of emails
             int numGleaned = 0;
-            while (numGleaned < count && !NcApplication.Instance.IsBackgroundAbateRequired) {
+            while (numGleaned < count && !NcApplication.Instance.IsBackgroundAbateRequired &&
+                   !EventQueue.Token.IsCancellationRequested) {
                 McEmailMessage emailMessage = McEmailMessage.QueryNeedGleaning ();
                 if (null == emailMessage) {
                     break;
@@ -145,7 +146,8 @@ namespace NachoCore.Brain
         private int AnalyzeEmailAddresses (int count)
         {
             int numAnalyzed = 0;
-            while (numAnalyzed < count && !NcApplication.Instance.IsBackgroundAbateRequired) {
+            while (numAnalyzed < count && !NcApplication.Instance.IsBackgroundAbateRequired &&
+                   !EventQueue.Token.IsCancellationRequested) {
                 McEmailAddress emailAddress = McEmailAddress.QueryNeedAnalysis ();
                 if (null == emailAddress) {
                     break;
@@ -161,7 +163,8 @@ namespace NachoCore.Brain
         private int AnalyzeEmails (int count)
         {
             int numAnalyzed = 0;
-            while (numAnalyzed < count && !NcApplication.Instance.IsBackgroundAbateRequired) {
+            while (numAnalyzed < count && !NcApplication.Instance.IsBackgroundAbateRequired &&
+                   !EventQueue.Token.IsCancellationRequested) {
                 McEmailMessage emailMessage = McEmailMessage.QueryNeedAnalysis ();
                 if (null == emailMessage) {
                     break;
@@ -177,7 +180,8 @@ namespace NachoCore.Brain
         private int UpdateEmailAddressScores (int count)
         {
             int numUpdated = 0;
-            while (numUpdated < count && !NcApplication.Instance.IsBackgroundAbateRequired) {
+            while (numUpdated < count && !NcApplication.Instance.IsBackgroundAbateRequired &&
+                   !EventQueue.Token.IsCancellationRequested) {
                 McEmailAddress emailAddress = McEmailAddress.QueryNeedUpdate ();
                 if (null == emailAddress) {
                     break;
@@ -197,7 +201,8 @@ namespace NachoCore.Brain
         private int UpdateEmailMessageScores (int count)
         {
             int numUpdated = 0;
-            while (numUpdated < count && !NcApplication.Instance.IsBackgroundAbateRequired) {
+            while (numUpdated < count && !NcApplication.Instance.IsBackgroundAbateRequired &&
+                   !EventQueue.Token.IsCancellationRequested) {
                 McEmailMessage emailMessage = McEmailMessage.QueryNeedUpdate ();
                 if (null == emailMessage) {
                     break;
@@ -224,6 +229,10 @@ namespace NachoCore.Brain
             List<McEmailMessage> emailMessages = McEmailMessage.QueryNeedsIndexing (count);
             Dictionary<int, Index.Index> indexes = new Dictionary<int, Index.Index> ();
             foreach (var emailMessage in emailMessages) {
+                if (EventQueue.Token.IsCancellationRequested) {
+                    break;
+                }
+
                 // If we don't have an index for this account, open one
                 Index.Index index;
                 if (!indexes.TryGetValue (emailMessage.AccountId, out index)) {


### PR DESCRIPTION
Add a lock to NcBrain object to prevent two tasks simultaneously process the event queue. Please see issue #872 for justification of this solution.
