### PR TITLE
Present the CredAsk VC from the Root View Controller

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -752,7 +752,7 @@ namespace NachoClient.iOS
             UIStoryboard x = UIStoryboard.FromName ("MainStoryboard_iPhone", null);
             CredentialsAskViewController cvc = (CredentialsAskViewController)x.InstantiateViewController ("CredentialsAskViewController");
             cvc.SetTabBarController (Util.GetActiveTabBar ());
-            this.Window.RootViewController.PresentedViewController.PresentViewController (cvc, true, null);
+            this.Window.RootViewController.PresentViewController (cvc, true, null);
         }
 
         /* BADGE & NOTIFICATION LOGIC HERE.


### PR DESCRIPTION
Fix #813.  <-- Should have included in the commit message, if this doesn't work I'll manually remove from Issues list. 

W/Steve's commit "Sometimes the root view controller is the Nacho tab bar", the app delegate just needs to display CredentialsAskVC from the RootViewController, not the RootViewController.PresentedViewController.
