### PR TITLE
Replace direct send of status ind with wrapper functions.

### DIFF
--- a/Test.Android/NcApplicationTest.cs
+++ b/Test.Android/NcApplicationTest.cs
@@ -45,13 +45,7 @@ namespace Test.Common
             Assert.True (task.Wait (3 * NcModel.Instance.RateLimiter.RefreshMsecs));
             // Put us in scrolling mode.
             task = Task.Run (() => {
-                NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () { 
-                    Status = NachoCore.Utils.NcResult.Info (NcResult.SubKindEnum.Info_BackgroundAbateStarted),
-                    Account = ConstMcAccount.NotAccountSpecific,
-                    Tokens = new string[1] {
-                        DateTime.Now.ToString()
-                    }
-                });
+                NcAbate.HighPriority("RateLimitBgDbWritesInScroll");
             });
             Assert.True (task.Wait (10 * 1000));
             while (!NcModel.Instance.RateLimiter.Enabled) {
@@ -82,13 +76,7 @@ namespace Test.Common
             Assert.True (task.Wait (10 * NcModel.Instance.RateLimiter.RefreshMsecs));
             // Take us out of scrolling mode.
             task = Task.Run (() => {
-                NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () { 
-                    Status = NachoCore.Utils.NcResult.Info (NcResult.SubKindEnum.Info_BackgroundAbateStopped),
-                    Account = ConstMcAccount.NotAccountSpecific,
-                    Tokens = new string[1] {
-                        DateTime.Now.ToString()
-                    }
-                });
+                NcAbate.RegularPriority("RateLimitBgDbWritesInScroll");
             });
             Assert.True (task.Wait (10 * 1000));
             while (NcModel.Instance.RateLimiter.Enabled) {


### PR DESCRIPTION
Replace direct send of status ind with wrapper functions. Wrapper functions are setting globals, not sending status inds any more.
