### PR TITLE
Don't order the main McPending Query

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McPending.cs
+++ b/NachoClient.Android/NachoCore/Model/McPending.cs
@@ -934,11 +934,15 @@ namespace NachoCore.Model
         }
 
         // Query APIs for any & all to call.
+
+        /// <summary>
+        /// All McPendings for an account, unordered.
+        /// </summary>
         public static List<McPending> Query (int accountId)
         {
             return NcModel.Instance.Db.Table<McPending> ()
                     .Where (x => x.AccountId == accountId)
-                .OrderBy (x => x.Priority).ToList ();
+                    .ToList ();
         }
 
         public static IEnumerable<McPending> QueryEligible (int accountId)


### PR DESCRIPTION
Some telemetry data was showing that McPending.Query() was taking
about 150 ms on average, which is much too long.  The SQL was ordering
the results by priority.  But all of the callers of McPending.Query()
were ignoring that order and reordering the results themselves.
Remove the ordering from the SQL, so we don't waste time while holding
a shared lock on the database.
