### PR TITLE
Handle forward/reply of message with empty body

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
@@ -1022,7 +1022,7 @@ namespace NachoClient.iOS
 
             bool originalEmailIsEmbedded = true;
             string bodyText = bodyTextView.Text;
-            if (initialQuotedText != null && 0 < initialQuotedText.Length && bodyText.EndsWith (initialQuotedText)) {
+            if (!string.IsNullOrEmpty(initialQuotedText) && bodyText.EndsWith (initialQuotedText)) {
                 // This is a reply or forward, and the user didn't changed the quoted text.
                 // Strip the quoted text from the body of the message and instead have the
                 // server add in the original message.


### PR DESCRIPTION
Forwarding or replying to a message with an empty body was causing a
crash.  I consider this a bug in the specification of C#'s
String.Remove.  It should allow an index that refers to the very end
of the string.  But it doesn't, so we have to work around that.

Fix #908
