### PR TITLE
Fix #943

### DIFF
--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -205,12 +205,14 @@ namespace NachoCore
             Log.Info (Log.LOG_LIFECYCLE, "NcApplication: StopClass1Services exited.");
         }
 
-        public void StartClass2Services ()
+        public void StartClass2Services (bool willEnterForeground = true)
         {
             Log.Info (Log.LOG_LIFECYCLE, "NcApplication: StartClass2Services called.");
             NcModel.Instance.EngageRateLimiter ();
-            NcBrain.StartService ();
-            NcContactGleaner.Start ();
+            if (willEnterForeground) {
+                NcBrain.StartService ();
+                NcContactGleaner.Start ();
+            }
             Log.Info (Log.LOG_LIFECYCLE, "NcApplication: StartClass2Services exited.");
         }
 

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -396,12 +396,12 @@ namespace NachoClient.iOS
             Log.Info (Log.LOG_LIFECYCLE, "FinalShutdown: Exit");
         }
 
-        private void ReverseFinalShutdown ()
+        private void ReverseFinalShutdown (bool willEnterForeground = true)
         {
             Log.Info (Log.LOG_LIFECYCLE, "ReverseFinalShutdown: Called");
             NcApplication.Instance.StartClass1Services ();
             Log.Info (Log.LOG_LIFECYCLE, "ReverseFinalShutdown: StartClass1Services complete");
-            NcApplication.Instance.StartClass2Services ();
+            NcApplication.Instance.StartClass2Services (willEnterForeground);
             Log.Info (Log.LOG_LIFECYCLE, "ReverseFinalShutdown: StartClass2Services complete");
             NcApplication.Instance.StartClass3Services ();
             Log.Info (Log.LOG_LIFECYCLE, "ReverseFinalShutdown: StartClass3Services complete");
@@ -514,7 +514,7 @@ namespace NachoClient.iOS
             }
         }
 
-        protected void CompletePerformFetchWithoutShutdown()
+        protected void CompletePerformFetchWithoutShutdown ()
         {
             performFetchTimer.Dispose ();
             performFetchTimer = null;
@@ -541,7 +541,7 @@ namespace NachoClient.iOS
             // Need to set ExecutionContext before Start of BE so that strategy can see it.
             NcApplication.Instance.ExecutionContext = NcApplication.ExecutionContextEnum.QuickSync;
             if (FinalShutdownHasHappened) {
-                ReverseFinalShutdown ();
+                ReverseFinalShutdown (false);
             }
             NcApplication.Instance.StatusIndEvent += FetchStatusHandler;
             NcApplication.Instance.QuickSync ();


### PR DESCRIPTION
If class 2 services are started for perform fetch, skip brain and contact gleaner activation because class 2 service is not properly stopped for perform fetch.

This is also likely the fix for #938. Brain task was shutdown but it was reactivated by background perform fetch.
