### PR TITLE
Truncated bodies are marked as Complete. Needed to make sure we

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
@@ -458,7 +458,7 @@ namespace NachoCore.ActiveSync
                 return null;
             }
             var body = emailMessage.GetBody ();
-            if(McAbstrFileDesc.IsComplete(body)) {
+            if(McAbstrFileDesc.IsNontruncatedBodyComplete(body)) {
                 Log.Error (Log.LOG_AS, "DnldEmailBodyCmd: FilePresence is Complete");
                 return null;
             }
@@ -629,7 +629,7 @@ namespace NachoCore.ActiveSync
                 return null;
             }
             var body = cal.GetBody ();
-            if(McAbstrFileDesc.IsComplete(body)) {
+            if(McAbstrFileDesc.IsNontruncatedBodyComplete(body)) {
                 return null;
             }
             var pending = new McPending (Account.Id) {
@@ -748,7 +748,7 @@ namespace NachoCore.ActiveSync
                 return null;
             }
             var body = contact.GetBody ();
-            if(McAbstrFileDesc.IsComplete(body)) {
+            if(McAbstrFileDesc.IsNontruncatedBodyComplete(body)) {
                 return null;
             }
             var pending = new McPending (Account.Id) {
@@ -865,7 +865,7 @@ namespace NachoCore.ActiveSync
                 return null;
             }
             var body = task.GetBody ();
-            if(McAbstrFileDesc.IsComplete(body)) {
+            if(McAbstrFileDesc.IsNontruncatedBodyComplete(body)) {
                 return null;
             }
             var pending = new McPending (Account.Id) {

--- a/NachoClient.Android/NachoCore/Model/McAbstrFileDesc.cs
+++ b/NachoClient.Android/NachoCore/Model/McAbstrFileDesc.cs
@@ -374,5 +374,10 @@ namespace NachoCore.Model
         {
             return (FilePresenceEnum.Complete == FilePresence);
         }
+
+        public static bool IsNontruncatedBodyComplete(McAbstrFileDesc file)
+        {
+            return (IsComplete (file) && !file.Truncated);
+        }
     }
 }

--- a/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
+++ b/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
@@ -189,7 +189,7 @@ namespace NachoCore.Utils
             error = null;
 
             var body = message.GetBody ();
-            if (!McBody.IsComplete (body)) {
+            if (!McBody.IsNontruncatedBodyComplete (body)) {
                 error = "Nacho Mail has not downloaded the body of this message yet.\n" + message.GetBodyPreviewOrEmpty ();
                 return null;
             }

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -112,7 +112,7 @@ namespace NachoClient.iOS
 
             var body = McBody.QueryById<McBody> (item.BodyId);
 
-            if (null != body && McAbstrFileDesc.FilePresenceEnum.Complete == body.FilePresence) {
+            if (McAbstrFileDesc.IsNontruncatedBodyComplete(body)) {
                 if (isRefresh && (itemDateTime == body.LastModified)) {
                     return;
                 }
@@ -132,7 +132,7 @@ namespace NachoClient.iOS
                 statusIndicatorIsRegistered = false;
             }
 
-            if (null == body || McAbstrFileDesc.FilePresenceEnum.Complete != body.FilePresence) {
+            if (!McAbstrFileDesc.IsNontruncatedBodyComplete(body)) {
                 StartDownload ();
                 return;
             }
@@ -220,7 +220,7 @@ namespace NachoClient.iOS
                 if (null != refreshedItem) {
                     item = refreshedItem;
                     var body = McBody.QueryById<McBody> (item.BodyId);
-                    if (null != body && McAbstrFileDesc.FilePresenceEnum.Complete == body.FilePresence) {
+                    if (McAbstrFileDesc.IsNontruncatedBodyComplete(body)) {
                         // It was a race condition. We're good.
                         Reconfigure ();
                     } else {


### PR DESCRIPTION
Truncated bodies are marked as Complete. Needed to make sure we
download truncated bodies even if they are marked as complete.
By convention, we are asking EAS for "AllOrNothing" when we do
the download, so we shouldn't get truncated bodies when we ask
to download a truncated body.
