### PR TITLE
Fix #1032

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -58,6 +58,10 @@ namespace NachoCore.Utils
 
         public DateTime Timestamp { set; get; }
 
+        // This is the event ID recorded in the server (not the id of the server);
+        // as opposed to the local dbId.
+        public string ServerId { set; get; }
+
         private TelemetryEventType _Type;
 
         public TelemetryEventType Type {
@@ -364,6 +368,7 @@ namespace NachoCore.Utils
         public TelemetryEvent (TelemetryEventType type)
         {
             Timestamp = DateTime.UtcNow;
+            ServerId = Guid.NewGuid ().ToString ().Replace ("-", "");
             _Type = type;
             _Message = null;
             _Wbxml = null;

--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -222,7 +222,13 @@ namespace NachoCore.Utils
             var anEvent = new Document ();
             // Client and timeestamp are the only common fields for all event tables.
             // They are also the primary keys.
-            anEvent ["id"] = Guid.NewGuid ().ToString ().Replace ("-", "");
+            if (null == tEvent.ServerId) {
+                // These are old events that do not have the ServerId field yet.
+                // In that case, create an id for the event.
+                anEvent ["id"] = Guid.NewGuid ().ToString ().Replace ("-", "");
+            } else {
+                anEvent ["id"] = tEvent.ServerId;
+            }
             anEvent ["client"] = GetUserName ();
             anEvent ["timestamp"] = tEvent.Timestamp.Ticks;
             return anEvent;


### PR DESCRIPTION
There are two WBMXL response record in DynamoDB for the same event. The reason is that it was uploaded twice and the event ID is created during upload time not during event creation time. I move the event id generation to the constructor of TelemetryEvent. So, even if it is uploaded twice, it will go to the same row.
