### PR TITLE
Fix #938

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -434,7 +434,7 @@ namespace NachoCore.Brain
         public void Process ()
         {
             if (ENABLED) {
-                McEmailMessage.StartTimeVariance ();
+                McEmailMessage.StartTimeVariance (EventQueue.Token);
                 NcApplication.Instance.StatusIndEvent += GenerateInitialContactScores;
                 NcApplication.Instance.StatusIndEvent += UIScrollingEnd;
             }

--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/EmailMessageScore.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/EmailMessageScore.cs
@@ -475,7 +475,7 @@ namespace NachoCore.Model
             }
         }
 
-        public static void StartTimeVariance ()
+        public static void StartTimeVariance (CancellationToken token)
         {
             /// Look for all email messages that are:
             ///
@@ -492,7 +492,9 @@ namespace NachoCore.Model
                 /// Throttle
                 n = (n + 1) % 8;
                 if (0 == n) {
-                    Thread.Sleep (new TimeSpan (0, 0, 0, 0, 500));
+                    if (!NcTask.CancelableSleep (500, token)) {
+                        break;
+                    }
                 }
             }
             Log.Info (Log.LOG_BRAIN, "{0} time variances started", emailMessageList.Count);

--- a/NachoClient.Android/NachoCore/Utils/NcTask.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcTask.cs
@@ -118,5 +118,33 @@ namespace NachoCore.Utils
                 }
             }
         }
+
+        /// <summary>
+        /// Sleep for a number of milliseconds 
+        /// </summary>
+        /// <returns><c>true</c> if it sleeps for the specified duration. If the sleep is interrupted by
+        /// cancellation, return <c>false</c>.</returns>
+        /// <param name="msec">Msec.</param>
+        /// <param name="token">Token.</param>
+        public static bool CancelableSleep (int msec, CancellationToken token)
+        {
+            try {
+                Task.WaitAll (new Task[] { Task.Delay (msec, token) });
+                return true;
+            } catch (AggregateException e) {
+                foreach (var ex in e.InnerExceptions) {
+                    if (ex is OperationCanceledException) {
+                        continue;
+                    }
+                    throw;
+                }
+                return false;
+            }
+        }
+
+        public static void CancelableSleep (int msec)
+        {
+            CancelableSleep (msec, Cts.Token);
+        }
     }
 }

--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -95,20 +95,6 @@ namespace NachoCore.Utils
             });
         }
 
-        private void CancelableSleep (int msec)
-        {
-            try {
-                Task.WaitAll (new Task[] { Task.Delay (msec, NcTask.Cts.Token) });
-            } catch (AggregateException e) {
-                foreach (var ex in e.InnerExceptions) {
-                    if (ex is OperationCanceledException) {
-                        continue;
-                    }
-                    throw;
-                }
-            }
-        }
-
         private void Retry (Action action)
         {
             bool isDone = false;
@@ -121,20 +107,20 @@ namespace NachoCore.Utils
                         throw;
                     }
                     // Otherwise, most likely HTTP client timeout
-                    CancelableSleep (5000);
+                    NcTask.CancelableSleep (5000);
                 } catch (AmazonServiceException e) {
                     Console.WriteLine ("AWS service exception {0}", e);
-                    CancelableSleep (5000);
+                    NcTask.CancelableSleep (5000);
                 } catch (AggregateException e) {
                     // Some code path wraps the exception with an AggregateException. Peel the onion
                     if (e.InnerException is TaskCanceledException) {
                         if (NcTask.Cts.Token.IsCancellationRequested) {
                             throw;
                         }
-                        CancelableSleep (5000);
+                        NcTask.CancelableSleep (5000);
                     } else if (e.InnerException is AmazonServiceException) {
                         Console.WriteLine ("AWS service inner exception {0}", e.InnerException);
-                        CancelableSleep (5000);
+                        NcTask.CancelableSleep (5000);
                     } else {
                         throw;
                     }


### PR DESCRIPTION
NcBrain.Process() first start all time variances before it enters the main loop. During this, cancellation is not being observed. So, if there are lots of emails have time variance state machines running, it can miss its deadline.

The solution is to pass the right token into StartTimeVariance() and use a cancelable sleep function.
