### PR TITLE
For #985

### DIFF
--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -307,6 +307,13 @@ namespace NachoCore
             Log.Info (Log.LOG_SYS, "Monitor: Min Threads {0}/{1}", workerThreads, completionPortThreads);
             ThreadPool.GetMaxThreads (out workerThreads, out completionPortThreads);
             Log.Info (Log.LOG_SYS, "Monitor: Max Threads {0}/{1}", workerThreads, completionPortThreads);
+            var numThreads = PlatformProcess.GetNumberOfSystemThreads ();
+            var message = String.Format ("Monitor: System Threads {0}", numThreads);
+            if (50 > numThreads) {
+                Log.Info (Log.LOG_SYS, message);
+            } else {
+                Log.Warn (Log.LOG_SYS, message);
+            }
             Log.Info (Log.LOG_SYS, "Monitor: Comm Status {0}, Speed {1}", 
                 NcCommStatus.Instance.Status, NcCommStatus.Instance.Speed);
             Log.Info (Log.LOG_SYS, "Monitor: Battery Level {0}, Plugged Status {1}",
@@ -378,8 +385,8 @@ namespace NachoCore
                     foreach (var pending in McPending.QueryOlderThanByState (account.Id, cutoff, McPending.StateEnum.Failed)) {
                         // TODO Expand this to clean up more than just downloads.
                         if (McPending.Operations.EmailBodyDownload == pending.Operation ||
-                                McPending.Operations.CalBodyDownload == pending.Operation ||
-                                McPending.Operations.AttachmentDownload == pending.Operation) {
+                            McPending.Operations.CalBodyDownload == pending.Operation ||
+                            McPending.Operations.AttachmentDownload == pending.Operation) {
                             pending.Delete ();
                         }
                     }


### PR DESCRIPTION
- Log the # of system threads (Mach thread for iOS) to monitor.
- Make it a warning if there are 50 or more threads.
- This is not a fix. But I am not sure if anything is really broken. Just because thread Id is going up does not equate to the # of live threads is increasing. So, this monitor will prove that it is not and if it is, it will generate a warning beyond 50 threads. From experimentation (by creating some dummy threads), I can see that a C# Thread corresponds a iOS Mach thread. So, this monitor is effective in monitoring threads in iOS. (Android implementation is a stub. Will deal with it later.)
