### PR TITLE
Make MX query results available to the advanced login page

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
@@ -88,12 +88,6 @@ namespace NachoCore.ActiveSync
             }
         }
 
-        private AutoDInfoEnum _autoDInfo;
-        public override AutoDInfoEnum AutoDInfo {
-            get {
-                return _autoDInfo;
-            }
-        }
         private X509Certificate2 _ServerCertToBeExamined;
         public override X509Certificate2 ServerCertToBeExamined {
             get {
@@ -991,8 +985,7 @@ namespace NachoCore.ActiveSync
         private void DoUiServConfReq ()
         {
             // Send the request toward the UI.
-            _autoDInfo = (AutoDInfoEnum)Sm.Arg;
-            Owner.ServConfReq (this, _autoDInfo);
+            Owner.ServConfReq (this);
         }
 
         private void DoSetServConf ()

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/AsAutodiscoverCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/AsAutodiscoverCommand.cs
@@ -562,7 +562,7 @@ namespace NachoCore.ActiveSync
 
         private void DoUiGetServer ()
         {
-            OwnerSm.PostEvent ((uint)AsProtoControl.CtlEvt.E.GetServConf, "AUTODDUGS", AutoDInfoEnum.None);
+            OwnerSm.PostEvent ((uint)AsProtoControl.CtlEvt.E.GetServConf, "AUTODDUGS");
         }
 
         private void DoUiServerCertAsk ()

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
@@ -681,6 +681,7 @@ namespace NachoCore.ActiveSync
 
             private void DoRobotDnsMxHardFail ()
             {
+                Command.ProtoControl.AutoDInfo = AutoDInfoEnum.MXNotFound;
                 Log.Info (Log.LOG_AS, "AUTOD:{0}:PROGRESS: DNS MX failed.", Step);
                 DoRobotHardFail ();
             }
@@ -1097,13 +1098,16 @@ namespace NachoCore.ActiveSync
                         NsType.MX == response.NsType) {
                         var aBest = (MxRecord)response.Answers.OrderBy (r1 => ((MxRecord)r1).Preference).First ();
                         if (aBest.MailExchange.EndsWith (McServer.GMail_MX_Suffix, StringComparison.OrdinalIgnoreCase)) {
+                            Command.ProtoControl.AutoDInfo = AutoDInfoEnum.MXFoundGoogle;
                             SrServerUri = new Uri (McServer.GMail_Uri);
                             return Event.Create ((uint)SmEvt.E.Success, "SRPRMXSUCCESS");
                         } else {
+                            Command.ProtoControl.AutoDInfo = AutoDInfoEnum.MXFoundNonGoogle;
                             return Event.Create ((uint)SmEvt.E.HardFail, "SRPRMXHARD1");
                         }
 
                     } else {
+                        Command.ProtoControl.AutoDInfo = AutoDInfoEnum.MXNotFound;
                         return Event.Create ((uint)SmEvt.E.HardFail, "SRPRMXHARD2");
                     }
 

--- a/NachoClient.Android/NachoCore/BackEnd/BackEnd.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/BackEnd.cs
@@ -470,10 +470,10 @@ namespace NachoCore
             });
         }
 
-        public void ServConfReq (ProtoControl sender, AutoDInfoEnum autoDInfo)
+        public void ServConfReq (ProtoControl sender)
         {
             InvokeOnUIThread.Instance.Invoke (delegate () {
-                Owner.ServConfReq (sender.AccountId, autoDInfo);
+                Owner.ServConfReq (sender.AccountId);
             });
         }
 

--- a/NachoClient.Android/NachoCore/BackEnd/IBackEnd.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IBackEnd.cs
@@ -18,8 +18,10 @@ namespace NachoCore
     };
 
     public enum AutoDInfoEnum {
-        None = 0,
-        MXNotFound = 1,
+        Unknown = 0,
+        MXNotFound,
+        MXFoundGoogle,
+        MXFoundNonGoogle,
     };
 
     public interface IBackEnd

--- a/NachoClient.Android/NachoCore/BackEnd/IBackEndOwner.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IBackEndOwner.cs
@@ -23,7 +23,7 @@ namespace NachoCore
         /// the account record. The BE will act based on the update event for the
         /// account record.
         ///
-        void ServConfReq (int accountId, AutoDInfoEnum autoDInfo);
+        void ServConfReq (int accountId);
 
         ///
         /// CertAskReq: When called the callee must ask the user whether the passed server cert can

--- a/NachoClient.Android/NachoCore/BackEnd/IProtoControlOwner.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IProtoControlOwner.cs
@@ -10,7 +10,7 @@ namespace NachoCore
         void StatusInd (ProtoControl sender, NcResult status);
         void StatusInd (ProtoControl sender, NcResult status, string[] tokens);
         void CredReq (ProtoControl sender);
-        void ServConfReq (ProtoControl sender, AutoDInfoEnum autoDInfo);
+        void ServConfReq (ProtoControl sender);
         void CertAskReq (ProtoControl sender, X509Certificate2 certificate);
         void SearchContactsResp (ProtoControl sender, string prefix, string token);
     }

--- a/NachoClient.Android/NachoCore/BackEnd/ProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ProtoControl.cs
@@ -53,9 +53,13 @@ namespace NachoCore
             }
         }
 
+        private AutoDInfoEnum _autoDInfo = AutoDInfoEnum.Unknown;
         public virtual AutoDInfoEnum AutoDInfo {
             get {
-                return AutoDInfoEnum.None;
+                return _autoDInfo;
+            }
+            set {
+                _autoDInfo = value;
             }
         }
 

--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -56,7 +56,7 @@ namespace NachoCore
         /// </summary>
         public CredReqCallbackDele CredReqCallback { set; get; }
 
-        public delegate void ServConfReqCallbackDele (int accountId, AutoDInfoEnum autoDInfo);
+        public delegate void ServConfReqCallbackDele (int accountId);
 
         /// <summary>
         /// ServConfRequest: When called the callee must gather the server information for the 
@@ -429,10 +429,10 @@ namespace NachoCore
             }
         }
 
-        public void ServConfReq (int accountId, AutoDInfoEnum autoDInfo)
+        public void ServConfReq (int accountId)
         {
             if (null != ServConfReqCallback) {
-                ServConfReqCallback (accountId, autoDInfo);
+                ServConfReqCallback (accountId);
             } else {
                 Log.Error (Log.LOG_UI, "Nothing registered for NcApplication ServConfReqCallback.");
             }

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -351,7 +351,7 @@ namespace NachoClient.iOS
                     Log.Info (Log.LOG_STATE, "OnActived: CREDCALLBACK ");
                     break;
                 case BackEndStateEnum.ServerConfWait:
-                    ServConfReqCallback (accountId, BackEnd.Instance.AutoDInfo (accountId));
+                    ServConfReqCallback (accountId);
                     Log.Info (Log.LOG_STATE, "OnActived: SERVCONFCALLBACK ");
                     break;
                 default:
@@ -661,9 +661,12 @@ namespace NachoClient.iOS
         }
 
 
-        public void ServConfReqCallback (int accountId, AutoDInfoEnum autoDInfo)
+        public void ServConfReqCallback (int accountId)
         {
             Log.Info (Log.LOG_UI, "ServConfReqCallback Called for account: {0}", accountId);
+
+            // TODO Make use of the MX information that was gathered during auto-d.
+            // It can be found at BackEnd.Instance.AutoDInfo(accountId).
 
             hasFirstSyncCompleted = LoginHelpers.HasFirstSyncCompleted (accountId); 
             if (hasFirstSyncCompleted == false) {
@@ -729,7 +732,7 @@ namespace NachoClient.iOS
                         gonnaquit.Show ();
                         gonnaquit.Clicked += delegate(object sender, UIButtonEventArgs e) {
                             if (e.ButtonIndex == 1) {
-                                ServConfReqCallback (accountId, BackEnd.Instance.AutoDInfo (accountId)); // go again
+                                ServConfReqCallback (accountId); // go again
                             }
                             gonnaquit.ResignFirstResponder ();
                         };

--- a/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
@@ -231,7 +231,7 @@ namespace NachoClient.iOS
                 int accountId = LoginHelpers.GetCurrentAccountId ();
                 if (BackEndStateEnum.ServerConfWait == backEndState) {
                     var x = (AppDelegate)UIApplication.SharedApplication.Delegate;
-                    x.ServConfReqCallback (accountId, BackEnd.Instance.AutoDInfo (accountId));
+                    x.ServConfReqCallback (accountId);
                 }
             }
         }

--- a/Test.Android/Common/CommonMocks.cs
+++ b/Test.Android/Common/CommonMocks.cs
@@ -219,7 +219,7 @@ namespace Test.iOS
 
         // we aren't interested in these
         public void CredReq (ProtoControl sender) {}
-        public void ServConfReq (ProtoControl sender, AutoDInfoEnum autoDInfo) {}
+        public void ServConfReq (ProtoControl sender) {}
         public void CertAskReq (ProtoControl sender, X509Certificate2 certificate) {}
         public void SearchContactsResp (ProtoControl sender, string prefix, string token) {}
     }

--- a/Test.Android/NcCalendarTest.cs
+++ b/Test.Android/NcCalendarTest.cs
@@ -42,7 +42,7 @@ namespace Test.Common
         {
         }
 
-        public void ServConfReq (ProtoControl sender, AutoDInfoEnum autoDInfo)
+        public void ServConfReq (ProtoControl sender)
         {
         }
 

--- a/Test.Android/NcContactTest.cs
+++ b/Test.Android/NcContactTest.cs
@@ -45,7 +45,7 @@ namespace Test.Common
             {
             }
 
-            public void ServConfReq (ProtoControl sender, AutoDInfoEnum autoDInfo)
+            public void ServConfReq (ProtoControl sender)
             {
             }
 

--- a/Test.Android/NcEmailTest.cs
+++ b/Test.Android/NcEmailTest.cs
@@ -53,7 +53,7 @@ namespace Test.Common
             {
             }
 
-            public void ServConfReq (ProtoControl sender, AutoDInfoEnum autoDInfo)
+            public void ServConfReq (ProtoControl sender)
             {
             }
 


### PR DESCRIPTION
Store the results of the MX query, which happens during auto-d, in the
ProtoControl object.  This way, they are available to UI, specifically
to the advanced login page that comes up when initial account
authentication fails.  (The advanced login page hasn't been changed
yet to use the information.  That will happen later.)

Remove an AutoDInfoEnum parameter from a bunch of methods.  Explicitly
passing that parameter through multiple layers of methods was
unnecessary.  Storing the value in the ProtoControl object is enough.

Fix #1081 
