### PR TITLE
Fix the GFE happy path

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
@@ -1099,7 +1099,7 @@ namespace NachoCore.ActiveSync
                         var aBest = (MxRecord)response.Answers.OrderBy (r1 => ((MxRecord)r1).Preference).First ();
                         if (aBest.MailExchange.EndsWith (McServer.GMail_MX_Suffix, StringComparison.OrdinalIgnoreCase)) {
                             Command.ProtoControl.AutoDInfo = AutoDInfoEnum.MXFoundGoogle;
-                            SrServerUri = new Uri (McServer.GMail_Uri);
+                            SrServerUri = McServer.BaseUriForHost (McServer.GMail_Host);
                             return Event.Create ((uint)SmEvt.E.Success, "SRPRMXSUCCESS");
                         } else {
                             Command.ProtoControl.AutoDInfo = AutoDInfoEnum.MXFoundNonGoogle;

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsCommand.cs
@@ -157,7 +157,7 @@ namespace NachoCore.ActiveSync
                         "&", string.Format ("{0}={1}", pair.Key, pair.Value));
                 }
             }
-            return new Uri (AsCommand.BaseUri (BEContext.Server), requestLine);
+            return new Uri (BEContext.Server.BaseUri (), requestLine);
         }
 
         public virtual void ServerUriChanged (Uri ServerUri, AsHttpOperation Sender)
@@ -636,13 +636,6 @@ namespace NachoCore.ActiveSync
             var doc = new XDocument ();
             doc.Declaration = new XDeclaration ("1.0", "utf-8", "no");
             return doc;
-        }
-
-        static internal Uri BaseUri (McServer server)
-        {
-            var retval = string.Format ("{0}://{1}:{2}{3}",
-                             server.Scheme, server.Host, server.Port, server.Path);
-            return new Uri (retval);
         }
     }
 }

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Operations/AsHttpOperation.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Operations/AsHttpOperation.cs
@@ -752,7 +752,7 @@ namespace NachoCore.ActiveSync
                         ServerUriBeingTested = true;
                         var dummy = McServer.Create (BEContext.Account.Id, redirUri);
                         var query = (string.Empty == redirUri.Query) ? ServerUri.Query : redirUri.Query;
-                        ServerUri = new Uri (AsCommand.BaseUri (dummy), query);
+                        ServerUri = new Uri (dummy.BaseUri (), query);
                         return Event.Create ((uint)SmEvt.E.Launch, "HTTPOP451C");
                     } catch (Exception ex) {
                         Log.Info (Log.LOG_HTTP, "ProcessHttpResponse {0} {1}: exception {2}", ex, ServerUri, ex.Message);

--- a/NachoClient.Android/NachoCore/Model/McServer.cs
+++ b/NachoClient.Android/NachoCore/Model/McServer.cs
@@ -18,7 +18,6 @@ namespace NachoCore.Model
         public string Host { get; set; }
 
         public const string GMail_Host = "m.google.com";
-        public const string GMail_Uri = "https://" + GMail_Host;
         public const string GMail_MX_Suffix = "ASPMX.L.GOOGLE.com";
         public const string HotMail_Host = "s.outlook.com";
         public const string HotMail_Suffix = "hotmail.com";
@@ -35,6 +34,31 @@ namespace NachoCore.Model
         // We want to remember if the user entered their
         // own server or if we figured it out on our own.
         public bool UserSpecifiedServer { get; set; }
+
+        /// <summary>
+        /// The base URI for the server.
+        /// </summary>
+        public Uri BaseUri ()
+        {
+            string uriString;
+            if (443 == Port && "https" == Scheme) {
+                uriString = string.Format ("{0}://{1}{2}", Scheme, Host, Path);
+            } else {
+                uriString = string.Format ("{0}://{1}:{2}{3}", Scheme, Host, Port, Path);
+            }
+            return new Uri (uriString);
+        }
+
+        /// <summary>
+        /// The base URI for the server at the given host.
+        /// </summary>
+        public static Uri BaseUriForHost (string host)
+        {
+            McServer dummy = new McServer () {
+                Host = host,
+            };
+            return dummy.BaseUri ();
+        }
 
         public bool HostIsHotMail ()
         {


### PR DESCRIPTION
Fix the Google Apps for Work (GFE) happy path case, where the user
enters the correct credentials and the server has the expected MX DNS
record.  This was broken earlier because the wrong server URL was
being constructed after a successful MX lookup.  That has been fixed,
and the construction of server base URLs has been centralized in class
McServer.
