### PR TITLE
Fix #980. Handle Info_InboxPingStarted status indicator. Receiving this ...

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/AdvancedLoginViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/AdvancedLoginViewController.cs
@@ -882,12 +882,11 @@ namespace NachoClient.iOS
 
             if (NcResult.SubKindEnum.Info_EmailMessageSetChanged == s.Status.SubKind) {
                 Log.Info (Log.LOG_UI, "Info_EmailMessageSetChanged Status Ind (AdvancedView)");
-                LoginHelpers.SetFirstSyncCompleted (LoginHelpers.GetCurrentAccountId (), true);
-                if (!hasSyncedEmail) {
-                    waitScreen.Layer.RemoveAllAnimations ();
-                    waitScreen.StartSyncedEmailAnimation ();
-                    hasSyncedEmail = true;
-                }
+                SyncCompleted ();
+            }
+            if (NcResult.SubKindEnum.Info_InboxPingStarted == s.Status.SubKind) {
+                Log.Info (Log.LOG_UI, "Info_InboxPingStarted Status Ind (AdvancedView)");
+                SyncCompleted ();
             }
             if (NcResult.SubKindEnum.Info_AsAutoDComplete == s.Status.SubKind) {
                 Log.Info (Log.LOG_UI, "Auto-D-Completed Status Ind (Advanced View)");
@@ -962,6 +961,16 @@ namespace NachoClient.iOS
             ConfigureView (LoginStatus.AcceptCertificate);
             NcApplication.Instance.CertAskResp (LoginHelpers.GetCurrentAccountId (), true);
             waitScreen.InitializeAutomaticSegueTimer ();
+        }
+
+        protected void SyncCompleted ()
+        {
+            LoginHelpers.SetFirstSyncCompleted (LoginHelpers.GetCurrentAccountId (), true);
+            if (!hasSyncedEmail) {
+                waitScreen.Layer.RemoveAllAnimations ();
+                waitScreen.StartSyncedEmailAnimation ();
+                hasSyncedEmail = true;
+            }
         }
 
         public class AccountSettings

--- a/NachoClient.iOS/NachoUI.iOS/HomeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/HomeViewController.cs
@@ -70,6 +70,10 @@ namespace NachoClient.iOS
                 Log.Info (Log.LOG_UI, "Info_EmailMessageSetChanged Status Ind (Tutorial)");
                 LoginHelpers.SetFirstSyncCompleted (accountId, true);
             }
+            if (NcResult.SubKindEnum.Info_InboxPingStarted == s.Status.SubKind) {
+                Log.Info (Log.LOG_UI, "Info_InboxPingStarted Status Ind (Tutorial)");
+                LoginHelpers.SetFirstSyncCompleted (accountId, true);
+            }
             if (NcResult.SubKindEnum.Info_AsAutoDComplete == s.Status.SubKind) {
                 Log.Info (Log.LOG_UI, "Info_AsAutoDComplete Status Ind (Tutorial)");
                 LoginHelpers.SetAutoDCompleted (LoginHelpers.GetCurrentAccountId (), true);


### PR DESCRIPTION
...status-ind in tutorial or AdvacedLoginVC acts as a key into NachoNow. Handle the status-ind the same way as Info_EmailMessageSetChanged. Before this status-ind was introduced, if a user had 0 messages in their account, the Info_EmailMessageSetChanged status-ind would never get invoked, which was the only ticket into NachoNow.
