### PR TITLE
Expand really long multi-day events on a background thread

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
@@ -952,6 +952,7 @@ namespace NachoCore.Utils
                     }
                     localStartTime = nextDay;
                     days -= 1.0;
+                    NcTask.Cts.Token.ThrowIfCancellationRequested ();
                 } while (days > 0.25);
             };
 


### PR DESCRIPTION
Clean up CalendarHelper.ExpandAllDayEvent():

If the event is more than a week long, create all the daily events on
a background thread. This prevents a really long event from blocking
the sync response processing. (The choice of one week as the cuttoff
was arbitrary. Any value between two days and a couple months should
work fine.)

Correctly handle exceptions for recurring all-day events. In the old
code, exceptions for recurring all-day events were ignored.

A reminder for a multi-day all-day event is applied only to the first
day. In the old code, it was applied to each day.

Fix #1153
