### PR TITLE
Fix #1135

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NachoPriorityEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoPriorityEmailMessages.cs
@@ -23,9 +23,18 @@ namespace NachoCore
 
         public bool Refresh (out List<int> deletes)
         {
-            var list = McEmailMessage.QueryActiveMessageItemsByScore (folder.AccountId, folder.Id);
-            if (null == list) {
-                list = new List<NcEmailMessageIndex> ();
+            List<NcEmailMessageIndex> list = new List<NcEmailMessageIndex> ();
+            double threshold = McEmailMessage.minHotScore;
+            // Before statistics converge, there may be a period when there is no hot emails.
+            // When that happens, lower the threshold until we found something
+            while ((0 == list.Count) && (0.0 <= threshold)) {
+                list = McEmailMessage.QueryActiveMessageItemsByScore (folder.AccountId, folder.Id, threshold);
+                if (null == list) {
+                    list = new List<NcEmailMessageIndex> ();
+                }
+                if (0 == list.Count) {
+                    threshold -= McEmailMessage.minHotScore * 0.5;
+                }
             }
             if (!NcMessageThreads.AreDifferent (threadList, list, out deletes)) {
                 return false;

--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
@@ -341,9 +341,9 @@ namespace NachoCore.Model
 
         public static List<NcEmailMessageIndex> QueryInteractions (int accountId, McContact contact)
         {
-            if (!string.IsNullOrEmpty(contact.GetPrimaryCanonicalEmailAddress())) {
+            if (!string.IsNullOrEmpty (contact.GetPrimaryCanonicalEmailAddress ())) {
 
-                string emailWildcard = "%" + contact.GetPrimaryCanonicalEmailAddress() + "%";
+                string emailWildcard = "%" + contact.GetPrimaryCanonicalEmailAddress () + "%";
                 McFolder deletedFolder = McFolder.GetDefaultDeletedFolder (accountId);
 
                 return NcModel.Instance.Db.Query<NcEmailMessageIndex> (
@@ -432,7 +432,7 @@ namespace NachoCore.Model
                 " m.FolderId = ? AND " +
                 " e.FlagUtcStartDate < ? AND " +
                 " e.UserAction > -1 AND " +
-                " (e.Score > ? OR e.UserAction = 1) " +
+                " (e.Score >= ? OR e.UserAction = 1) " +
                 "UNION " +
                 "SELECT e.Id as Id, e.DateReceived FROM McEmailMessage AS e " +
                 " JOIN McMapFolderFolderEntry AS m ON e.Id = m.FolderEntryId " +


### PR DESCRIPTION
The contact-based scoring that brain does now rely on reasonable address score. In O365, we get that from RIC. But in GFE, RIC is empty. So, the initial address scores are all 0. And no email is above the threshold (0.5). Statistical algorithm is not effective when the sample is small. E.g. at the beginning of an initial sync. During that time, neither the address nor the email message scores are reliable. In Jeff's GFE account, I see it took 2 min before an email with a score over 0.5 shows up and over 3 min before all statistics converges.

To solve this initial convergent problem, we lower the hotness threshold if we cannot find any emails at the current threshold. (From 0.5 to 0.25 to 0.0) When it gets to 0.0, the now view effectively becomes the inbox. My argument for this behavior is that when you have a small # of emails (say ~30), hot / not hot are indistinguishable. This affects only the query and not on the backend scoring. So, if later, a better algorithm can more quickly identify hot emails, this threshold adjustment logic will automatically be bypassed. In a way, it becomes a safety net for bad brain algorithm.
