### PR TITLE
Fix #1198

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -732,6 +732,7 @@ namespace NachoCore.Utils
             bool ranOnce = false;
 
             BackEnd = new T ();
+            BackEnd.Initialize ();
             Counters [0].ReportPeriod = 5 * 60; // report once every 5 min
 
             // Capture the transaction time to telemetry server
@@ -856,6 +857,8 @@ namespace NachoCore.Utils
 
     public interface ITelemetryBE
     {
+        void Initialize ();
+
         bool IsUseable ();
 
         string GetUserName ();

--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -39,6 +39,10 @@ namespace NachoCore.Utils
 
         public TelemetryBEAWS ()
         {
+        }
+
+        public void Initialize ()
+        {
             InitializeTables ();
         }
 
@@ -215,11 +219,6 @@ namespace NachoCore.Utils
         {
             if (null != e) {
                 if (e is AggregateException) {
-                    return HandleAWSException (e.InnerException);
-                }
-                if (e is TargetInvocationException) {
-                    // Have seen this being nested in a stack of exceptions. It looks like
-                    // We may be trying to get a stack trace and fails.
                     return HandleAWSException (e.InnerException);
                 }
                 if (e is ProvisionedThroughputExceededException) {


### PR DESCRIPTION
- Move the AWS initialization out of the constructor and into Initialize(). This is done because cancellation of a task inside a constructor does not seem to work properly. (See #1198 for details.)
- Refactor Retry() so that all AWS exception handling logic is in HandleAWSException().
