### PR TITLE
Better management of local notifications

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -350,6 +350,7 @@
     <Compile Include="NachoCore\Index\Index.cs" />
     <Compile Include="NachoCore\Index\IndexDocument.cs" />
     <Compile Include="NachoCore\Utils\EmailHelper.cs" />
+    <Compile Include="NachoCore\Utils\LocalNotificationManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -242,6 +242,9 @@ namespace NachoCore
         // ALL CLASS-4 STARTS ARE DEFERRED BASED ON TIME.
         public void StartClass4Services ()
         {
+            // Make sure the scheduled notifications are up to date.
+            LocalNotificationManager.ScheduleNotifications ();
+
             ExecutionContext = ExecutionContextEnum.Foreground;
             MonitorStart (); // Has a deferred timer start inside.
             Log.Info (Log.LOG_LIFECYCLE, "{0} (build {1}) built at {2} by {3}",
@@ -378,6 +381,8 @@ namespace NachoCore
             // Things that don't need to run on the UI thread and don't need
             // to happen right away should go into a background task.
             NcTask.Run (delegate {
+
+                LocalNotificationManager.InitializeLocalNotifications ();
 
                 // Clean up old McPending tasks that have been abandoned.
                 DateTime cutoff = DateTime.UtcNow - new TimeSpan (2, 0, 0, 0); // Two days ago

--- a/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
@@ -947,7 +947,7 @@ namespace NachoCore.Utils
                     DateTime nextDay = localStartTime.AddDays (1.0);
                     var ev = McEvent.Create (c.AccountId, localStartTime.ToUniversalTime (), nextDay.ToUniversalTime (), c.Id, exceptionId);
                     if (needsReminder) {
-                        ScheduleNotification (ev, reminderItem.Reminder);
+                        ev.SetReminder (reminderItem.Reminder);
                         needsReminder = false; // Only the first day should have a reminder.
                     }
                     localStartTime = nextDay;
@@ -1034,7 +1034,7 @@ namespace NachoCore.Utils
             if ((null == exceptions) || (0 == exceptions.Count)) {
                 var e = McEvent.Create (c.AccountId, startTime, endTime, c.Id, 0);
                 if (c.ReminderIsSet) {
-                    ScheduleNotification (e, c.Reminder);
+                    e.SetReminder (c.Reminder);
                 }
             } else {
                 foreach (var exception in exceptions) {
@@ -1046,7 +1046,7 @@ namespace NachoCore.Utils
                     }
                     var e = McEvent.Create (c.AccountId, exception.StartTime, exception.EndTime, c.Id, exception.Id);
                     if (exception.ReminderIsSet) {
-                        ScheduleNotification (e, exception.Reminder);
+                        e.SetReminder (exception.Reminder);
                     }
                 }
             }
@@ -1058,21 +1058,6 @@ namespace NachoCore.Utils
             c.RecurrencesGeneratedUntil = DateTime.MinValue;
             c.Update ();
             NcEventManager.Instance.ExpandRecurrences ();
-        }
-
-        /// Note that McEvent Ids are not immutable; they change often as the
-        /// calendar event changes. Thus we push the immutable calendar ID into
-        /// the notification. The 'calendar view' event will show the proper view.
-        protected static void ScheduleNotification (McEvent e, uint reminder)
-        {
-            var notifier = NachoPlatform.Notif.Instance;
-            notifier.CancelNotif (e.Id);
-            var notificationTime = e.StartTime.AddMinutes (-reminder);
-            var calendarItem = e.GetCalendarItemforEvent ();
-            var message = Pretty.Join (Pretty.SubjectString (calendarItem.Subject), Pretty.FormatAlert (reminder));
-            if (DateTime.UtcNow < notificationTime) {
-                notifier.ScheduleNotif (e.Id, e.StartTime.AddMinutes (-reminder), message);
-            }
         }
 
         /// <summary>

--- a/NachoClient.Android/NachoCore/Utils/LocalNotificationManager.cs
+++ b/NachoClient.Android/NachoCore/Utils/LocalNotificationManager.cs
@@ -1,0 +1,196 @@
+﻿//  Copyright (C) 2014 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+using NachoCore.Model;
+using System.Collections.Generic;
+using NachoPlatform;
+using System.Threading;
+
+namespace NachoCore.Utils
+{
+    /// <summary>
+    /// Manage local notifications for the app.  Local notifications are the pop-ups
+    /// that appear when the app is not in the foreground to let the user know about
+    /// an event that is about to happen.
+    /// 
+    /// It is assumed that the only use for local notifications is to implement
+    /// reminders for upcoming calendar events.  If local notifications are to be
+    /// used for anything else, then this class must be changed.
+    /// </summary>
+    public class LocalNotificationManager
+    {
+        // The number of notifications that are scheduled at any moment depends on how
+        // often meetings happen.  Try to schedule notifications for all the meetings
+        // in the next four days, but never schedule more than 50 at a time.  If the
+        // next four days aren't packed solid, then schedule notifications for the next
+        // 20 meetings, but never schedule a notification more than 30 days in the future.
+        private const int MINIMUM_NUM_EVENTS = 20;
+        private const int MAXIMUM_NUM_EVENTS = 50;
+        private static TimeSpan MINIMUM_WINDOW = new TimeSpan (4 * TimeSpan.TicksPerDay);
+        private static TimeSpan MAXIMUM_WINDOW = new TimeSpan (30 * TimeSpan.TicksPerDay);
+
+        private static object lockObject = new object ();
+
+        // The handles of all the scheduled notifications.  Keeping our own list
+        // reduces the amount of work that needs to be done on the UI thread.
+        private static HashSet<Int32> scheduledEvents = null;
+
+        // If a new event is created with a reminder before "scheduledThrough",
+        // then the schedule of notifications needs to be redone.
+        private static DateTime scheduledThrough = DateTime.MaxValue;
+
+        // Has there been a new event in near future?
+        private static bool reschedulingNeeded = false;
+
+        public static void InitializeLocalNotifications ()
+        {
+            lock (lockObject) {
+                NcAssert.True (null == scheduledEvents, "LocalNotificationManager.InitializeLocalNotifications() was called twice.");
+                scheduledEvents = new HashSet<Int32> ();
+                var notifications = new List<NotificationInfo> ();
+                int count = 0;
+                DateTime now = DateTime.UtcNow;
+                scheduledThrough = now + MAXIMUM_WINDOW;
+                foreach (var ev in McEvent.QueryEventsWithRemindersInRange(now, now + MAXIMUM_WINDOW)) {
+                    if (MAXIMUM_NUM_EVENTS <= count || (MINIMUM_NUM_EVENTS <= count && ev.ReminderTime - now > MINIMUM_WINDOW)) {
+                        // More than the maximum total notifications,
+                        // or more than the minimum number and past the minimum window.
+                        // Record when we left off and stop.
+                        scheduledThrough = ev.ReminderTime;
+                        break;
+                    }
+                    notifications.Add (new NotificationInfo (ev.Id, ev.ReminderTime, NotificationMessage (ev)));
+                    scheduledEvents.Add (ev.Id);
+                    ++count;
+                }
+                reschedulingNeeded = false;
+                NachoPlatform.Notif.Instance.ScheduleNotifications (notifications);
+
+                // DEBUG Until we are convinced that this works correctly.
+                Log.Info (Log.LOG_CALENDAR, "Initialized LocalNotificationManager with {0} notifications", notifications.Count);
+
+                NcApplication.Instance.StatusIndEvent += StatusIndicatorCallback;
+            }
+
+            // DEBUG Until we are convinced that this works correctly.
+            NachoPlatform.Notif.DumpNotifications ();
+        }
+
+        public static void ScheduleNotifications ()
+        {
+            // Before starting a background task, check to see if any work needs to be
+            // done.  But don't block while trying to figure that out.  If the lock is
+            // not available right away, then just go ahead and schedule the task.
+            if (Monitor.TryEnter (lockObject)) {
+                try {
+                    if (!ShouldReschedule ()) {
+                        return;
+                    }
+                } finally {
+                    Monitor.Exit (lockObject);
+                }
+            }
+            NcTask.Run (DoScheduling, "ScheduleNotifications");
+        }
+
+        private static void DoScheduling ()
+        {
+            lock (lockObject) {
+                NcAssert.NotNull (scheduledEvents, "LocalNotificationManager.ScheduleNotifications() was called before InitializeLocalNotifications().");
+                if (!ShouldReschedule ()) {
+                    return;
+                }
+                Log.Info (Log.LOG_CALENDAR, "LocalNotificationManager: Adjusting the notifications...");
+                int count = 0;
+                DateTime now = DateTime.UtcNow;
+                bool limitReached = false;
+                foreach (var ev in McEvent.QueryEventsWithRemindersInRange(now, now + MAXIMUM_WINDOW)) {
+                    if (!limitReached) {
+                        limitReached = MAXIMUM_NUM_EVENTS <= count || (MINIMUM_NUM_EVENTS <= count && ev.ReminderTime - now > MINIMUM_WINDOW);
+                        if (limitReached) {
+                            scheduledThrough = ev.ReminderTime;
+                        }
+                    }
+                    if (!limitReached) {
+                        if (scheduledEvents.Add (ev.Id)) {
+                            Log.Info (Log.LOG_CALENDAR, "Adding notification for event {0}", ev.Id);
+                            NachoPlatform.Notif.Instance.ScheduleNotification (ev.Id, ev.ReminderTime, NotificationMessage (ev));
+                        }
+                    } else {
+                        if (scheduledEvents.Remove (ev.Id)) {
+                            Log.Info (Log.LOG_CALENDAR, "Removing notification for event {0}", ev.Id);
+                            NachoPlatform.Notif.Instance.CancelNotification (ev.Id);
+                        }
+                    }
+                    ++count;
+                }
+                if (!limitReached) {
+                    scheduledThrough = now + MAXIMUM_WINDOW;
+                }
+                reschedulingNeeded = false;
+            }
+
+            // DEBUG Until we are convinced that this works correctly.
+            NachoPlatform.Notif.DumpNotifications ();
+        }
+
+        /// <summary>
+        /// Make note of a new event.  If the event has a reminder in the near future,
+        /// set a flag so that its notification will be scheduled on the next
+        /// Info_EventSetChanged event.
+        /// </summary>
+        public static void ScheduleNotification (McEvent ev)
+        {
+            if (DateTime.MinValue == ev.ReminderTime) {
+                // The event doesn't have a reminder.
+                return;
+            }
+            DateTime now = DateTime.UtcNow;
+            if (ev.ReminderTime < now) {
+                if (ev.EndTime > now) {
+                    // The reminder time has passed, but the event isn't over yet.
+                    // Notify the user right now.
+                    string message = Pretty.Join (Pretty.SubjectString (ev.GetCalendarItemforEvent ().Subject), Pretty.ReminderTime (ev.StartTime - now));
+                    NachoPlatform.Notif.Instance.ImmediateNotification (ev.Id, message);
+                }
+                return;
+            }
+            lock (lockObject) {
+                if (ev.ReminderTime < scheduledThrough) {
+                    // The actual scheduling of the notification doesn't happen
+                    // until ScheduleNotifications() is called.
+                    reschedulingNeeded = true;
+                }
+            }
+        }
+
+        public static void CancelNotification (McEvent ev)
+        {
+            lock (lockObject) {
+                NcAssert.NotNull (scheduledEvents, "LocalNotificationManager.CancelNotification() was called before InitializeLocalNotifications().");
+                if (scheduledEvents.Remove (ev.Id)) {
+                    NachoPlatform.Notif.Instance.CancelNotification (ev.Id);
+                }
+            }
+        }
+
+        private static bool ShouldReschedule ()
+        {
+            return reschedulingNeeded || scheduledThrough - DateTime.UtcNow < MINIMUM_WINDOW;
+        }
+
+        private static string NotificationMessage (McEvent ev)
+        {
+            return Pretty.Join (Pretty.SubjectString (ev.GetCalendarItemforEvent ().Subject), Pretty.ReminderTime (ev.StartTime - ev.ReminderTime));
+        }
+
+        private static void StatusIndicatorCallback (object sender, EventArgs e)
+        {
+            var args = (StatusIndEventArgs)e;
+            if (NcResult.SubKindEnum.Info_EventSetChanged == args.Status.SubKind) {
+                ScheduleNotifications ();
+            }
+        }
+    }
+}
+

--- a/NachoClient.Android/NachoCore/Utils/Pretty.cs
+++ b/NachoClient.Android/NachoCore/Utils/Pretty.cs
@@ -371,30 +371,40 @@ namespace NachoCore.Utils
             }
         }
 
-
-        public static string FormatAlert (uint alert)
+        public static string ReminderTime (TimeSpan startsIn)
         {
-            var alertMessage = "";
-            if (0 == alert) {
-                alertMessage = "now";
-            } else if (1 == alert) {
-                alertMessage = " in a minute";
-            } else if (5 == alert || 15 == alert || 30 == alert) {
-                alertMessage = " in " + alert + " minutes";
-            } else if (60 == alert) {
-                alertMessage = " in an hour";
-            } else if (120 == alert) {
-                alertMessage = " in two hours";
-            } else if ((60 * 24) == alert) {
-                alertMessage = " in one day";
-            } else if ((60 * 48) == alert) {
-                alertMessage = " in two days";
-            } else if ((60 * 24 * 7) == alert) {
-                alertMessage = " in a week";
-            } else {
-                alertMessage = String.Format (" in {0} minutes", alert);
+            int minutes = Convert.ToInt32 (startsIn.TotalMinutes);
+            if (0 > minutes) {
+                return "already started";
             }
-            return alertMessage;
+            if (0 == minutes) {
+                return "now";
+            }
+            if (1 == minutes) {
+                return "in a minute";
+            }
+            if (60 == minutes) {
+                return "in an hour";
+            }
+            if ((60 * 24) == minutes) {
+                return "in a day";
+            }
+            if ((60 * 24 * 7) == minutes) {
+                return "in a week";
+            }
+            if (60 > minutes) {
+                return string.Format ("in {0} minutes", minutes);
+            }
+            if (120 > minutes) {
+                return string.Format ("in an hour and {0} minutes", minutes - 60);
+            }
+            if (0 == minutes % (60 * 24)) {
+                return string.Format ("in {0} days", minutes / (60 * 24));
+            }
+            if (0 == minutes % 60) {
+                return string.Format ("in {0} hours", minutes / 60);
+            }
+            return string.Format ("in {0}:{1:D2}", minutes / 60, minutes % 60);
         }
 
         public static string PrettyFileSize (long fileSize)

--- a/NachoClient.Android/NachoPlatform.Android/NotifAndroid.cs
+++ b/NachoClient.Android/NachoPlatform.Android/NotifAndroid.cs
@@ -31,19 +31,35 @@ namespace NachoPlatform
             }
         }
 
-        public void ScheduleNotif (int handle, DateTime when, string message)
+        public void ImmediateNotification (int handle, string message)
         {
             NcAssert.True (false);
         }
 
-        public void CancelNotif (int handle)
+        public void ScheduleNotification (int handle, DateTime when, string message)
         {
             NcAssert.True (false);
         }
 
-        public void CancelNotif (List<int> handles)
+        public void ScheduleNotification (NotificationInfo notification)
+        {
+            ScheduleNotification (notification.Handle, notification.When, notification.Message);
+        }
+
+        public void ScheduleNotifications (List<NotificationInfo> notifications)
+        {
+            foreach (var notification in notifications) {
+                ScheduleNotification (notification);
+            }
+        }
+
+        public void CancelNotification (int handle)
         {
             NcAssert.True (false);
+        }
+
+        public static void DumpNotifications ()
+        {
         }
     }
 }

--- a/NachoClient.Android/NachoPlatform/IPlatform.cs
+++ b/NachoClient.Android/NachoPlatform/IPlatform.cs
@@ -79,11 +79,59 @@ namespace NachoPlatform
         void Invoke (Action action);
     }
 
+    /// <summary>
+    /// Information necessary for a notification of an upcoming event.
+    /// </summary>
+    public struct NotificationInfo
+    {
+        public int Handle;
+        public DateTime When;
+        public string Message;
+        public NotificationInfo (int handle, DateTime when, string message)
+        {
+            Handle = handle;
+            When = when;
+            Message = message;
+        }
+    }
+
+    /// <summary>
+    /// Local notifications.  Used to inform the user about events in the near future.
+    /// </summary>
     public interface IPlatformNotif
     {
-        void ScheduleNotif (int handle, DateTime when, string message);
-        void CancelNotif (int handle);
-        void CancelNotif (List<int> handles);
+        /// <summary>
+        /// Notify the user right away.
+        /// </summary>
+        void ImmediateNotification (int handle, string message);
+
+        /// <summary>
+        /// Schedule a notification some time in the future.
+        /// </summary>
+        /// <param name="handle">An identifier that can be used to cancel the notification.</param>
+        /// <param name="when">When the notification should happen.</param>
+        /// <param name="message">The message to display to the user.</param>
+        void ScheduleNotification (int handle, DateTime when, string message);
+
+        /// <summary>
+        /// Schedule a notification some time in the future.
+        /// </summary>
+        void ScheduleNotification (NotificationInfo notification);
+
+        /// <summary>
+        /// Schedule a set of notifications. This might replace all existing
+        /// notifications with the new notifications, or it might merge the
+        /// new notifications in with the existing ones.
+        /// </summary>
+        /// <remarks>iOS and Android have very different capabilities for
+        /// local notifications, which makes it difficult to nail down the
+        /// exact behavior of this method.</remarks>
+        void ScheduleNotifications (List<NotificationInfo> notifications);
+
+        /// <summary>
+        /// Cancel the scheduled notification with the given handle.
+        /// </summary>
+        void CancelNotification (int handle);
     }
 
     public abstract class PlatformContactRecord

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -867,7 +867,7 @@ namespace NachoClient.iOS
             var c = McCalendar.QueryById<McCalendar> (e.CalendarId);
             var notif = new UILocalNotification () {
                 AlertAction = null,
-                AlertBody = c.Subject + Pretty.FormatAlert (7),
+                AlertBody = c.Subject + Pretty.ReminderTime (new TimeSpan (0, 7, 0)),
                 UserInfo = NSDictionary.FromObjectAndKey (NSNumber.FromInt32 (c.Id), EventNotificationKey),
                 FireDate = NSDate.FromTimeIntervalSinceNow (15),
             };

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1174,6 +1174,9 @@
     <Compile Include="..\NachoClient.Android\NachoCore\Utils\EmailHelper.cs">
       <Link>NachoCore\Utils\EmailHelper.cs</Link>
     </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Utils\LocalNotificationManager.cs">
+      <Link>NachoCore\Utils\LocalNotificationManager.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -1340,10 +1340,6 @@ namespace NachoClient.iOS
 
         protected void DeleteEvent ()
         {
-            Notif eventNotif = Notif.Instance;
-            if (null != eventNotif.FindNotif (c.Id)) {
-                eventNotif.CancelNotif (c.Id);
-            }
             //remove item from db
             BackEnd.Instance.DeleteCalCmd (account.Id, c.Id);
             var controllers = this.NavigationController.ViewControllers;

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -1425,11 +1425,6 @@ namespace NachoClient.iOS
         {
             NavigationController.PopViewControllerAnimated (true);
 
-            // Cancel notification if there is one
-            Notif eventNotif = Notif.Instance;
-            if (null != eventNotif.FindNotif (c.Id)) {
-                eventNotif.CancelNotif (c.Id);
-            }
             // Remove the item from the calendar.
             BackEnd.Instance.DeleteCalCmd (c.AccountId, c.Id);
         }

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyCalendarView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyCalendarView.cs
@@ -900,11 +900,6 @@ namespace NachoClient.iOS
                     removeFromCalendarButton.Hidden = true;
                 });
 
-            // Cancel notification if there is one
-            Notif eventNotif = Notif.Instance;
-            if (null != eventNotif.FindNotif (calendarItem.Id)) {
-                eventNotif.CancelNotif (calendarItem.Id);
-            }
             // Remove the item from the calendar.
             BackEnd.Instance.DeleteCalCmd (calendarItem.AccountId, calendarItem.Id);
         }


### PR DESCRIPTION
Manage the scheduling of local notifications.  Because iOS has a limit
on the number of scheduled notifications, we can't just schedule the
notification for an event when the event is first created.

Class LocalNotificationManager manages the scheduling of local
notifications.  It queries the McEvents in the database to find the
ones with upcoming reminders, and schedules the notifications for a
reasonable number of the next reminders.

Fix #1194
