### PR TITLE
Handle task and operation canceled exceptions properly.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -110,6 +110,11 @@ namespace NachoCore.Utils
                     isDone = true;
                 } catch (Exception e) {
                     if (!HandleAWSException (e)) {
+                        if (NcTask.Cts.Token.IsCancellationRequested) {
+                            Client.Dispose ();
+                            Client = null;
+                            NcTask.Cts.Token.ThrowIfCancellationRequested ();
+                        }
                         throw;
                     }
                     NcTask.CancelableSleep (5000);
@@ -261,6 +266,11 @@ namespace NachoCore.Utils
                 action ();
             } catch (Exception e) {
                 if (!HandleAWSException (e)) {
+                    if (NcTask.Cts.Token.IsCancellationRequested) {
+                        Client.Dispose ();
+                        Client = null;
+                        NcTask.Cts.Token.ThrowIfCancellationRequested ();
+                    }
                     throw;
                 }
                 return false;


### PR DESCRIPTION
In some cases, TaskCanceledException and OperationCanceledException are wrapped inside AggregateException like this:

**\* Terminating app due to uncaught exception 'System.AggregateException: One or more errors occurred', reason: 'System.AggregateException: One or more errors occurred ---> System.AggregateException: One or more errors occurred ---> System.Threading.Tasks.TaskCanceledException: The Task was canceled

HandleAWSException correctly decides this is not an exception that is not caught. So, it rethrows in AwsSendEvent(). The problem is that the C# run-times does not see the inner exception and cancels the task.

The fix is to check the token if cancellation has already occurred. If yes, just throw a new exception. Also, dispose the old AWS client (in case it has any HTTP client task still running).
