### PR TITLE
Handle missing time zone name in event time zones

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsTimeZone.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsTimeZone.cs
@@ -101,9 +101,22 @@ namespace NachoCore.ActiveSync
                     new TimeSpan (-((DaylightBias - StandardBias) * TimeSpan.TicksPerMinute)),
                     transitionToDaylight, transitionToStandard);
 
+                string timeZoneID;
+                string displayName;
+                string standardName;
+                if (string.IsNullOrEmpty (StandardName)) {
+                    timeZoneID = "CustomID";
+                    displayName = "Custom Time Zone";
+                    standardName = "Standard";
+                } else {
+                    timeZoneID = StandardName;
+                    displayName = StandardName;
+                    standardName = StandardName;
+                }
+                string daylightName = string.IsNullOrEmpty(DaylightName) ? "Daylight" : DaylightName;
                 return TimeZoneInfo.CreateCustomTimeZone (
-                    StandardName, new TimeSpan (-((Bias + StandardBias) * TimeSpan.TicksPerMinute)),
-                    StandardName, StandardName, DaylightName,
+                    timeZoneID, new TimeSpan (-((Bias + StandardBias) * TimeSpan.TicksPerMinute)),
+                    displayName, standardName, daylightName,
                     new TimeZoneInfo.AdjustmentRule[] { adjustment });
 
             } catch (ArgumentException e) {


### PR DESCRIPTION
The time zone information in calendar events sometimes has an empty
name field.  That was causing an exception when creating a C#
TimeZoneInfo object.  Change the code to protect against this
situation.

Fix #1155
