### PR TITLE
More aggressive brain processing for initial sync

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrainControl.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainControl.cs
@@ -3,11 +3,14 @@
 using System;
 using NachoPlatform;
 using NachoCore.Utils;
+using NachoCore.Model;
 
 namespace NachoCore.Brain
 {
     public partial class NcBrain
     {
+        private bool Bootstrapped;
+
         // Amount of "thinking" per background invocation
         private int WorkCredits;
 
@@ -30,12 +33,38 @@ namespace NachoCore.Brain
                 Console.WriteLine ("Plugged in, work_credit={0}", WorkCredits);
             } else {
                 double level = Power.Instance.BatteryLevel;
-                if (level < 0.3) {
-                    WorkCredits = 0;
-                } else if (level < 0.6) {
-                    WorkCredits = 10;
+                if (!Bootstrapped) {
+                    int numScored = McEmailMessage.CountByVersion (Scoring.Version);
+                    int numTotal = McEmailMessage.Count ();
+                    double percentageScored = 0.0;
+                    if (0 < numTotal) {
+                        percentageScored = Math.Min (1.0, (double)numScored / (double)numTotal);
+                    }
+                    if (0.75 <= percentageScored) {
+                        Bootstrapped = true;
+                    }
+                }
+                if (!Bootstrapped &&
+                    (NcApplication.ExecutionContextEnum.Foreground == NcApplication.Instance.ExecutionContext)) {
+                    // If brain is not fully initialized, we want to run brain more aggressively.
+                    // "Not fully initialized" is defined as less than 50% of the emails are fully scored.
+                    if (level < 0.10) {
+                        WorkCredits = 0;
+                    } else if (level < 0.3) {
+                        WorkCredits = 10;
+                    } else if (level < 0.5) {
+                        WorkCredits = 20;
+                    } else {
+                        WorkCredits = 30;
+                    }
                 } else {
-                    WorkCredits = 20;
+                    if (level < 0.3) {
+                        WorkCredits = 0;
+                    } else if (level < 0.6) {
+                        WorkCredits = 10;
+                    } else {
+                        WorkCredits = 20;
+                    }
                 }
                 Log.Debug (Log.LOG_BRAIN, "On battery, power_level={0}, work_credit={1}", level, WorkCredits);
                 Console.WriteLine ("On battery, power_level={0}, work_credit={1}", level, WorkCredits);

--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/EmailMessageScore.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/EmailMessageScore.cs
@@ -299,6 +299,17 @@ namespace NachoCore.Model
             return table.FirstOrDefault ();
         }
 
+        public static int CountByVersion (int version)
+        {
+            return NcModel.Instance.Db.Table<McEmailMessage> ().Where (x => x.ScoreVersion == version).Count ();
+        }
+
+        public static int Count ()
+        {
+            return NcModel.Instance.Db.Table<McEmailMessage> ().Count ();
+        }
+
+
         /// <summary>
         /// Evaluate the parameters in McEmailMessage and produce a list of 
         /// NcTimeVariance that applies. These NcTimeVariance do not need to be 


### PR DESCRIPTION
- When the app is foreground and less than 75% of all emails are scored. Using a different schedule that allows brain to process more items.
- Note it checks for the # of emails that has the latest version. So, this schedule applies for a new version of the client that has a new scoring scheme as well.
