### PR TITLE
Adjust the Options used in Sync and Fetch requests

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
+++ b/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
@@ -147,41 +147,6 @@ namespace NachoCore.Utils
             return null;
         }
 
-        static public string ExtractSummary (McEmailMessage message)
-        {
-            var body = message.GetBody ();
-
-            if (!McBody.IsComplete (body)) {
-                return "";
-            }
-
-            if (McAbstrFileDesc.BodyTypeEnum.None == body.BodyType) {
-                return "";
-            }
-
-            if (McAbstrFileDesc.BodyTypeEnum.HTML_2 == body.BodyType) {
-                return "";
-            }
-
-            if (McAbstrFileDesc.BodyTypeEnum.RTF_3 == body.BodyType) {
-                return "";
-            }
-
-            string text;
-            if (McAbstrFileDesc.BodyTypeEnum.PlainText_1 == body.BodyType) {
-                text = body.GetContentsString ();
-            } else {
-                NcAssert.True (McAbstrFileDesc.BodyTypeEnum.MIME_4 == body.BodyType);
-                text = ExtractTextPart (McBody.QueryById<McBody> (message.BodyId));
-            }
-            if (null == text) {
-                return "";
-            }
-            var raw = text.Substring (0, Math.Min (text.Length, 1000));
-            var cooked = System.Text.RegularExpressions.Regex.Replace (raw, @"\s+", " ");
-            return cooked;
-        }
-
         /// <summary>
         /// Returns the plain text part of a message body, an error message if the body is in
         /// a format other than plain text, or <code>null</code> if no body can be found.

--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -541,10 +541,6 @@ namespace NachoClient.iOS
             // Preview label view
             var previewLabelView = cell.ContentView.ViewWithTag (PREVIEW_TAG) as UILabel;
             previewLabelView.Hidden = false;
-            if (null == message.BodyPreview) {
-                message.BodyPreview = MimeHelpers.ExtractSummary (message);
-                message.Update ();
-            }
             var rawPreview = message.GetBodyPreviewOrEmpty ();
             var cookedPreview = System.Text.RegularExpressions.Regex.Replace (rawPreview, @"\s+", " ");
             previewLabelView.AttributedText = new NSAttributedString (cookedPreview);


### PR DESCRIPTION
Evaluate the Options that the app sends in sync requests for the
calendars and e-mail, and in the fetch request for an e-mail message.
Adjust the options to get the best behavior possible.  Unfortunately,
to work around quirks and limitations in the servers, this resulted in
using different options for different servers.

When synching an e-mail folder, the app wants to get the message
preview but does not want to receive the body.  For servers that
support previews, the app asks for MIME with a truncation size of zero
(so no body is actually sent) and sets the preview flag.  For servers
that don't provide any previews (GFE and Exchange 2007), the app asks
for plain text truncated at 255 bytes.  This possibly truncated plain
text body is used only to set the message's preview and is not saved
as the message's body.

When fetching an individual e-mail message, the app wants the entire
body and wants it as MIME.  (Some messages display better if we have
them as MIME, and none of the servers will send MIME unless the client
explicitly demands it.)  The existing code already did this, so in the
end those options were not changed.

When synching the calendar, the app wants the bodies for the event
descriptions as part of the sync.  The app also wants the bodies as
MIME.  But some servers (GFE, Hotmail, and Exchange 2007) only deliver
event bodies as plain text.  So the options for synching the calendar
were changed to request either MIME or plain text, depending on the
server.

This update only looked at e-mail and calendars.  Similar analysis
should be done for contacts, and maybe for tasks.

Fix #1189
Fix #1152
Fix #1264 
