### PR TITLE
Minor improvements to speed up launch / foregrounding

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -463,6 +463,8 @@ namespace NachoCore.Brain
                 // If brain task is running under quick sync, do not start time variance
                 // as it is a waste of time.
                 if (NcApplication.ExecutionContextEnum.QuickSync != NcApplication.Instance.ExecutionContext) {
+                    // Defer the processing until Nacho Nov view shows up.
+                    NcTask.CancelableSleep (4000);
                     McEmailMessage.StartTimeVariance (EventQueue.Token);
                     tvStarted = true;
                 }

--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -20,14 +20,14 @@ namespace NachoCore.Model
         private bool DidDispose;
 
         public NcSQLiteConnection (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = false) :
-        base (databasePath, openFlags, storeDateTimeAsTicks)
+            base (databasePath, openFlags, storeDateTimeAsTicks)
         {
             LockObj = new object ();
             LastAccess = DateTime.UtcNow;
         }
 
         public NcSQLiteConnection (string databasePath, bool storeDateTimeAsTicks = false) :
-        base (databasePath, storeDateTimeAsTicks)
+            base (databasePath, storeDateTimeAsTicks)
         {
             LockObj = new object ();
             LastAccess = DateTime.UtcNow;
@@ -352,7 +352,7 @@ namespace NachoCore.Model
                     }
                      */
                 }
-            }, null, 1000, 1000);
+            }, null, 4000, 1000);
             CheckPointTimer.Stfu = true;
         }
 


### PR DESCRIPTION
Defer the initial WAL checkpoint / integrity test and brain initialization in order to reduce processing before Now view is shown.
