### PR TITLE
Fix #1261

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -811,6 +811,7 @@ namespace NachoCore.Utils
                         if (MAX_IDLE_PERIOD < (DateTime.Now - then).TotalSeconds) {
                             Log.Info (Log.LOG_UTILS, "Telemetry has no event for more than {0} seconds",
                                 MAX_IDLE_PERIOD);
+                            then = DateTime.Now;
                         }
                     }
                     continue;


### PR DESCRIPTION
- There is already a console log that indicates telemetry idle for more than 30 seconds. Just need to convert that to a telemetry log.
- Also, piggyback a change to rate limit the "fail to reach telemetry server" log to roughly one per minute.
