### PR TITLE
Fix #1279.  Add a dot to the header to highlight an unread message.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
@@ -49,6 +49,7 @@ namespace NachoClient.iOS
         protected const int MESSAGE_HEADER_TAG = 99107;
         protected const int TOOLBAR_TAG = 99109;
         protected const int USER_MORE_TAG = 99110;
+        protected const int UNREAD_IMAGE_TAG = 99111;
 
         public HotListTableViewSource (IMessageTableViewSourceDelegate owner, INachoEmailMessages messageThreads)
         {
@@ -151,6 +152,15 @@ namespace NachoClient.iOS
             userLabelView.Layer.MasksToBounds = true;
             userLabelView.Tag = USER_LABEL_TAG;
             view.AddSubview (userLabelView);
+
+            // Unread message dot
+            var unreadMessageView = new UIImageView (new Rectangle (5, 30, 9, 9));
+            using (var image = UIImage.FromBundle ("SlideNav-Btn")) {
+                unreadMessageView.Image = image;
+            }
+            unreadMessageView.BackgroundColor = UIColor.White;
+            unreadMessageView.Tag = UNREAD_IMAGE_TAG;
+            view.AddSubview (unreadMessageView);
 
             var messageHeaderView = new MessageHeaderView (new RectangleF (65, 0, viewWidth - 65, 75));
             messageHeaderView.CreateView ();
@@ -333,6 +343,9 @@ namespace NachoClient.iOS
                 userLabelView.Text = message.cachedFromLetters;
                 userLabelView.BackgroundColor = Util.ColorForUser (message.cachedFromColor);
             }
+
+            var unreadMessageView = (UIImageView) cell.ContentView.ViewWithTag (UNREAD_IMAGE_TAG);
+            unreadMessageView.Hidden = message.IsRead;
 
             var messageHeaderView = view.ViewWithTag (MESSAGE_HEADER_TAG) as MessageHeaderView;
             messageHeaderView.ConfigureView (message);

--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageHeaderView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageHeaderView.cs
@@ -126,8 +126,11 @@ namespace NachoClient.iOS
             if (String.IsNullOrEmpty (message.Subject)) {
                 subjectLabelView.Text = Pretty.NoSubjectString ();
                 subjectLabelView.TextColor = A.Color_9B9B9B;
+                subjectLabelView.Font = A.Font_AvenirNextRegular17;
             } else {
+                subjectLabelView.TextColor = A.Color_0F424C;
                 subjectLabelView.Text = Pretty.SubjectString (message.Subject);
+                subjectLabelView.Font = A.Font_AvenirNextRegular17;
             }
             subjectLabelView.Hidden = false;
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -201,6 +201,7 @@ namespace NachoClient.iOS
         protected const int REMINDER_ICON_TAG = 99105;
         protected const int REMINDER_TEXT_TAG = 99106;
         protected const int MESSAGE_HEADER_TAG = 99107;
+        protected const int UNREAD_IMAGE_TAG = 99108;
 
         [MonoTouch.Foundation.Export ("ImageViewTapSelector:")]
         public void ImageViewTapSelector (UIGestureRecognizer sender)
@@ -350,6 +351,15 @@ namespace NachoClient.iOS
                 userLabelView.Tag = USER_LABEL_TAG;
                 imageViews.AddSubview (userLabelView);
                 userLabelView.BackgroundColor = UIColor.Yellow;
+
+                // Unread message dot
+                var unreadMessageView = new UIImageView (new Rectangle (4, 35, 9, 9));
+                using (var image = UIImage.FromBundle ("SlideNav-Btn")) {
+                    unreadMessageView.Image = image;
+                }
+                unreadMessageView.BackgroundColor = UIColor.White;
+                unreadMessageView.Tag = UNREAD_IMAGE_TAG;
+                imageViews.AddSubview (unreadMessageView);
 
                 // Set up multi-select on checkmark
                 var imagesViewTap = new UITapGestureRecognizer ();
@@ -529,6 +539,9 @@ namespace NachoClient.iOS
                 userLabelView.Text = message.cachedFromLetters;
                 userLabelView.BackgroundColor = Util.ColorForUser (message.cachedFromColor);
             }
+
+            var unreadMessageView = (UIImageView) cell.ContentView.ViewWithTag (UNREAD_IMAGE_TAG);
+            unreadMessageView.Hidden = message.IsRead;
 
             var messageHeaderView = cell.ContentView.ViewWithTag (MESSAGE_HEADER_TAG) as MessageHeaderView;
             messageHeaderView.ConfigureView (message);


### PR DESCRIPTION
Fix #1279.  Add a dot to the header to highlight an unread message.  Create the dot.  Show or hide it based on whether the message is unread or not.  The dot is not part of the MessageHeader so the code is duplicated, just like the user image & label fields.  That's for another day.
