### PR TITLE
Fix #1302.  Typo.  Use exceptions from the list.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
@@ -958,8 +958,8 @@ namespace NachoCore.Utils
                 var exceptions = McException.QueryForExceptionId (c.Id, start);
                 if (0 < exceptions.Count) {
                     foreach (var ex in exceptions) {
-                        DateTime exceptionStart = DateTime.MinValue == exception.StartTime ? start : exception.StartTime;
-                        DateTime exceptionEnd = DateTime.MinValue == exception.EndTime ? end : exception.EndTime;
+                        DateTime exceptionStart = DateTime.MinValue == ex.StartTime ? start : ex.StartTime;
+                        DateTime exceptionEnd = DateTime.MinValue == ex.EndTime ? end : ex.EndTime;
                         ExpandAllDayEvent (c, exceptionStart, exceptionEnd, ex);
                     }
                     return;


### PR DESCRIPTION
The code was dereferencing the variablle 'exception' which we can see from the test is null.  Use 'ex' instead.
