### PR TITLE
Fix problem of scrolling event descriptions with HTML

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -1390,7 +1390,8 @@ namespace NachoClient.iOS
             // BodyView needs to know when scrolling happens, so it can do its magic and make sure
             // the correct stuff is visible.
             descriptionView.ScrollingAdjustment (new PointF (
-                scrollView.ContentOffset.X - descriptionView.Frame.X, scrollView.ContentOffset.Y - descriptionView.Frame.Y));
+                scrollView.ContentOffset.X - (eventCardView.Frame.X + descriptionView.Frame.X),
+                scrollView.ContentOffset.Y - (eventCardView.Frame.Y + descriptionView.Frame.Y)));
         }
 
         private void AttendeeTapGestureRecognizerTap ()


### PR DESCRIPTION
When an event with an HTML description was scrolled, the description
would disappear before reaching the top of the screen.  This change
fixes that problem.  The code in
EventViewController.ScrollViewScrolled that was calculating the offset
of the BodyView was using the offset of the BodyView within
eventCardView, but was forgetting about the offset of eventCardView
within scrollView.

This fixes one of the two problems in 1284. The other problem is still
there, so the issue can't be closed yet.
