### PR TITLE
Fix problem of initial size of event descriptions with HTML

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -100,10 +100,17 @@ namespace NachoClient.iOS
             NcApplication.Instance.StatusIndEvent -= StatusIndicatorCallback;
             EvaluateJavascript (string.Format(magic, preferredWidth));
             // Force a re-layout of this web view now that the JavaScript magic has been applied.
-            ViewFramer.Create (this).Height (Frame.Height - 1);
-            // And force a re-layout of the entire BodyView now that the size of this web view is known.
+            // The ScrollView.ContentSize is never smaller than the frame size, so in order to
+            // figure out how big the content really is, we have to set the frame height to a
+            // small number.
+            ViewFramer.Create (this).Height (1);
+            // Force a re-layout of the entire BodyView now that the size of this web view is known.
+            // This web view's frame will be adjusted as part of that.
             if (null != sizeChangedCallback) {
                 sizeChangedCallback ();
+            } else {
+                // There is no callback to force the BodyView to re-layout.
+                ViewFramer.Create (this).Height (ScrollView.ContentSize.Height);
             }
         }
 


### PR DESCRIPTION
When an event has a small HTML description, the initial layout of the
event detail view would get the size of the description wrong, making
it one entire screen high.  This extra white space would not go away
until the user scrolled the view.

The problem was triggered by a misunderstanding of one of the details
of how scroll views work.  I had assumed that
UIWebView.ScrollView.ContentSize.Height was always the natural height
of the rendered HTML, regardless of the UIWebView's frame size.
That's not true. The ContentSize.Height might be larger than the
frame's height, but it will never be smaller than the frame's height.
This meant that the BodyWebView was not being shrunk to its correct
height after the initial layout has completed.  The fix is to
temporarily set the UIWebView's height to 1, so we can find out the
natural height of the HTML content.

This bug was not noticed in message detail view because it is rare to
have content underneath the HTML section.  It was very obvious in the
event detail view because the description is always followed by
something else.

Fix #1284
