### PR TITLE
Fix #814

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -719,6 +719,14 @@ namespace NachoCore.Utils
             RecordSupport (dict);
         }
 
+        public static void StartService ()
+        {
+            #if __IOS__
+            // FIXME - Add AWS SDK for Android so we can actually run telemetry for Android.
+            SharedInstance.Start <TelemetryBEAWS> ();
+            #endif
+        }
+
         public void Start<T> () where T : ITelemetryBE, new()
         {
             if (!ENABLED) {
@@ -728,7 +736,7 @@ namespace NachoCore.Utils
                 NcTask.Run (() => {
                     Token = NcTask.Cts.Token;
                     Process<T> ();
-                }, "Telemetry");
+                }, "Telemetry", false, true);
             }
         }
 

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -253,7 +253,7 @@ namespace NachoClient.iOS
                     });
                 }
                 // Telemetry is in AppDelegate because the implementation is iOS-only right now.
-                Telemetry.SharedInstance.Start<TelemetryBEAWS> ();
+                Telemetry.StartService ();
             };
 
             Log.Info (Log.LOG_LIFECYCLE, "FinishedLaunching: NcApplication Class4LateShowEvent registered");

--- a/NachoClient.iOS/NachoUI.iOS/SupportMessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/SupportMessageViewController.cs
@@ -274,6 +274,7 @@ namespace NachoClient.iOS
                 supportInfo.Add ("ContactInfo", contactInfoTextField.Text);
                 supportInfo.Add ("Message", messageInfoTextView.Text);
 
+                Telemetry.StartService ();
                 Telemetry.RecordSupport (supportInfo, () => {
                     NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () { 
                         Status = NachoCore.Utils.NcResult.Info (NcResult.SubKindEnum.Info_TelemetrySupportMessageReceived),


### PR DESCRIPTION
- Start telemetry as soon as a support request is sent. So that if support request is sent in the first 15 sec after foreground (i.e. before Telemetry task starts), the request can be sent to telemetry server right away.
- Add a flag to NcTask.Run() to make it execute conditionally if there is no existing task by that name. This is to avoid two instances of telemetry tasks running.
