### PR TITLE
Show response bar in event detail view when user hasn't responded yet

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -1097,71 +1097,34 @@ namespace NachoClient.iOS
                 removeFromCalendarButton.Hidden = true;
                 rsvpSeparatorLine.Hidden = true;
                 return;
-            } else if (c.ResponseTypeIsSet) {
 
-                switch (c.ResponseType) {
+            } else {
 
-                case NcResponseType.Accepted:
-                    acceptButton.Selected = true;
-                    acceptButton.Hidden = false;
-                    acceptLabel.Hidden = false;
-                    tentativeButton.Hidden = false;
-                    declineButton.Hidden = false;
-                    tentativeLabel.Hidden = false;
-                    declineLabel.Hidden = false;
-                    //                    messageLabel.Text = "You are going";
-                    //                    messageLabel.Hidden = false;
-                    //                    changeResponseButton.Hidden = false;
-                    //                    acceptButton.Frame = new RectangleF (18, 18, 24, 24);
-                    //                    acceptLabel.Hidden = true;
-                    //                    tentativeButton.Hidden = true;
-                    //                    declineButton.Hidden = true;
-                    //                    tentativeLabel.Hidden = true;
-                    //                    declineLabel.Hidden = true;
-                    acceptButton.UserInteractionEnabled = false;
-                    break;
-
-                case NcResponseType.Tentative:
-                    tentativeButton.Selected = true;
-                    acceptButton.Hidden = false;
-                    acceptLabel.Hidden = false;
-                    tentativeButton.Hidden = false;
-                    declineButton.Hidden = false;
-                    tentativeLabel.Hidden = false;
-                    declineLabel.Hidden = false;
-                    //                    messageLabel.Text = "Tentative";
-                    //                    messageLabel.Hidden = false;
-                    //                    changeResponseButton.Hidden = false;
-                    //                    tentativeButton.Frame = new RectangleF (18, 18, 24, 24);
-                    //                    acceptButton.Hidden = true;
-                    //                    acceptLabel.Hidden = true;
-                    //                    tentativeLabel.Hidden = true;
-                    //                    declineButton.Hidden = true;
-                    //                    declineLabel.Hidden = true;
-                    tentativeButton.UserInteractionEnabled = false;
-                    break;
-
-                case NcResponseType.Declined:
-                    declineButton.Selected = true;
-                    acceptButton.Hidden = false;
-                    acceptLabel.Hidden = false;
-                    tentativeButton.Hidden = false;
-                    declineButton.Hidden = false;
-                    tentativeLabel.Hidden = false;
-                    declineLabel.Hidden = false;
-                    //                    messageLabel.Text = "You are not going to this meeting";
-                    //                    messageLabel.Hidden = false;
-                    //                    changeResponseButton.Hidden = false;
-                    //                    declineButton.Frame = new RectangleF (18, 18, 24, 24);
-                    //                    acceptButton.Hidden = true;
-                    //                    acceptLabel.Hidden = true;
-                    //                    tentativeButton.Hidden = true;
-                    //                    tentativeLabel.Hidden = true;
-                    //                    declineLabel.Hidden = true;
-                    declineButton.UserInteractionEnabled = false;
-                    break;
-                }
+                // Show the Accept, Decline, and Maybe buttons.
+                acceptButton.Hidden = false;
+                acceptLabel.Hidden = false;
+                tentativeButton.Hidden = false;
+                tentativeLabel.Hidden = false;
+                declineButton.Hidden = false;
+                declineLabel.Hidden = false;
                 rsvpSeparatorLine.Hidden = false;
+
+                if (c.ResponseTypeIsSet) {
+                    switch (c.ResponseType) {
+                    case NcResponseType.Accepted:
+                        acceptButton.Selected = true;
+                        acceptButton.UserInteractionEnabled = false;
+                        break;
+                    case NcResponseType.Tentative:
+                        tentativeButton.Selected = true;
+                        tentativeButton.UserInteractionEnabled = false;
+                        break;
+                    case NcResponseType.Declined:
+                        declineButton.Selected = true;
+                        declineButton.UserInteractionEnabled = false;
+                        break;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
In the event detail view, the response bar was missing when for
meetings where the user had not yet responded (or when the user had
responded but Nacho Mail doesn't know about it).  This was a simple
coding bug and was easy to fix.

Fix #1327
