### PR TITLE
Fix #1307 - Add GAL search to contact list and contact search view search.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactListViewController.cs
@@ -126,9 +126,14 @@ namespace NachoClient.iOS
         public void StatusIndicatorCallback (object sender, EventArgs e)
         {
             var s = (StatusIndEventArgs)e;
-            if ((NcResult.SubKindEnum.Info_ContactSetChanged == s.Status.SubKind) ||
-                (NcResult.SubKindEnum.Info_SearchCommandSucceeded == s.Status.SubKind)) {
+            if (NcResult.SubKindEnum.Info_ContactSetChanged == s.Status.SubKind) {
                 LoadContacts ();
+            }
+            if (NcResult.SubKindEnum.Info_SearchCommandSucceeded == s.Status.SubKind) {
+                LoadContacts ();
+                var sb = SearchDisplayController.SearchBar;
+                contactTableViewSource.UpdateSearchResults (sb.SelectedScopeButtonIndex, sb.Text, false);
+                SearchDisplayController.SearchResultsTableView.ReloadData ();
             }
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/ContactSearchViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactSearchViewController.cs
@@ -95,9 +95,14 @@ namespace NachoClient.iOS
         public void StatusIndicatorCallback (object sender, EventArgs e)
         {
             var s = (StatusIndEventArgs)e;
-            if ((NcResult.SubKindEnum.Info_ContactSetChanged == s.Status.SubKind) ||
-                (NcResult.SubKindEnum.Info_SearchCommandSucceeded == s.Status.SubKind)) {
+            if (NcResult.SubKindEnum.Info_ContactSetChanged == s.Status.SubKind) {
                 LoadContacts ();
+            }
+            if (NcResult.SubKindEnum.Info_SearchCommandSucceeded == s.Status.SubKind) {
+                LoadContacts ();
+                var sb = SearchDisplayController.SearchBar;
+                contactTableViewSource.UpdateSearchResults (sb.SelectedScopeButtonIndex, sb.Text, false);
+                SearchDisplayController.SearchResultsTableView.ReloadData ();
             }
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
@@ -601,17 +601,20 @@ namespace NachoClient.iOS
         /// <returns><c>true</c>, if search results are updated, <c>false</c> otherwise.</returns>
         /// <param name="forSearchOption">Index of the selected tab.</param>
         /// <param name="forSearchString">The prefix string to search for.</param>
-        public bool UpdateSearchResults (int forSearchOption, string forSearchString)
+        /// <param name="doGalSearch">True if it should issue a GAL search as well</param>.
+        public bool UpdateSearchResults (int forSearchOption, string forSearchString, bool doGalSearch = true)
         {
             NachoCore.Utils.NcAbate.HighPriority ("ContactTableViewSource UpdateSearchResults");
-            // Search GAL
-            if (null != account) {
+            if ((null != account) && doGalSearch) {
+                // Issue a GAL search. The status indication handler will update the search results
+                // (with doGalSearch = false) to reflect potential matches from GAL.
                 if (String.IsNullOrEmpty (searchToken)) {
                     searchToken = BackEnd.Instance.StartSearchContactsReq (account.Id, forSearchString, null);
                 } else {
                     BackEnd.Instance.SearchContactsReq (account.Id, forSearchString, null, searchToken);
                 }
             }
+            // We immeidately display matches from our db.
             var results = McContact.SearchAllContactItems (forSearchString);
             SetSearchResults (results);
             NachoCore.Utils.NcAbate.RegularPriority ("ContactTableViewSource UpdateSearchResults");


### PR DESCRIPTION
- During regular search update, issue a GAL search for the latest search string.
- In status indication handler, update the contact list and search result list for search command succeed event.
