### PR TITLE
Fix message detail response bar when there is no calendar event

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
@@ -937,7 +937,7 @@ namespace NachoCore.ActiveSync
 
         public override string RespondEmailCmd (int emailMessageId, NcResponseType response)
         {
-            return RespondItemCmd<McCalendar> (emailMessageId, response);
+            return RespondItemCmd<McEmailMessage> (emailMessageId, response);
         }
 
         public override string RespondCalCmd (int calId, NcResponseType response, DateTime? instance = null)
@@ -963,9 +963,9 @@ namespace NachoCore.ActiveSync
                 // 
                 // In this (these?) scenarios, update the Cal item in the DB, and Sync the change to the server.
                 //
-                var cal = item as McCalendar;
                 if (Xml.FolderHierarchy.TypeCode.DefaultInbox_2 != folder.Type &&
                 14.1 > Convert.ToDouble (ProtocolState.AsProtocolVersion)) {
+                    var cal = item as McCalendar;
                     if (null == cal) {
                         Log.Error (Log.LOG_AS, "Cannot respond to an email-invite message not in Inbox for older EAS ({0})", folder.Type);
                         return;

--- a/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
@@ -232,7 +232,21 @@ namespace NachoCore.Utils
 
         public static bool IsMailToURL (string urlString)
         {
-            return urlString.StartsWith ("mailto:", StringComparison.OrdinalIgnoreCase);
+            return urlString.StartsWith (Uri.UriSchemeMailto + ":", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static Uri MailToUri (string emailAddress)
+        {
+            return new Uri (Uri.UriSchemeMailto + ":" + emailAddress);
+        }
+
+        public static string EmailAddressFromUri (Uri mailtoUri)
+        {
+            if (Uri.UriSchemeMailto.Equals (mailtoUri.Scheme, StringComparison.OrdinalIgnoreCase)) {
+                return mailtoUri.AbsoluteUri.Substring (Uri.UriSchemeMailto.Length + 1);
+            } else {
+                return mailtoUri.ToString ();
+            }
         }
 
         /// <summary>

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -596,7 +596,7 @@ namespace NachoClient.iOS
 
         private void RenderCalendarPart (MimePart part)
         {
-            var calView = new BodyCalendarView (yOffset, preferredWidth, part, !UserInteractionEnabled);
+            var calView = new BodyCalendarView (yOffset, preferredWidth, item, part, !UserInteractionEnabled);
             AddSubview (calView);
             childViews.Add (calView);
             yOffset += calView.Frame.Height;


### PR DESCRIPTION
When there was a meeting request message in the inbox but no
corresponding calendar event, the Attend/Maybe/Decline buttons in the
message detail view were duds and had no effect.  This update fixes
that problem, and slightly changes the behavior even when there is a
calendar event.

The buttons for a meeting request in the message detail view now
always use the RespondEmail command instead of the RespondCal command.
A side effect of this change is that meeting request message is
deleted by the server once the user responds.

Meeting response messages are now assembled from the iCalendar
information in the meeting request rather than from the McCalendar
object.

(This update only affects the Attend/Maybe/Decline buttons in the
message detail view.  The behavior of the buttons in the event detail
view was not changed.)

Fix #1346
