### PR TITLE
Fix #1356.  Recent changes in the db code caught a case where

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NcDeviceContacts.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcDeviceContacts.cs
@@ -18,7 +18,7 @@ namespace NachoCore
         static bool running;
         static object lockObject = new object ();
 
-        private static void Process()
+        private static void Process ()
         {
             lock (lockObject) {
                 if (running) {
@@ -41,40 +41,42 @@ namespace NachoCore
             if (null == deviceContacts) {
                 return;
             }
-            Func<PlatformContactRecord, McContact> inserter = (deviceContact) => {
-                var result = deviceContact.ToMcContact ();
-                if (result.isOK ()) {
-                    var contact = result.GetValue<McContact> ();
-                    NcModel.Instance.RunInTransaction(() => {
-                        contact.Insert ();
-                        folder.Link (contact);
-                    });
-                    return contact;
-                } else {
-                    Log.Error (Log.LOG_SYS, "Failed to create McContact from device contact {0}", deviceContact.UniqueId);
-                    return null;
-                }
+            Func<McContact, McContact> inserter = (contact) => {
+                NcModel.Instance.RunInTransaction (() => {
+                    contact.Insert ();
+                    folder.Link (contact);
+                });
+                return contact;
+            };
+            Func<McContact, McContact> updater = (contact) => {
+                NcModel.Instance.RunInTransaction (() => {
+                    contact.Update ();
+                });
+                return contact;
             };
             List<McMapFolderFolderEntry> present = McMapFolderFolderEntry.QueryByFolderIdClassCode (folder.AccountId, folder.Id, 
-                McAbstrFolderEntry.ClassCodeEnum.Contact);
+                                                       McAbstrFolderEntry.ClassCodeEnum.Contact);
             foreach (var deviceContact in deviceContacts) {
                 // Use the TPL like iOS GCD here. Schedule chunks.
                 var task = NcTask.Run (() => {
                     var existing = McContact.QueryByDeviceUniqueId (deviceContact.UniqueId);
-                    if (null == existing) {
-                        // If missing, insert it.
-                        inserter.Invoke (deviceContact);
-                    } else {
-                        NcAssert.AreEqual (1, present.RemoveAll (x => x.FolderEntryId == existing.Id));
-                        // If present and stale, update it.
-                        if (deviceContact.LastUpdate > existing.DeviceLastUpdate) {
-                            NcModel.Instance.RunInTransaction(() => {
-                                if (null != inserter.Invoke (deviceContact)) {
-                                    folder.Unlink (existing);
-                                    existing.Delete ();
-                                }
-                            });
+                    if (null != existing) {
+                        var removed = present.RemoveAll (x => x.FolderEntryId == existing.Id);
+                        NcAssert.AreEqual (1, removed);
+                        if (deviceContact.LastUpdate <= existing.DeviceLastUpdate) {
+                            return;
                         }
+                    }
+                    var result = deviceContact.ToMcContact (existing);
+                    if (!result.isOK ()) {
+                        Log.Error (Log.LOG_SYS, "Failed to create McContact from device contact {0}", deviceContact.UniqueId);
+                        return;
+                    }
+                    var contact = result.GetValue<McContact> ();
+                    if (null == existing) {
+                        inserter.Invoke (contact);
+                    } else {
+                        updater.Invoke (contact);
                     }
                 }, "NcDeviceContacts:Process", true);
                 task.Wait (NcTask.Cts.Token);

--- a/NachoClient.Android/NachoPlatform/IPlatform.cs
+++ b/NachoClient.Android/NachoPlatform/IPlatform.cs
@@ -138,7 +138,7 @@ namespace NachoPlatform
     {
         public abstract string UniqueId { get; }
         public abstract DateTime LastUpdate { get; }
-        public abstract NcResult ToMcContact ();
+        public abstract NcResult ToMcContact (McContact contactToUpdate);
     }
 
     public interface IPlatformContacts

--- a/NachoClient.iOS/NachoPlatform.iOS/ContactsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/ContactsiOS.cs
@@ -37,26 +37,26 @@ namespace NachoPlatform
 
         public class PlatformContactRecordiOS : PlatformContactRecord
         {
-            public override string UniqueId { get { 
-                    return Person.Id.ToString (); 
-                } 
-            }
-            public override DateTime LastUpdate { get {
-                    return Person.ModificationDate.ToDateTime ();
-                }
-            }
+            public override string UniqueId { get { return Person.Id.ToString (); } }
+
+            public override DateTime LastUpdate { get { return Person.ModificationDate.ToDateTime (); } }
             // Person not to be referenced from platform independent code.
             public ABPerson Person { get; set; }
 
-            public override NcResult ToMcContact ()
+            public override NcResult ToMcContact (McContact contactToUpdate)
             {
                 var accountId = McAccount.GetDeviceAccount ().Id;
-                var contact = new McContact () {
-                    Source = McAbstrItem.ItemSource.Device,
-                    ServerId = "NachoDeviceContact:" + UniqueId,
-                    AccountId = accountId,
-                    OwnerEpoch = SchemaRev,
-                };
+                McContact contact;
+                if (null == contactToUpdate) {
+                    contact = new McContact () {
+                        Source = McAbstrItem.ItemSource.Device,
+                        ServerId = "NachoDeviceContact:" + UniqueId,
+                        AccountId = accountId,
+                        OwnerEpoch = SchemaRev,
+                    };
+                } else {
+                    contact = contactToUpdate;
+                }
                 contact.FirstName = Person.FirstName;
                 contact.LastName = Person.LastName;
                 contact.MiddleName = Person.MiddleName;


### PR DESCRIPTION
Fix #1356.  Recent changes in the db code caught a case where a device contact is being updated before deleting the contact that is being replaced (creating a duplicate of the same record, which is bad).  Now the code does an update in place because we want to preserve the item ID instead of generating a new ID with delete/insert, which also prevents the duplicate from being created.

Once this change is shaken out, we'll look for this pattern in device calendar imports.
