### PR TITLE
Log an error if the server creates a message about sync failure

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -839,6 +839,9 @@ namespace NachoCore.ActiveSync
                     if (!String.IsNullOrEmpty (emailMessage.Subject) && (emailMessage.Subject != child.Value)) {
                         Log.Error (Log.LOG_AS, "Subject overwritten with changed value: serverId={0} {1} {2}", emailMessage.ServerId, emailMessage.Subject, child.Value);
                     }
+                    if (child.Value.StartsWith ("Synchronization with your") && child.Value.Contains ("failed for")) {
+                        Log.Error (Log.LOG_AS, "Server reports that synchronization failed. The user was notified via an e-mail message.");
+                    }
                     emailMessage.Subject = child.Value;
                     break;
 


### PR DESCRIPTION
A couple weeks ago we had a bug there calendars were not getting
synched with Exchange 2007 servers, and the server was sending an
e-mail message to the user letting them know about the failure.  That
bug has been fixed, but we want to log an error message if the server
ever does that again, so we can spot the problem right away.

Fix #1338
