### PR TITLE
Edit event attachments ui bug fix

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -524,9 +524,7 @@ namespace NachoClient.iOS
             alertDetailLabel.Text = Pretty.ReminderString (c.ReminderIsSet, c.Reminder);
             alertDetailLabel.SizeToFit ();
 
-            if (0 != c.attachments.Count ()) {
-                hasAttachments = true;
-            }
+            hasAttachments = 0 != c.attachments.Count ();
             attachmentListView.Hidden = !hasAttachments;
             ConfigureAttachments ();
 
@@ -798,7 +796,7 @@ namespace NachoClient.iOS
                 };
                 return;
             }
-                
+
             if (segue.Identifier.Equals ("EventToNotes")) {
                 var dc = (NotesViewController)segue.DestinationViewController;
                 dc.SetOwner (this, true);
@@ -878,7 +876,7 @@ namespace NachoClient.iOS
                 AdjustViewLayout (TagType.EVENT_LOCATION_TITLE_TAG, 0, ref internalYOffset, 18, EVENT_CARD_WIDTH - 100);
                 AdjustViewLayout (TagType.EVENT_LOCATION_DETAIL_LABEL_TAG, 42, ref internalYOffset, 5, EVENT_CARD_WIDTH - 60);
             }
-                
+
             AdjustViewLayout (TagType.EVENT_DESCRIPTION_TITLE_TAG, 0, ref internalYOffset, 18, EVENT_CARD_WIDTH - 100);
             if (yOffset != descriptionView.Frame.Y) {
                 ViewFramer.Create (descriptionView).Y (internalYOffset);

--- a/NachoClient.sln
+++ b/NachoClient.sln
@@ -530,6 +530,7 @@ Global
 		{E301B932-D165-4A65-8916-3E80C000B6AC}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = NachoClient.iOS\NachoClient.iOS.csproj
 		Policies = $0
 		$0.StandardHeader = $1
 		$1.Text = @ Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.\n


### PR DESCRIPTION
When a user is viewing an event they created > edits the event > removes all attachments > returns to event view > attachments section is now hidden (was still visible before)  
