### PR TITLE
Fix upload of calendar events to Exchange 2007

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -152,7 +152,7 @@ namespace NachoCore.ActiveSync
             return (value) ? "1" : "0";
         }
 
-        public static XElement ToXmlApplicationData (McCalendar cal)
+        public static XElement ToXmlApplicationData (McCalendar cal, IBEContext beContext)
         {
             XNamespace AirSyncNs = Xml.AirSync.Ns;
             XNamespace CalendarNs = Xml.Calendar.Ns;
@@ -236,7 +236,7 @@ namespace NachoCore.ActiveSync
             // TODO: exceptions.
             // TODO recurrences.
 
-            if (cal.ResponseRequestedIsSet) {
+            if (cal.ResponseRequestedIsSet && 14.0 <= Convert.ToDouble (beContext.ProtocolState.AsProtocolVersion)) {
                 xmlAppData.Add (new XElement (CalendarNs + Xml.Calendar.ResponseRequested, XmlFromBool (cal.ResponseRequested)));
             }
             if (cal.DisallowNewTimeProposalIsSet) {

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
@@ -109,7 +109,7 @@ namespace NachoCore.ActiveSync
                 McAbstrFolderEntry.ClassCodeEnum.Calendar) {
                 add.Add (new XElement (m_ns + Xml.AirSync.Class, Xml.AirSync.ClassCode.Calendar));
             }
-            add.Add (AsHelpers.ToXmlApplicationData (cal));
+            add.Add (AsHelpers.ToXmlApplicationData (cal, BEContext));
             return add;
         }
 
@@ -118,7 +118,7 @@ namespace NachoCore.ActiveSync
             var cal = McCalendar.QueryById<McCalendar> (pending.ItemId);
             return new XElement (m_ns + Xml.AirSync.Change, 
                 new XElement (m_ns + Xml.AirSync.ServerId, pending.ServerId),
-                AsHelpers.ToXmlApplicationData (cal));
+                AsHelpers.ToXmlApplicationData (cal, BEContext));
         }
 
         private XElement ToCalDelete (McPending pending, McFolder folder)


### PR DESCRIPTION
Calendar events created in Nacho Mail were not being synched to an
Exchange 2007 server.  The server was rejecting the Sync command
because of the ResponseRequested field in the event data.  That field
was added in protocol version 14.0, but a 2007 server is on protocol
version 12.1.

Fix #1297
