### PR TITLE
Don't crash when accepting a meeting or editing a meeting

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
@@ -295,7 +295,11 @@ namespace NachoCore.Utils
             newEvent.Start = evt.Start;
             newEvent.End = evt.End;
             newEvent.IsAllDay = evt.IsAllDay;
-            newEvent.Priority = evt.Priority;
+            // The Priority of the existing event cannot be accessed.  Doing so will
+            // crash the app when running on a device (but not on the simulator. See
+            // http://developer.xamarin.com/guides/ios/advanced_topics/limitations/
+            // Priority is essentially a write-only property.
+            newEvent.Priority = 5; // evt.Priority;
             newEvent.Location = evt.Location;
             newEvent.Status = EventStatus.Confirmed;
             newEvent.Class = "PUBLIC";


### PR DESCRIPTION
An iOS limitation makes it difficult to use generics with value type
arguments.  The DDay.iCal code uses generics with value type
arguments.  We need to be careful to avoid calling that DDay.iCal
code.  If we aren't careful, the app will crash when run on a real
device (but not on the simulator).

Fix #1382
Fix #1388
