### PR TITLE
Don't crash when editing GFE meetings

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -352,8 +352,8 @@ namespace NachoCore.ActiveSync
                     status = statusElement.Value.ToEnum<NcAttendeeStatus> ();
                 }
 
-                // Optional
-                NcAttendeeType type = NcAttendeeType.Unknown;
+                // Optional.  Default is Required.  (At least that's how GFE behaves.)
+                NcAttendeeType type = NcAttendeeType.Required;
                 var typeElement = attendee.Element (ns + Xml.Calendar.Attendee.AttendeeType);
                 if (null != typeElement) {
                     type = typeElement.Value.ToEnum<NcAttendeeType> ();


### PR DESCRIPTION
When the GFE server syncs a meeting to the client, it leaves out the
AttendeeType field for required attendees.  Our code was asserting
that the attendee field was always being exlicitly set.  Change the
code that parses attendees to assume that an attendee is required if
there is no AttendeeType field.

Fix #1386
Fix #1215
Fix #1214
