### PR TITLE
Fix #1411. In the MessageTableViewSource, the ConfigureMessageCell should...

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -477,7 +477,7 @@ namespace NachoClient.iOS
             cell.TextLabel.Text = "";
             cell.ContentView.Hidden = false;
 
-            var cellWidth = cell.Frame.Width;
+            var cellWidth = tableView.Frame.Width;
 
             var view = cell.ContentView.ViewWithTag (SWIPE_TAG) as SwipeActionView;
             view.Frame = new RectangleF (0, 0, cellWidth, HeightForMessage (message));


### PR DESCRIPTION
... set the cell's width to be the same width as the table.
