### PR TITLE
Choose the correct calendar when creating a new event

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -1029,7 +1029,18 @@ namespace NachoClient.iOS
             var calFolder = new McFolder ();
             if (!calendarChanged) {
                 if (action == CalendarItemEditorAction.create) {
+                    // The new event should go in the default calendar.  (In most cases, there is only one
+                    // calendar folder.  But Hotmail does things differently, and choosing the correct
+                    // folder is vital.)  Start with the first calendar in the list, regardless of its
+                    // type.  But then look for a default calendar folder elsewhere in the calendar list.
                     calFolder = calendars.GetFolder (0);
+                    for (int i = 1; i < calendars.Count (); ++i) {
+                        var cal = calendars.GetFolder (i);
+                        if (Xml.FolderHierarchy.TypeCode.DefaultCal_8 == cal.Type) {
+                            calFolder = cal;
+                            break;
+                        }
+                    }
                 } else {
                     calFolder = GetCalendarFolder ();
                     if (null == calFolder) {


### PR DESCRIPTION
Hotmail creates three calendar folders for each user.  Two of them,
Birthdays and US Holidays, are read-only.  Any attempt to add an event
to those calendars will result in an sync failure.  When creating a
new calendar event, it is important that Nacho Mail choose the default
calendar folder for the event.  The user can change the calendar, but
the initial setting should be the default folder.  Change
EditEventViewController to find the default calendar folder among the
list of possible calendar folders when a new event is created.

Fix #1370
