### PR TITLE
New events should have a status of "Busy" rather than "Free"

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -1314,11 +1314,12 @@ namespace NachoClient.iOS
                 c.ResponseRequestedIsSet = true;
             }
 
-            // There is no UI for setting the BusyStatus.  For new events, set it to the default
-            // value of Busy.  If we don't explicitly set BusyStatus, some servers will treat it
-            // as if it were Free, while others will act as if it were Busy.
+            // There is no UI for setting the BusyStatus.  For new events, set it to Free for
+            // all-day events and Busy for other events.  If we don't explicitly set BusyStatus,
+            // some servers will treat it as if it were Free, while others will act as if it
+            // were Busy.
             if (!c.BusyStatusIsSet) {
-                c.BusyStatus = NcBusyStatus.Busy;
+                c.BusyStatus = allDayEvent ? NcBusyStatus.Free : NcBusyStatus.Busy;
                 c.BusyStatusIsSet = true;
             }
 


### PR DESCRIPTION
Nacho Mail was not setting the BusyStatus field on newly created
events.  Some servers would treat the meeting as if the user were
"Free", while others would treat it as "Busy".  There needs to be
consistency.

New events are now explicitly set to Busy.  Existing events that
already have a BusyStatus are left alone.  (There is no UI for the
user to pick a different BusyStatus, so new events will always be
Busy.)

Fix #1417
