### PR TITLE
Protect against a crash in NcMigration2

### DIFF
--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration2.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration2.cs
@@ -50,6 +50,9 @@ namespace NachoCore.Model
                 return 0;
             }
             var address = NcEmailAddress.ParseMailboxAddressString (addressString);
+            if (null == address) {
+                return 0;
+            }
             return ProcessAddress (accountId, objectId, address, addressType);
         }
 


### PR DESCRIPTION
The app is crashing during startup while upgrading the database.
Based on a stack dump in the console log, it looks like a null
reference exception when an e-mail address can't be parsed.  This
update will hopefully avoid the crash.
