### PR TITLE
Sort migrations to make sure they are applied in the right order.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration.cs
@@ -16,6 +16,24 @@ namespace NachoCore.Model
 
     public delegate void NcMigrationProgressUpdateFunction (float percentageComplete);
 
+    public class NcMigrationComparer : IComparer<NcMigration>
+    {
+        public NcMigrationComparer ()
+        {
+        }
+
+        public int Compare (NcMigration x, NcMigration y)
+        {
+            if (x.Version () < y.Version ()) {
+                return -1;
+            }
+            if (x.Version () > y.Version ()) {
+                return +1;
+            }
+            return 0;
+        }
+    }
+
     /// <summary>
     /// Base class for all migrations. Each migration is really a task that updates the database in some ways.
     /// </summary>
@@ -85,6 +103,9 @@ namespace NachoCore.Model
                             _migrations.Add (migration);
                         }
                     }
+
+                    // Sort the migration
+                    _migrations.Sort (new NcMigrationComparer ());
                 }
                 return _migrations;
             }


### PR DESCRIPTION
When I was testing with only two migrations, this bug does not show up because if migration1 is missed, migration2 fills in a migration version of 2 and migration1 is effectively skipped for the table. So, it ends up with the correct result. But when running with 3 migrations, without a sort, the order of applying the migration may be wrong.
