### PR TITLE
Fix #1466

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -117,8 +117,10 @@ namespace NachoCore.Utils
                 } catch (Exception e) {
                     if (!HandleAWSException (e)) {
                         if (NcTask.Cts.Token.IsCancellationRequested) {
-                            Client.Dispose ();
-                            Client = null;
+                            if (null != Client) {
+                                Client.Dispose ();
+                                Client = null;
+                            }
                             NcTask.Cts.Token.ThrowIfCancellationRequested ();
                         }
                         throw;


### PR DESCRIPTION
Client can be null if it is cancelled when it is retrying to connect to AWS. Check before disposing.
