### PR TITLE
Fix #1474

### DIFF
--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration.cs
@@ -106,6 +106,19 @@ namespace NachoCore.Model
 
                     // Sort the migration
                     _migrations.Sort (new NcMigrationComparer ());
+
+                    // If this is a fresh install, all migrations will be included because the table is empty
+                    // and it thinks no migration has been run.
+                    if (NcModel.Instance.FreshInstall) {
+                        var migrationRecord = new McMigration ();
+                        migrationRecord.Version = CurrentVersion;
+                        migrationRecord.StartTime = DateTime.UtcNow;
+                        migrationRecord.Finished = true;
+                        var rows = migrationRecord.Insert ();
+                        NcAssert.True (1 == rows);
+                        _migrations.Clear ();
+                        LastMigration = CurrentVersion;
+                    }
                 }
                 return _migrations;
             }

--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -65,6 +65,8 @@ namespace NachoCore.Model
         // RateLimiter PUBLIC FOR TEST ONLY.
         public NcRateLimter RateLimiter { set; get; }
 
+        public bool FreshInstall { protected set; get; }
+
         private const string KTmpPathSegment = "tmp";
         private const string KFilesPathSegment = "files";
 
@@ -270,6 +272,7 @@ namespace NachoCore.Model
             }), (IntPtr)null);
             Documents = Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments);
             DbFileName = Path.Combine (Documents, "db");
+            FreshInstall = !File.Exists (DbFileName);
             InitializeDb ();
             TeleDbFileName = Path.Combine (Documents, "teledb");
             InitializeTeleDb ();


### PR DESCRIPTION
If the db file does not exist, mark it as a fresh install. For a fresh install, clear all migrations and manually an record in McMigration for the current version. This avoids unnecessary migrations.
