### PR TITLE
Avoid ThreadPool related crash on startup on iPhone 4s

### DIFF
--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -149,8 +149,16 @@ namespace NachoCore
 
         private NcApplication ()
         {
-            NcAssert.True (ThreadPool.SetMinThreads (8, 6));
-            NcAssert.True (ThreadPool.SetMaxThreads (50, 16));
+            // SetMaxThreads needs to be called before SetMinThreads, because on some devices (such as
+            // iPhone 4s running iOS 7) the default maximum is less than the minimums we are trying to set.
+            // NcAssert.True can't be called here, because logging hasn't been set up yet, meaning a
+            // failure can't be properly reported.
+            if (!ThreadPool.SetMaxThreads (50, 16)) {
+                Console.WriteLine ("ERROR: ThreadPool maximums could not be set.");
+            }
+            if (!ThreadPool.SetMinThreads (8, 6)) {
+                Console.WriteLine ("ERROR: ThreadPool minimums could not be set.");
+            }
             TaskScheduler.UnobservedTaskException += (object sender, UnobservedTaskExceptionEventArgs eargs) => {
                 NcAssert.True (eargs.Exception is AggregateException, "AggregateException check");
                 var aex = (AggregateException)eargs.Exception;


### PR DESCRIPTION
The app was crashing during startup on iPhone 4s because the minimum
thread pool settings were greater than the default maximums.  Avoid
the problem by calling SetMaxThreads before SetMinThreads.

Also, don't use NcAssert in NcApplication's constructor, because
logging hasn't been set up yet and an assertion failure will result in
stack overflow.
