### PR TITLE
Don't crash when a message is deleted while it is being gleaned

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcContactGleaner.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcContactGleaner.cs
@@ -189,8 +189,13 @@ namespace NachoCore.Brain
             }
             if (!File.Exists (path)) {
                 var e2 = McEmailMessage.QueryById<McEmailMessage> (emailMessage.Id);
+                if (null == e2) {
+                    // E-mail message has been deleted while it was being processed.  This is rare, but it can happen.
+                    return;
+                }
                 var b2 = McBody.QueryById<McBody> (e2.BodyId);
-                Log.Error (Log.LOG_BRAIN, "Lost body: {0} == {1} and {2} == {3}", emailMessage.BodyId, body.Id, e2.BodyId, b2.Id);
+                Log.Error (Log.LOG_BRAIN, "Lost body: {0} == {1} and {2} == {3}",
+                    emailMessage.BodyId, body.Id, e2.BodyId, null == b2 ? 0 : b2.Id);
                 // FIXME: Let's not crash at the moment
                 MarkAsGleaned (emailMessage);
                 return;


### PR DESCRIPTION
Fix #1483 

Because the crash was caused by a race condition, I can't reproduce it and have no way to test it.  So please review it carefully.
