### PR TITLE
#1480. Do not assign NcModel object to instance until the write lock is set up.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -289,8 +289,9 @@ namespace NachoCore.Model
                 if (instance == null) {
                     lock (syncRoot) {
                         if (instance == null) {
-                            instance = new NcModel ();
-                            instance.WriteNTransLockObj = new object ();
+                            var newInstnace = new NcModel ();
+                            newInstnace.WriteNTransLockObj = new object ();
+                            instance = newInstnace;
                         }
                     }
                 }


### PR DESCRIPTION
It is theoretically possible for another thread to come in between the assignment of instance and set up of write lock and observe a partially set up NcModel.
