### PR TITLE
Move the termination check in front of the time variance start

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -479,15 +479,15 @@ namespace NachoCore.Brain
             lock (LockObj) {
                 while (true) {
                     var brainEvent = EventQueue.Dequeue ();
-                    if (!tvStarted &&
-                        (NcApplication.ExecutionContextEnum.Background == NcApplication.Instance.ExecutionContext ||
-                            NcApplication.ExecutionContextEnum.Foreground == NcApplication.Instance.ExecutionContext)) {
-                        McEmailMessage.StartTimeVariance (EventQueue.Token);
-                        tvStarted = true;
-                    }
                     if (NcBrainEventType.TERMINATE == brainEvent.Type) {
                         Log.Info (Log.LOG_BRAIN, "NcBrain Task exits");
                         return;
+                    }
+                    if (!tvStarted &&
+                        (NcApplication.ExecutionContextEnum.Background == NcApplication.Instance.ExecutionContext ||
+                        NcApplication.ExecutionContextEnum.Foreground == NcApplication.Instance.ExecutionContext)) {
+                        McEmailMessage.StartTimeVariance (EventQueue.Token);
+                        tvStarted = true;
                     }
                     // TODO - scheduling of brain actions need to be smarter. This will be
                     // addressed in brain 2.0.


### PR DESCRIPTION
Spot this problem when digging thru telemetry log. If the brain task moves to foreground and then quickly to background. It would call McEmailMessage.StartTimveVariances() before exiting. The shuffle of 2 chunks of code avoids doing useless work and delaying exiting (especially for users with lots of emails).
