### PR TITLE
Undo BusyProtect of telemetry operations.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McTelemetryEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McTelemetryEvent.cs
@@ -90,9 +90,7 @@ namespace NachoCore.Model
             NcAssert.True (0 == Id);
             try {
                 InsertCapture.Start ();
-                int rc = NcModel.Instance.BusyProtect (() => {
-                    return NcModel.Instance.TeleDb.Insert (this);
-                });
+                int rc = NcModel.Instance.TeleDb.Insert (this);
                 InsertCapture.Stop ();
                 InsertCapture.Reset ();
                 return rc;
@@ -111,9 +109,7 @@ namespace NachoCore.Model
             NcAssert.True (0 < Id);
             try {
                 DeleteCapture.Start ();
-                int rc = NcModel.Instance.BusyProtect (() => {
-                    return NcModel.Instance.TeleDb.Delete (this);
-                });
+                int rc = NcModel.Instance.TeleDb.Delete (this);
                 DeleteCapture.Stop ();
                 DeleteCapture.Reset ();
                 return rc;


### PR DESCRIPTION
Protecting the Insert and Delete operations for telemetry with
BusyProtect was causing the app to hang during startup after a fresh
install.  Henry thinks the BusyProtect isn't necessary.  So we are
removing it.

Fix #1523
