### PR TITLE
Don't crash when TNEF parsing fails

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
+++ b/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
@@ -472,10 +472,17 @@ namespace NachoCore.Utils
 
             if (part is MimeKit.Tnef.TnefPart) {
                 // Convert the TNEF stuff into a MIME message, and look through that.
-                MimeMessage tnef = (part as MimeKit.Tnef.TnefPart).ConvertToMessage ();
-                if (null != tnef.Body) {
-                    FixTnefMessage (tnef);
-                    MimeDisplayList (tnef, ref list);
+                try {
+                    MimeMessage tnef = (part as MimeKit.Tnef.TnefPart).ConvertToMessage ();
+                    if (null != tnef.Body) {
+                        FixTnefMessage (tnef);
+                        MimeDisplayList (tnef, ref list);
+                    }
+                } catch (Exception e) {
+                    // Parsing the TNEF has failed with an ArgumentOutOfRangeException before.  If the
+                    // TNEF can't be parsed, log an error but otherwise ignore the problem.  There is
+                    // nothing we can do to extract the data.
+                    Log.Error (Log.LOG_CALENDAR, "Parsing of TNEF section failed: {0}", e.ToString ());
                 }
                 return;
             }


### PR DESCRIPTION
Wrap the call to TnefPart.ConvertToMessage() in an try block so that a
malformed TNEF section doesn't crash the entire app.

Fix #1533
