### PR TITLE
Fix #1547

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -115,7 +115,7 @@ namespace NachoCore.Utils
                     action ();
                     isDone = true;
                 } catch (Exception e) {
-                    if (!HandleAWSException (e)) {
+                    if (!HandleAWSException (e, false)) {
                         if (NcTask.Cts.Token.IsCancellationRequested) {
                             if (null != Client) {
                                 Client.Dispose ();
@@ -230,7 +230,7 @@ namespace NachoCore.Utils
         /// <returns><c>true</c>, if AWS exception was handled, <c>false</c> otherwise.
         /// In that case, the caller must re-throw.</returns>
         /// <param name="e">E.</param>
-        private bool HandleAWSException (Exception e)
+        private bool HandleAWSException (Exception e, bool doReinitialize = true)
         {
             if (null != e) {
                 if (e is AggregateException) {
@@ -266,7 +266,9 @@ namespace NachoCore.Utils
             // This workaround simply catches everything and re-initializes
             // the connection and tables.
             Console.WriteLine ("Some exception caught in AWS send event\n{0}", e);
-            ReinitializeTables ();
+            if (doReinitialize) {
+                ReinitializeTables ();
+            }
             return true;
         }
 


### PR DESCRIPTION
HandleAWSException() re-initializes the AWS client when it sees an exception it does not anticipate. But during AWS client initialization, that is the wrong thing to do. Either: 1) there is no client set up to re-initialize, 2) it leads to a recursion.

Fix is to disable re-initializing during client initialization.
