### PR TITLE
Migrate AttendeeType and AttendeeTypeIsSet fields of McAttendee

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -360,6 +360,7 @@
     <Compile Include="NachoCore\Model\Migration\NcMigration2.cs" />
     <Compile Include="NachoCore\Model\McMapEmailAddressEntry.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration3.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration4.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration4.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration4.cs
@@ -1,0 +1,40 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+
+namespace NachoCore.Model
+{
+    /// <summary>
+    /// Migrate the McAttendee.AttendeeType and McAttendee.AttendeeTypeIsSet fields.  In the past, they could have the
+    /// values of Unknown and false if the user was connected to a Google server.  The ActiveSync code has been changed
+    /// to set the AttendeeType to Required is none is specified, but old McAttendee items need to be migrated.
+    /// </summary>
+    public class NcMigration4 : NcMigration
+    {
+        public NcMigration4 ()
+        {
+        }
+
+        public override int GetNumberOfObjects ()
+        {
+            return Db.Table<McAttendee> ().Where (x =>
+                x.AttendeeTypeIsSet == false || x.AttendeeType == NcAttendeeType.Unknown).Count ();
+        }
+
+        public override void Run (System.Threading.CancellationToken token)
+        {
+            foreach (McAttendee attendee in Db.Table<McAttendee>().Where (x => x.AttendeeTypeIsSet == false || x.AttendeeType ==  NcAttendeeType.Unknown)) {
+                token.ThrowIfCancellationRequested ();
+                NcModel.Instance.RunInTransaction (() => {
+                    attendee.AttendeeTypeIsSet = true;
+                    if (NcAttendeeType.Unknown == attendee.AttendeeType) {
+                        attendee.AttendeeType = NcAttendeeType.Required;
+                    }
+                    attendee.Update ();
+                    UpdateProgress (1);
+                });
+            }
+        }
+    }
+}
+

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1219,6 +1219,9 @@
     <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration3.cs">
       <Link>NachoCore\Model\Migration\NcMigration3.cs</Link>
     </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration4.cs">
+      <Link>NachoCore\Model\Migration\NcMigration4.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />


### PR DESCRIPTION
In the past, these fields could have the values of Unknown and false
if the user was connected to a Google server.  The ActiveSync code has
been changed to set the AttendeeType to Required if none is specified,
but old McAttendee items need to be migrated.
