### PR TITLE
Fix brain unit test breakage

### DIFF
--- a/Test.Android/NcBrainTest.cs
+++ b/Test.Android/NcBrainTest.cs
@@ -26,6 +26,7 @@ namespace Test.Common
             base.SetUp ();
             NcApplication.Instance.TestOnlyInvokeUseCurrentThread = true;
             NcTask.StartService ();
+            NcBrain.StartupDelayMsec = 0;
             NcBrain.StartService ();
             Telemetry.ENABLED = false;
             if (!Initialized) {


### PR DESCRIPTION
New life cycle fixes cause brain to not run in Test.iOS. Make brain task startup delay an adjustable parameter where a value of 0 means it is in test mode. In test mode, init code is skipped.
