### PR TITLE
Fix #1559. Prevent app from starting up until after migration and

### DIFF
--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -51,6 +51,11 @@ namespace NachoCore
             }
         }
 
+        public bool IsUp()
+        {
+            return (ExecutionContextEnum.Migrating != ExecutionContext) && (ExecutionContextEnum.Initializing != ExecutionContext);
+        }
+
         public ExecutionContextEnum PlatformIndication {
             get { return _PlatformIndication; }
             set { 

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -274,8 +274,7 @@ namespace NachoClient.iOS
 
             NcKeyboardSpy.Instance.Init ();
 
-            if (NcApplication.ExecutionContextEnum.Migrating != NcApplication.Instance.ExecutionContext &&
-                "SegueToTabController" == StartupViewController.NextSegue ()) {
+            if (NcApplication.Instance.IsUp () && "SegueToTabController" == StartupViewController.NextSegue ()) {
                 var storyboard = UIStoryboard.FromName ("MainStoryboard_iPhone", null);
                 var vc = storyboard.InstantiateViewController ("NachoTabBarController");
                 Log.Info (Log.LOG_UI, "fast path to tab bar controller: {0}", vc);

--- a/NachoClient.iOS/NachoUI.iOS/StartupViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/StartupViewController.cs
@@ -12,8 +12,8 @@ namespace NachoClient.iOS
 {
     public partial class StartupViewController : NcUIViewController
     {
-        UIProgressView ProgressBar = null;
-        UITextView TextField = null;
+        UIProgressView MigrationProgressBar = null;
+        UITextView MigrationMessageTextView = null;
 
         public StartupViewController (IntPtr handle) : base (handle)
         {
@@ -25,11 +25,12 @@ namespace NachoClient.iOS
         public override void ViewDidLoad ()
         {
             base.ViewDidLoad ();
-            if (NcApplication.ExecutionContextEnum.Migrating != NcApplication.Instance.ExecutionContext) {
+            if (NcApplication.Instance.IsUp ()) {
                 var segueIdentifer = NextSegue ();
-                Log.Info (Log.LOG_UI, "StartupViewController: PerformSegue({0})", segueIdentifer);
+                Log.Info (Log.LOG_UI, "svc: PerformSegue({0})", segueIdentifer);
                 PerformSegue (NextSegue (), this);
             } else {
+                CreateView ();
                 NcApplication.Instance.StatusIndEvent += StatusIndicatorCallback;
             }
         }
@@ -73,7 +74,6 @@ namespace NachoClient.iOS
             }
         }
 
-
         public override void ViewWillAppear (bool animated)
         {
             base.ViewWillAppear (animated);
@@ -85,30 +85,51 @@ namespace NachoClient.iOS
         public override void ViewDidAppear (bool animated)
         {
             base.ViewDidAppear (animated);
+            ConfigureView ();
+        }
+
+        public void CreateView ()
+        {
             // We need to migrate. Put up a spinner until this is done.
             this.NavigationItem.Title = "Upgrade";
             this.View.BackgroundColor = A.Color_NachoGreen;
             var frame = this.View.Frame;
             var halfHeight = frame.Height / 2.0f;
 
-            TextField = new UITextView ();
-            ViewFramer.Create (TextField)
+            MigrationMessageTextView = new UITextView ();
+            ViewFramer.Create (MigrationMessageTextView)
                 .X (0)
                 .Y (halfHeight - 35.0f)
                 .Width (frame.Width)
                 .Height (35.0f);
-            TextField.TextColor = UIColor.White;
-            TextField.Font = A.Font_AvenirNextRegular14;
-            TextField.Text = "Updating your app with latest features... (1 of 1)";
-            TextField.BackgroundColor = A.Color_NachoGreen;
-            TextField.TextAlignment = UITextAlignment.Center;
+            MigrationMessageTextView.TextColor = UIColor.White;
+            MigrationMessageTextView.Font = A.Font_AvenirNextRegular14;
+            MigrationMessageTextView.Text = "Updating your app with latest features... (1 of 1)";
+            MigrationMessageTextView.BackgroundColor = A.Color_NachoGreen;
+            MigrationMessageTextView.TextAlignment = UITextAlignment.Center;
 
-            ProgressBar = new UIProgressView (frame);
-            ViewFramer.Create (ProgressBar).Y (halfHeight + 10.0f).AdjustHeight (20.0f);
-            ProgressBar.ProgressTintColor = A.Color_NachoYellow;
-            ProgressBar.TrackTintColor = A.Color_NachoIconGray;
-            this.Add (TextField);
-            this.Add (ProgressBar);
+            MigrationProgressBar = new UIProgressView (frame);
+            ViewFramer.Create (MigrationProgressBar).Y (halfHeight + 10.0f).AdjustHeight (20.0f);
+            MigrationProgressBar.ProgressTintColor = A.Color_NachoYellow;
+            MigrationProgressBar.TrackTintColor = A.Color_NachoIconGray;
+            this.Add (MigrationMessageTextView);
+            this.Add (MigrationProgressBar);
+        }
+
+        void ConfigureView ()
+        {
+            if (NcApplication.ExecutionContextEnum.Migrating == NcApplication.Instance.ExecutionContext) {
+                this.NavigationItem.Title = "Upgrade";
+                MigrationMessageTextView.Hidden = false;
+                MigrationProgressBar.Hidden = false;
+            } else if (NcApplication.ExecutionContextEnum.Initializing == NcApplication.Instance.ExecutionContext) {
+                this.NavigationItem.Title = "Initializing";
+                MigrationMessageTextView.Hidden = true;
+                MigrationProgressBar.Hidden = true;
+            } else {
+                this.NavigationItem.Title = "Initialization";
+            }
+            Log.Info (Log.LOG_UI, "svc: {0}", NcApplication.Instance.ExecutionContext);
         }
 
         public void StatusIndicatorCallback (object sender, EventArgs e)
@@ -116,29 +137,30 @@ namespace NachoClient.iOS
             var s = (StatusIndEventArgs)e;
             if (NcResult.SubKindEnum.Info_ExecutionContextChanged == s.Status.SubKind) {
                 var execContext = (NcApplication.ExecutionContextEnum)s.Status.Value;
-                if ((NcApplication.ExecutionContextEnum.Initializing != execContext) &&
-                    (NcApplication.ExecutionContextEnum.Migrating != execContext)) {
+                if (NcApplication.Instance.IsUp ()) {
                     InvokeOnMainThread (() => {
-                        if (null != ProgressBar) {
-                            ProgressBar.Hidden = false;
+                        if (null != MigrationProgressBar) {
+                            MigrationProgressBar.Hidden = false;
                         }
                         PerformSegue (NextSegue (), this);
                     });
+                } else {
+                    ConfigureView ();
                 }
             }
             if (NcResult.SubKindEnum.Info_MigrationProgress == s.Status.SubKind) {
                 var percentage = (float)s.Status.Value;
-                if (null != ProgressBar) {
+                if (null != MigrationProgressBar) {
                     InvokeOnMainThread (() => {
-                        ProgressBar.SetProgress (percentage, true);
+                        MigrationProgressBar.SetProgress (percentage, true);
                     });
                 }
             }
             if (NcResult.SubKindEnum.Info_MigrationDescription == s.Status.SubKind) {
                 var description = (string)s.Status.Value;
-                if (null != TextField) {
+                if (null != MigrationMessageTextView) {
                     InvokeOnMainThread (() => {
-                        TextField.Text = description;
+                        MigrationMessageTextView.Text = description;
                     });
                 }
             }


### PR DESCRIPTION
Prevent app from starting up until after migration and initialization have completed.  Won't call fast path unless we're up and running. In start up view, during migration and now during initialization, display an appropriate screen.
