### PR TITLE
Don't crash when starting from a notification and migration is required

### DIFF
--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -234,7 +234,6 @@ namespace NachoCore
             ExecutionContext = ExecutionContextEnum.Initializing;
             NcModel.Instance.GarbageCollectFiles ();
             NcModel.Instance.Start ();
-            Account = McAccount.QueryByAccountType (McAccount.AccountTypeEnum.Exchange).FirstOrDefault ();
             EstablishService ();
             NcModel.Instance.EngageRateLimiter ();
             NcBrain.StartService ();
@@ -251,6 +250,7 @@ namespace NachoCore
             Log.Info (Log.LOG_LIFECYCLE, "NcApplication: StartBasalServices called.");
             NcTask.StartService ();
             Telemetry.StartService ();
+            Account = McAccount.QueryByAccountType (McAccount.AccountTypeEnum.Exchange).FirstOrDefault ();
             // Start Migrations, if any.
             if (!NcMigration.WillStartService ()) {
                 StartBasalServicesCompletion ();


### PR DESCRIPTION
If the user started the app by swiping a notification and a database
migration is required as part of startup, then the app would crash
during startup.  The problem was that NcApplication.Instance.Account
was not initialized in time.  It wasn't initialized until after
migration completed, but it was referenced from the code that deals
with the notification, which is in AppDelegate.FinishedLaunching.

The fix is to move the initialization of
NcApplication.Instance.Account from StartBasalServicesCompletion
(which might be delayed until after migration) to StartBasalServices.

This was tested by hacking the code to always perform a migration during startup.

Fix #1543
