### PR TITLE
The 'hot' event shouldn't be a canceled meeting

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McEvent.cs
@@ -69,7 +69,15 @@ namespace NachoCore.Model
 
         public static McEvent GetCurrentOrNextEvent()
         {
-            return NcModel.Instance.Db.Table<McEvent> ().Where (x => x.EndTime >= DateTime.UtcNow).OrderBy (x => x.StartTime).FirstOrDefault ();
+            foreach (var evt in NcModel.Instance.Db.Table<McEvent> ().Where (x => x.EndTime >= DateTime.UtcNow).OrderBy (x => x.StartTime)) {
+                var cal = evt.GetCalendarItemforEvent ();
+                if (null != cal && NcMeetingStatus.MeetingCancelled != cal.MeetingStatus && NcMeetingStatus.ForwardedMeetingCancelled != cal.MeetingStatus) {
+                    // An event that hasn't been canceled.  This is what we are looking for.
+                    return evt;
+                }
+                // The event was canceled.  Go to the next one in the list.
+            }
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
When looking for the event to show in the Nacho Hot view, ignore
meetings that have been canceled (but not yet removed from the
calendar).

Fix #1273
