### PR TITLE
Fix #1562

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -469,6 +469,11 @@ namespace NachoCore.Brain
         {
             bool tvStarted = false;
             if (ENABLED && !IsInUnitTest ()) {
+                // Delay brain to avoid initialization logjam
+                if (!NcTask.CancelableSleep (StartupDelayMsec)) {
+                    NcTask.Cts.Token.ThrowIfCancellationRequested ();
+                }
+
                 // If brain task is running under quick sync, do not start time variance
                 // as it is a waste of time.
                 if (NcApplication.ExecutionContextEnum.Background == NcApplication.Instance.ExecutionContext ||


### PR DESCRIPTION
Please see #1562 for the root cause analysis. Move the delay outside of the loop so that it is not skipped if the exec context is Initializing.
