### PR TITLE
Fix #1570

### DIFF
--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration.cs
@@ -218,7 +218,6 @@ namespace NachoCore.Model
                         migrationRecord.StartTime = startTime;
                         rows = migrationRecord.Insert ();
                         NcAssert.True (1 == rows);
-                        migration.Finished = true;
                     }
                     migrationRecord.NumberOfTimesRan += 1;
                     migrationRecord.Update ();
@@ -232,6 +231,7 @@ namespace NachoCore.Model
                         migrationRecord.Finished = true;
                         rows = migrationRecord.Update ();
                         NcAssert.True (1 == rows);
+                        migration.Finished = true;
                     } catch (OperationCanceledException) {
                         migrationRecord.DurationMsec += (int)(DateTime.UtcNow - startTime).TotalMilliseconds;
                         rows = migrationRecord.Update ();


### PR DESCRIPTION
NcMigration.Finished is marked prematurely. If the migration does not finish on its 1st run and migration task is restarted later, the Finished field is never set to true. So, a normal background-foreground will result in the migration being re-run.

The fix is to mark the NcMigration object as finished after it is done; not when it is created.
