### PR TITLE
#1480. When logging SQLite error, record the ObjC stack.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -264,10 +264,14 @@ namespace NachoCore.Model
                     ((int)SQLite3.Result.Locked == code && message.Contains ("PRAGMA main.wal_checkpoint (PASSIVE)"))) {
                     return;
                 }
+                var messageWithStack = string.Format ("SQLite Error Log (code {0}): {1}", code, message);
+                foreach (var frame in NachoPlatformBinding.PlatformProcess.GetStackTrace ()) {
+                    messageWithStack += "\n" + frame;
+                }
                 Log.IndirectQ.Enqueue (new LogElement () {
                     Level = LogElement.LevelEnum.Error,
                     Subsystem = Log.LOG_DB,
-                    Message = string.Format ("SQLite Error Log (code {0}): {1}", code, message),
+                    Message = messageWithStack,
                     Occurred = DateTime.UtcNow,
                     ThreadId = Thread.CurrentThread.ManagedThreadId,
                 });


### PR DESCRIPTION
We have several issues reporting SQLite errors but the error message is very cryptic and sometimes we cannot even tell if they are from our code or iOS. We pull the ObjC stack frame inside the error callback. If it is some iOS code, we would see some iOS function calling sqlite functions. This help us to decide if some errors can be ignored.
