### PR TITLE
Check the returned code of NcTask.CancelableSleep() and throw cancellation exception if necessary.

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -479,7 +479,9 @@ namespace NachoCore.Brain
                 if (NcApplication.ExecutionContextEnum.Background == NcApplication.Instance.ExecutionContext ||
                     NcApplication.ExecutionContextEnum.Foreground == NcApplication.Instance.ExecutionContext) {
                     // Defer the processing until Nacho Nov view shows up.
-                    NcTask.CancelableSleep (StartupDelayMsec);
+                    if (!NcTask.CancelableSleep (StartupDelayMsec)) {
+                        NcTask.Cts.Token.ThrowIfCancellationRequested ();
+                    }
                     McEmailMessage.StartTimeVariance (EventQueue.Token);
                     tvStarted = true;
                 }

--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -286,7 +286,9 @@ namespace NachoCore.Utils
                     throw;
                 }
                 // Linear backoff
-                NcTask.CancelableSleep (1000);
+                if (!NcTask.CancelableSleep (1000)) {
+                    NcTask.Cts.Token.ThrowIfCancellationRequested ();
+                }
                 return false;
             }
             return true;


### PR DESCRIPTION
Miss checking returned code for a few NcTask.CancelableSleep() that may delay cancellation of brain and telemetry tasks.
