### PR TITLE
Limit the Hot event query to look one week into the future

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McEvent.cs
@@ -72,9 +72,16 @@ namespace NachoCore.Model
             }
         }
 
+        /// <summary>
+        /// Return the event that is currently in progress, or the next one to start.
+        /// Ignore events associated with a canceled meeting.  Ignore events that are
+        /// more than a week away.  Return null if no event is found.
+        /// </summary>
         public static McEvent GetCurrentOrNextEvent()
         {
-            foreach (var evt in NcModel.Instance.Db.Table<McEvent> ().Where (x => x.EndTime >= DateTime.UtcNow).OrderBy (x => x.StartTime)) {
+            DateTime now = DateTime.UtcNow;
+            DateTime weekInFuture = now + new TimeSpan (7, 0, 0, 0);
+            foreach (var evt in NcModel.Instance.Db.Table<McEvent> ().Where (x => x.EndTime >= now && x.StartTime < weekInFuture).OrderBy (x => x.StartTime)) {
                 var cal = evt.GetCalendarItemforEvent ();
                 if (null != cal && NcMeetingStatus.MeetingCancelled != cal.MeetingStatus && NcMeetingStatus.ForwardedMeetingCancelled != cal.MeetingStatus) {
                     // An event that hasn't been canceled.  This is what we are looking for.


### PR DESCRIPTION
Change the query that finds the Hot view event to look no more than
one week into the future.  If the user's calendar was full of
recurring events, the old query could take way too long to run.  The
new query should always run within a reasonable amount of time.

By never finding an event more than a week away, this change happens
to fix issue 1569, where events more than a week away were displayed
incorrectly.

Fix #1569
