### PR TITLE
Improve the performance of McCalendar.Delete()

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McEvent.cs
@@ -10,6 +10,14 @@ using System.Linq;
 
 namespace NachoCore.Model
 {
+    /// <summary>
+    /// For queries that only need the McEvent ID, not the entire object.
+    /// </summary>
+    public class NcEventIndex
+    {
+        public int Id { set; get; }
+    }
+
     public class McEvent : McAbstrObjectPerAcc
     {
         public McEvent ()
@@ -117,6 +125,27 @@ namespace NachoCore.Model
         {
             return NcModel.Instance.Db.Table<McEvent> ()
                 .Where (e => e.CalendarId == calendarId && e.StartTime > after);
+        }
+
+        /// <summary>
+        /// Return the IDs for all of the McEvents associated with the given calendar item.
+        /// </summary>
+        public static List<NcEventIndex> QueryEventIdsForCalendarItem (int calendarId)
+        {
+            return NcModel.Instance.Db.Query<NcEventIndex> (
+                "SELECT e.Id as Id FROM McEvent AS e WHERE e.CalendarId = ?", calendarId);
+        }
+
+        /// <summary>
+        /// Delete all the McEvents associated with the given calendar item. This method does not cancel
+        /// any local notifications for the events.  Callers of this method must handle local notification
+        /// cancelation themselves.
+        /// </summary>
+        /// <returns>The number of McEvents that were deleted.</returns>
+        public static int DeleteEventsForCalendarItem (int calendarId)
+        {
+            return NcModel.Instance.Db.Execute (
+                "DELETE FROM McEvent WHERE CalendarId = ?", calendarId);
         }
     }
 }

--- a/NachoClient.Android/NachoCore/Model/McException.cs
+++ b/NachoClient.Android/NachoCore/Model/McException.cs
@@ -29,5 +29,14 @@ namespace NachoCore.Model
             var result = NcModel.Instance.Db.Query<McException> (query, calendarId, exceptionStartTime).ToList ();
             return result;
         }
+
+        /// <summary>
+        /// Delete all the McExceptions associated with the given calendar event.
+        /// </summary>
+        /// <returns>The number of McExceptions that were deleted.</returns>
+        public static int DeleteExceptionsForCalendarItem (int calendarId)
+        {
+            return NcModel.Instance.Db.Execute ("DELETE FROM McException WHERE CalendarId = ?", calendarId);
+        }
     }
 }

--- a/NachoClient.Android/NachoCore/Utils/LocalNotificationManager.cs
+++ b/NachoClient.Android/NachoCore/Utils/LocalNotificationManager.cs
@@ -155,12 +155,24 @@ namespace NachoCore.Utils
             }
         }
 
-        public static void CancelNotification (McEvent ev)
+        public static void CancelNotification (McEvent evt)
         {
             lock (lockObject) {
                 NcAssert.NotNull (scheduledEvents, "LocalNotificationManager.CancelNotification() was called before InitializeLocalNotifications().");
-                if (scheduledEvents.Remove (ev.Id)) {
-                    NachoPlatform.Notif.Instance.CancelNotification (ev.Id);
+                if (scheduledEvents.Remove (evt.Id)) {
+                    NachoPlatform.Notif.Instance.CancelNotification (evt.Id);
+                }
+            }
+        }
+
+        public static void CancelNotifications (List<NcEventIndex> events)
+        {
+            lock (lockObject) {
+                NcAssert.NotNull (scheduledEvents, "LocalNotificationManager.CancelNotifications() was called before InitializeLocalNotifications().");
+                foreach (var eventId in events) {
+                    if (scheduledEvents.Remove (eventId.Id)) {
+                        NachoPlatform.Notif.Instance.CancelNotification (eventId.Id);
+                    }
                 }
             }
         }

--- a/Test.Android/McEventTest.cs
+++ b/Test.Android/McEventTest.cs
@@ -198,6 +198,110 @@ namespace Test.Common
             Assert.NotNull (nextEvent, "GetCurrentOrNextEvent() didn't find any event.");
             Assert.AreEqual (e2.Id, nextEvent.Id, "GetCurrentOrNextEvent() returned the wrong event.");
         }
+
+        [Test]
+        public void TestQueryEventIdsForCalendarItem ()
+        {
+            var e0 = new McEvent () {
+                AccountId = 1,
+                CalendarId = 100,
+                StartTime = new DateTime (2015, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndTime = new DateTime (2015, 2, 1, 1, 0, 0, DateTimeKind.Utc),
+            };
+            var e1 = new McEvent () {
+                AccountId = 1,
+                CalendarId = 100,
+                StartTime = new DateTime (2015, 2, 2, 0, 0, 0, DateTimeKind.Utc),
+                EndTime = new DateTime (2015, 2, 2, 1, 0, 0, DateTimeKind.Utc),
+            };
+            var e2 = new McEvent () {
+                AccountId = 1,
+                CalendarId = 101,
+                StartTime = new DateTime (2015, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndTime = new DateTime (2015, 2, 1, 1, 0, 0, DateTimeKind.Utc),
+            };
+            var e3 = new McEvent () {
+                AccountId = 1,
+                CalendarId = 101,
+                StartTime = new DateTime (2015, 2, 2, 0, 0, 0, DateTimeKind.Utc),
+                EndTime = new DateTime (2015, 2, 2, 1, 0, 0, DateTimeKind.Utc),
+            };
+
+            e0.Insert ();
+            e1.Insert ();
+            e2.Insert ();
+            e3.Insert ();
+
+            var eventIds = McEvent.QueryEventIdsForCalendarItem (100);
+            Assert.AreEqual (2, eventIds.Count,
+                "QueryEventIdsForCalendaritem(100) returned the wrong number of event IDs.");
+            Assert.True (e0.Id == eventIds [0].Id || e1.Id == eventIds [0].Id,
+                "QueryEventIdsForCalendarItem(100) returned the wrong event ID.");
+            Assert.True (e0.Id == eventIds [1].Id || e1.Id == eventIds [1].Id,
+                "QueryEventIdsForCalendarItem(100) returned the wrong event ID.");
+            Assert.AreNotEqual (eventIds [0].Id, eventIds [1].Id,
+                "QueryEventIdsForCalendarItem(100) returned the same event ID multiple times.");
+
+            eventIds = McEvent.QueryEventIdsForCalendarItem (101);
+            Assert.AreEqual (2, eventIds.Count,
+                "QueryEventIdsForCalendaritem(101) returned the wrong number of event IDs.");
+            Assert.True (e2.Id == eventIds [0].Id || e3.Id == eventIds [0].Id,
+                "QueryEventIdsForCalendarItem(100) returned the wrong event ID.");
+            Assert.True (e2.Id == eventIds [1].Id || e3.Id == eventIds [1].Id,
+                "QueryEventIdsForCalendarItem(100) returned the wrong event ID.");
+            Assert.AreNotEqual (eventIds [0].Id, eventIds [1].Id,
+                "QueryEventIdsForCalendarItem(100) returned the same event ID multiple times.");
+
+            eventIds = McEvent.QueryEventIdsForCalendarItem (200);
+            Assert.AreEqual (0, eventIds.Count,
+                "QueryEventIdsForCalendarItem(200) returned {0} event IDs when it should have returned none.", eventIds.Count);
+        }
+
+        [Test]
+        public void TestDeleteEventsForCalendarItem ()
+        {
+            var e0 = new McEvent () {
+                AccountId = 1,
+                CalendarId = 100,
+                StartTime = new DateTime (2015, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndTime = new DateTime (2015, 1, 1, 1, 0, 0, DateTimeKind.Utc),
+            };
+            var e1 = new McEvent () {
+                AccountId = 1,
+                CalendarId = 100,
+                StartTime = new DateTime (2015, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+                EndTime = new DateTime (2015, 1, 2, 1, 0, 0, DateTimeKind.Utc),
+            };
+            var e2 = new McEvent () {
+                AccountId = 1,
+                CalendarId = 101,
+                StartTime = new DateTime (2015, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndTime = new DateTime (2015, 2, 1, 1, 0, 0, DateTimeKind.Utc),
+            };
+            var e3 = new McEvent () {
+                AccountId = 1,
+                CalendarId = 101,
+                StartTime = new DateTime (2015, 2, 2, 0, 0, 0, DateTimeKind.Utc),
+                EndTime = new DateTime (2015, 2, 2, 1, 0, 0, DateTimeKind.Utc),
+            };
+
+            e0.Insert ();
+            e1.Insert ();
+            e2.Insert ();
+            e3.Insert ();
+
+            int numDeleted = McEvent.DeleteEventsForCalendarItem (200);
+            Assert.AreEqual (0, numDeleted,
+                "DeletEventsForCalendarItem(200) deleted {0} events when it shouldn't have deleted any.", numDeleted);
+
+            numDeleted = McEvent.DeleteEventsForCalendarItem (100);
+            Assert.AreEqual (2, numDeleted, "DeleteEventsForCalendarItem(100) deleted {0} events when it should have deleted 2.", numDeleted);
+            var notDeletedEvents = McEvent.QueryAllEventsInOrder ();
+            Assert.AreEqual (e2.Id, notDeletedEvents [0].Id,
+                "DeleteEventsForCalendarItem(100) deleted the wrong events.");
+            Assert.AreEqual (e3.Id, notDeletedEvents [1].Id,
+                "DeleteEventsForCalendarItem(100) deleted the wrong events.");
+        }
     }
 }
 


### PR DESCRIPTION
When a McCalendar item is deleted, all of its related exceptions and
events also need to be deleted.  This was being done by looping
through all of the exceptions and events and calling Delete() for each
one.  This proved to be inefficient.

The code was changed to use just one SQL DELETE command each for
exceptions and events, deleting them all at once instead of one at a
time.

Canceling the local notifications for the events being deleted
requires running some code on the UI thread.  Even if the UI thread
action is invoked asynchronously, the UI thread will take priority and
run for a little while, slowing down the background thread.  Move the
local notification cancelation code outside of the database
transaction.  This change doesn't make it run any faster, but it
avoids running it when an important lock is being held.
