### PR TITLE
Only index MIME body for now

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
@@ -564,9 +564,10 @@ namespace NachoCore.Model
                 " JOIN McBody as b ON b.Id == e.BodyId " +
                 " WHERE e.IsIndexed = 0 AND " +
                 " e.BodyId != 0 AND " +
-                " b.FilePresence = ? " +
+                " b.FilePresence = ? AND " +
+                " b.BodyType = ? " +
                 " ORDER BY e.DateReceived DESC LIMIT ?",
-                McAbstrFileDesc.FilePresenceEnum.Complete, maxMessages
+                McAbstrFileDesc.FilePresenceEnum.Complete, McAbstrFileDesc.BodyTypeEnum.MIME_4, maxMessages
             );
         }
 

--- a/Test.Android/McEmailMessageTest.cs
+++ b/Test.Android/McEmailMessageTest.cs
@@ -380,24 +380,28 @@ namespace Test.Common
             // 5. Has body and is complete, and marked indexed
             var body1 = new McBody () {
                 AccountId = 1,
+                BodyType = McAbstrFileDesc.BodyTypeEnum.MIME_4,
                 FilePresence = McAbstrFileDesc.FilePresenceEnum.Complete
             };
             InsertAndCheckBody (body1);
 
             var body3 = new McBody () {
                 AccountId = 1,
+                BodyType = McAbstrFileDesc.BodyTypeEnum.MIME_4,
                 FilePresence = McAbstrFileDesc.FilePresenceEnum.Complete
             };
             InsertAndCheckBody (body3);
 
             var body4 = new McBody () {
                 AccountId = 1,
+                BodyType = McAbstrFileDesc.BodyTypeEnum.MIME_4,
                 FilePresence = McAbstrFileDesc.FilePresenceEnum.Partial
             };
             InsertAndCheckBody (body4);
 
             var body5 = new McBody () {
                 AccountId = 1,
+                BodyType = McAbstrFileDesc.BodyTypeEnum.MIME_4,
                 FilePresence = McAbstrFileDesc.FilePresenceEnum.Complete
             };
             InsertAndCheckBody (body5);


### PR DESCRIPTION
Modify QueryNeedsIndexing() to search for MIME body type only because we only have tokenizer for that for now. Will add other body type later.
