### PR TITLE
Remove some of the error messages about duplicate UIDs for events

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncEventCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncEventCommand.cs
@@ -76,8 +76,10 @@ namespace NachoCore.ActiveSync
             } else {
                 var sameUid = McCalendar.QueryByUID (newItem.AccountId, newItem.UID);
                 if (null != sameUid && sameUid.ServerId != newItem.ServerId) {
-                    Log.Error (Log.LOG_SYNC, "Two events have the same UID ({0}) but different ServerId ({1} and {2}). This will likely result in a duplicate event.",
-                        newItem.UID, sameUid.AccountId, sameUid.ServerId, newItem.AccountId, newItem.ServerId);
+                    // It is normal for there to be duplicate UIDs for a short period of time when the server
+                    // changes an event using an add/delete.  So this is probably not an error.
+                    Log.Info (Log.LOG_SYNC, "Two events have the same UID ({0}) but different ServerId ({1} and {2}). This will likely result in a duplicate event.",
+                        newItem.UID, sameUid.ServerId, newItem.ServerId);
                 }
                 if (null != oldItem && oldItem.UID != newItem.UID) {
                     Log.Error (Log.LOG_SYNC, "The UID for event {0} is changing from {1} to {2}",

--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -569,15 +569,6 @@ namespace NachoCore.Model
         private static void Scrub ()
         {
             // The contents of this method change, depending on what we are scrubbing for.
-            // TODO: Make SQL this account-sensitive.
-            var dupCals = Instance.Db.Query<McCalendar> (
-                              "SELECT * FROM McCalendar WHERE UID IN " +
-                              "(SELECT UID FROM McCalendar GROUP BY UID HAVING COUNT(*) > 1)"
-                          );
-            foreach (var dupCal in dupCals) {
-                Log.Error (Log.LOG_DB, "Duplicate McCalendar Entry: Id={0}, ServerId={1}, UID={2}", 
-                    dupCal.Id, dupCal.ServerId, dupCal.UID);
-            }
         }
 
         public void ResetTeleDb ()


### PR DESCRIPTION
Some servers will do an add and delete of a calendar item.  This
results in two items with the same UID in the database for a short
period of time.  Since duplicate UIDs are sometimes normal, and since
we can't detect the difference between a normal case and a buggy
situation, some of the error messages about duplicate UIDs have been
removed.

The message "Duplicate McCalendar Entry" is gone.  The message "Two
events have the same UID" was changed from an error to an
informational message.  The message "There are {0} events with the
same UID" remains an error, since that message happens when the
duplicate UIDs become a real problem rather than just a theoretical
problem.

Fix #945
