### PR TITLE
Fix swiping a notification after a fresh install

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -636,6 +636,9 @@ namespace NachoClient.iOS
                     nachoTabBarController = (NachoTabBarController)Window.RootViewController.PresentedViewController.TabBarController;
                 }
             }
+            if (null == nachoTabBarController) {
+                Log.Error (Log.LOG_LIFECYCLE, "The NachoTabBarController could not be found.  Handling of the notification will be delayed or skipped.");
+            }
                 
             if (null != emailNotification) {
                 var emailMessageId = emailNotification.ToMcModelIndex ();


### PR DESCRIPTION
If the app went through the login process or a database migration when
launched, then swiping an e-mail notification would not work.  It
would open the app, but not take the user to the message that was
swiped.  This is fixed by doing a more thorough search for the
NachoTabBarController.

Fix #1589
