### PR TITLE
Fix the initial setting of the date/time picker in the event editor

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -974,7 +974,7 @@ namespace NachoClient.iOS
                 startDatePicker.Mode = UIDatePickerMode.DateAndTime;
             }
             startDate = c.StartTime;
-            startDatePicker.Date = c.StartTime.LocalT ().ToNSDate();
+            startDatePicker.Date = c.StartTime.ToNSDate ();
             startDateLabelView.SizeToFit ();
             startDateLabelView.Frame = new CGRect (SCREEN_WIDTH - startDateLabel.Frame.Width - 15, 12.438f, startDateLabel.Frame.Width, TEXT_LINE_HEIGHT);
 
@@ -985,12 +985,12 @@ namespace NachoClient.iOS
                 endDateLabelView.Text = Pretty.FullDateString (endDay);
                 endDatePicker.Mode = UIDatePickerMode.Date;
                 endDate = endDay;
-                endDatePicker.Date = endDay.LocalT ().ToNSDate();
+                endDatePicker.Date = endDay.ToNSDate ();
             } else {
                 endDateLabelView.Text = Pretty.FullDateTimeString (c.EndTime);
                 endDatePicker.Mode = UIDatePickerMode.DateAndTime;
                 endDate = c.EndTime;
-                endDatePicker.Date = c.EndTime.LocalT ().ToNSDate();
+                endDatePicker.Date = c.EndTime.ToNSDate ();
             }
             endDateLabelView.SizeToFit ();
             endDateLabelView.Frame = new CGRect (SCREEN_WIDTH - endDateLabel.Frame.Width - 15, 12.438f, endDateLabel.Frame.Width, TEXT_LINE_HEIGHT);


### PR DESCRIPTION
In the move to the Xamarin 64-bit unified API, there was a mixup with
local time vs. UTC, which caused the date/time picker in the edit
event view to start with the wrong value.  That problem is now fixed.

Fix nachocove/qa#18
