### PR TITLE
Fix nachocove/qa#64

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -240,9 +240,7 @@ namespace NachoCore.Brain
             }
 
             foreach (var index in indexes.Values) {
-                if (index.Dirty) {
-                    index.EndAddTransaction ();
-                }
+                index.EndAddTransaction ();
             }
             if (0 != numIndexed) {
                 Log.Info (Log.LOG_BRAIN, "{0} email messages indexed", numIndexed);

--- a/NachoClient.Android/NachoCore/Index/Index.cs
+++ b/NachoClient.Android/NachoCore/Index/Index.cs
@@ -61,7 +61,7 @@ namespace NachoCore.Index
         public long BatchAdd (NcIndexDocument doc)
         {
             if (null == Writer) {
-                throw new ArgumentNullException ();
+                throw new ArgumentNullException ("writer not set up");
             }
 
             // Index the document
@@ -75,7 +75,7 @@ namespace NachoCore.Index
         {
             Lock.WaitOne ();
             if (null != Writer) {
-                throw new ArgumentException ();
+                throw new ArgumentException ("writer already exists");
             }
             Dirty = false;
             Writer = new IndexWriter (IndexDirectory, Analyzer, IndexWriter.MaxFieldLength.UNLIMITED);
@@ -83,10 +83,12 @@ namespace NachoCore.Index
 
         public void EndAddTransaction ()
         {
-            Writer.Commit ();
+            if (Dirty) {
+                Writer.Commit ();
+                Dirty = false;
+            }
             Writer.Dispose ();
             Writer = null;
-            Dirty = false;
             Lock.ReleaseMutex ();
         }
 
@@ -103,7 +105,7 @@ namespace NachoCore.Index
         public bool BatchRemove (string type, string id)
         {
             if (null == Reader) {
-                throw new ArgumentNullException ();
+                throw new ArgumentNullException ("reader not set up");
             }
             var parser = new QueryParser (Lucene.Net.Util.Version.LUCENE_30, "id", Analyzer);
             var queryString = String.Format ("type:{0} AND id:{1}", type, id);
@@ -127,7 +129,7 @@ namespace NachoCore.Index
         {
             Lock.WaitOne ();
             if (null != Reader) {
-                throw new ArgumentException ();
+                throw new ArgumentException ("reader already exists");
             }
             Reader = IndexReader.Open (IndexDirectory, false);
         }


### PR DESCRIPTION
It is possible to call IndexEmailMessage() but not index the email. (E.g., if the body somehow is not there.) So, we must always call EndAddTransaction() so mutex is unlocked but only call Commit() if the index is dirty.
