### PR TITLE
Handle an ActiveSync time zone with no ID and no daylight saving time

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsTimeZone.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsTimeZone.cs
@@ -69,10 +69,24 @@ namespace NachoCore.ActiveSync
         public TimeZoneInfo ConvertToSystemTimeZone ()
         {
             try {
+                string timeZoneID;
+                string displayName;
+                string standardName;
+                if (string.IsNullOrEmpty (StandardName)) {
+                    timeZoneID = "CustomID";
+                    displayName = "Custom Time Zone";
+                    standardName = "Standard";
+                } else {
+                    timeZoneID = StandardName;
+                    displayName = StandardName;
+                    standardName = StandardName;
+                }
+                string daylightName = string.IsNullOrEmpty(DaylightName) ? "Daylight" : DaylightName;
+
                 if (0 == DaylightBias && 0 == StandardBias) {
                     // Simple case. No daylight saving time.
                     return TimeZoneInfo.CreateCustomTimeZone (
-                        StandardName, new TimeSpan (-(Bias * TimeSpan.TicksPerMinute)), StandardName, StandardName);
+                        timeZoneID, new TimeSpan (-(Bias * TimeSpan.TicksPerMinute)), displayName, standardName);
                 }
                 TimeZoneInfo.TransitionTime transitionToDaylight;
                 if (0 == DaylightDate.year) {
@@ -101,19 +115,6 @@ namespace NachoCore.ActiveSync
                     new TimeSpan (-((DaylightBias - StandardBias) * TimeSpan.TicksPerMinute)),
                     transitionToDaylight, transitionToStandard);
 
-                string timeZoneID;
-                string displayName;
-                string standardName;
-                if (string.IsNullOrEmpty (StandardName)) {
-                    timeZoneID = "CustomID";
-                    displayName = "Custom Time Zone";
-                    standardName = "Standard";
-                } else {
-                    timeZoneID = StandardName;
-                    displayName = StandardName;
-                    standardName = StandardName;
-                }
-                string daylightName = string.IsNullOrEmpty(DaylightName) ? "Daylight" : DaylightName;
                 return TimeZoneInfo.CreateCustomTimeZone (
                     timeZoneID, new TimeSpan (-((Bias + StandardBias) * TimeSpan.TicksPerMinute)),
                     displayName, standardName, daylightName,


### PR DESCRIPTION
Sometimes the time zone information in a calendar item doesn't have a
name, which causes problems when creating a C# time zone structure.
This situation was being handled correctly when the time zone had
daylight saving time.  But I had missed the case of a time zone with
no daylight saving time.  This change fixes that oversight.

Fix nachocove/qa#81
