### PR TITLE
add IsFolder to McPath to make recursive deletes fast

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -367,6 +367,8 @@
     <Compile Include="NachoCore\Adapters\NachoThreadedEmailMessages.cs" />
     <Compile Include="NachoCore\Adapters\NachoMessageSearchResults.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration7.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration6.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration8.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderCreateCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderCreateCommand.cs
@@ -51,6 +51,7 @@ namespace NachoCore.ActiveSync
                 var pathElem = new McPath (BEContext.Account.Id);
                 pathElem.ServerId = serverId;
                 pathElem.ParentId = PendingSingle.ParentId;
+                pathElem.IsFolder = true;
                 pathElem.Insert ();
                 var applyFolderCreate = new ApplyCreateFolder (BEContext.Account.Id) {
                     PlaceholderId = PendingSingle.ServerId,

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderSyncCommand/AsFolderSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderSyncCommand/AsFolderSyncCommand.cs
@@ -59,6 +59,7 @@ namespace NachoCore.ActiveSync
                             pathElem = new McPath (BEContext.Account.Id);
                             pathElem.ServerId = serverId;
                             pathElem.ParentId = parentId;
+                            pathElem.IsFolder = true;
                             pathElem.Insert ();
                             var applyAdd = new ApplyFolderAdd (BEContext.Account.Id) {
                                 ServerId = serverId, 

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration6.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration6.cs
@@ -4,11 +4,6 @@ using System;
 
 namespace NachoCore.Model
 {
-    /// <summary>
-    /// Migrate the McAttendee.AttendeeType and McAttendee.AttendeeTypeIsSet fields.  In the past, they could have the
-    /// values of Unknown and false if the user was connected to a Google server.  The ActiveSync code has been changed
-    /// to set the AttendeeType to Required is none is specified, but old McAttendee items need to be migrated.
-    /// </summary>
     public class NcMigration6 : NcMigration
     {
         public NcMigration6 ()

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration7.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration7.cs
@@ -4,11 +4,6 @@ using System;
 
 namespace NachoCore.Model
 {
-    /// <summary>
-    /// Migrate the McAttendee.AttendeeType and McAttendee.AttendeeTypeIsSet fields.  In the past, they could have the
-    /// values of Unknown and false if the user was connected to a Google server.  The ActiveSync code has been changed
-    /// to set the AttendeeType to Required is none is specified, but old McAttendee items need to be migrated.
-    /// </summary>
     public class NcMigration7 : NcMigration
     {
         public NcMigration7 ()

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration8.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration8.cs
@@ -1,0 +1,27 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+
+namespace NachoCore.Model
+{
+    public class NcMigration8 : NcMigration
+    {
+        public override int GetNumberOfObjects ()
+        {
+            return Db.Table<McFolder> ().Where (x => false == x.IsClientOwned). Count ();
+        }
+
+        public override void Run (System.Threading.CancellationToken token)
+        {
+            foreach (var folder in Db.Table<McFolder> ().Where (x => false == x.IsClientOwned)) {
+                token.ThrowIfCancellationRequested ();
+                var path = McPath.QueryByServerId (folder.AccountId, folder.ServerId);
+                if (null != path) {
+                    path.IsFolder = true;
+                    path.Update ();
+                }
+            }
+        }
+    }
+}
+

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1252,7 +1252,6 @@
       <Link>NachoCore\Adapters\NachoThreadedEmailMessages.cs</Link>
     </Compile>
     <Compile Include="NachoUI.iOS\Interfaces\INachoMessageViewer.cs" />
-    <Compile Include="NachoCore\Model\Migration\NcMigration6.cs" />
     <Compile Include="..\NachoClient.Android\NachoCore\Adapters\NachoMessageSearchResults.cs">
       <Link>NachoCore\Adapters\NachoMessageSearchResults.cs</Link>
     </Compile>
@@ -1262,6 +1261,12 @@
     <Compile Include="NachoUI.iOS\NotesViewerViewController.cs" />
     <Compile Include="NachoUI.iOS\NotesViewerViewController.designer.cs">
       <DependentUpon>NotesViewerViewController.cs</DependentUpon>
+    </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration6.cs">
+      <Link>NachoCore\Model\Migration\NcMigration6.cs</Link>
+    </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration8.cs">
+      <Link>NachoCore\Model\Migration\NcMigration8.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/Test.Android/Common/CommonUtils.cs
+++ b/Test.Android/Common/CommonUtils.cs
@@ -244,11 +244,12 @@ namespace Test.iOS
 
     public class PathOps : CommonTestOps
     {
-        public static McPath CreatePath (int accountId, string serverId = "", string parentId = "")
+        public static McPath CreatePath (int accountId, string serverId = "", string parentId = "", bool isFolder = false)
         {
             var path = new McPath (accountId);
             path.ServerId = serverId;
             path.ParentId = parentId;
+            path.IsFolder = isFolder;
             path.Insert ();
             return path;
         }

--- a/Test.Android/McPathTest.cs
+++ b/Test.Android/McPathTest.cs
@@ -20,7 +20,7 @@ namespace Test.iOS
         // returns the root node
         public McPathNode CreateTree (int accountId, uint numSubChildren = 3)
         {
-            var root = CreatePath (accountId, serverId: "1", parentId: "0");
+            var root = CreatePath (accountId, serverId: "1", parentId: "0", isFolder: true);
             var node = new McPathNode (root);
 
             // create children, each with a different serverId
@@ -39,7 +39,11 @@ namespace Test.iOS
             }
 
             for (int i = 0; i < 3; ++i) {
-                var newPath = CreatePath (accountId, parentId: parent.Root.ServerId, serverId: serverId.ToString ());
+                var newPath = CreatePath (accountId, 
+                    parentId: parent.Root.ServerId, 
+                    serverId: serverId.ToString (),
+                    isFolder: (numLayers - 1) > 0
+                );
                 var newNode = new McPathNode (newPath);
                 parent.Children.Add (newNode);
                 serverId++;
@@ -59,9 +63,14 @@ namespace Test.iOS
             // find root
             var foundRoot = McPath.QueryById<McPath> (node.Root.Id);
             Assert.NotNull (foundRoot, "Root should not have been deleted");
-
+            if (childrenExpected) {
+                Assert.IsTrue (foundRoot.IsFolder);
+            }
             // find children
-            var foundChildren = McPath.QueryByParentId (accountId, node.Root.ServerId);
+            var foundFolders = McPath.QueryByParentId (accountId, node.Root.ServerId, true);
+            var foundItems = McPath.QueryByParentId (accountId, node.Root.ServerId, false);
+            var foundChildren = foundFolders.ToList ();
+            foundChildren.AddRange (foundItems);
             Assert.AreEqual (3, foundChildren.ToList ().Count, "Should have correct number of children");
 
             var sortedChildren = foundChildren.OrderBy (c => Convert.ToInt32 (c.ServerId)).ToList ();
@@ -153,6 +162,31 @@ namespace Test.iOS
                 compare (top, bottom);
                 TraverseTreeWithOp (bottom, compare);
             }
+        }
+
+        [Test]
+        public void TestDeleteNonFolderByParentId ()
+        {
+            int accountId = 99;
+            var tree1 = CreateTree (accountId);
+            var tree2 = CreateTree (accountId + 1);
+            McPath.DeleteNonFolderByParentId (accountId, tree1.Root.ServerId);
+            var folders = McPath.QueryByParentId (accountId, tree1.Root.ServerId, true);
+            Assert.AreEqual (3, folders.ToList ().Count);
+            var leaves = McPath.QueryByParentId (accountId, tree1.Root.ServerId, false);
+            Assert.AreEqual (0, leaves.ToList ().Count);
+            // All children of root are folders.
+            ValidateTree (accountId, tree1);
+            var lowestFolder0 = tree1.Children [0];
+            var lowestFolder1 = tree1.Children [1];
+            leaves = McPath.QueryByParentId (accountId, lowestFolder0.Root.ServerId, false);
+            Assert.AreEqual (3, leaves.ToList ().Count);
+            McPath.DeleteNonFolderByParentId (accountId, lowestFolder0.Root.ServerId);
+            leaves = McPath.QueryByParentId (accountId, lowestFolder0.Root.ServerId, false);
+            Assert.AreEqual (0, leaves.ToList ().Count);
+            ValidateTree (accountId + 1, tree2);
+            leaves = McPath.QueryByParentId (accountId, lowestFolder1.Root.ServerId, false);
+            Assert.AreEqual (3, leaves.ToList ().Count);
         }
     }
 


### PR DESCRIPTION
leaving aside for the moment the reason WHY we deleted the folder's McPath, make the legitimate deletion of a folder in McPath fast (not a Delete()-a-thon).
