### PR TITLE
Make sure that contacts with different suffixes will not be eclipsed by mistake.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -1584,7 +1584,11 @@ namespace NachoCore.Model
 
         public bool HasSameName (McContact other)
         {
-            return ((FirstName == other.FirstName) && (MiddleName == other.MiddleName) && (LastName == other.LastName));
+            return (
+                (FirstName == other.FirstName) &&
+                (MiddleName == other.MiddleName) &&
+                (LastName == other.LastName) &&
+                (Suffix == other.Suffix));
         }
 
         public bool IsAnonymous ()


### PR DESCRIPTION
This does not fix #89 but it was discovered from that bug. "Bob Smith" and "Bob Smith Jr." are different people and should not be considered for eclipsing.
