### PR TITLE
Open the correct message when tapping on a card in Hot view

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
@@ -686,12 +686,52 @@ namespace NachoClient.iOS
             }
         }
 
+        private int VisibleRow (UITableView tableView)
+        {
+            var visibleRows = tableView.IndexPathsForVisibleRows;
+            if (1 == visibleRows.Length) {
+                // Only one entry in the hot view.
+                return visibleRows [0].Row;
+            }
+            if (2 == visibleRows.Length) {
+                if (2 == messageThreads.Count ()) {
+                    // There isn't an easy way to tell which row is fully visible and which is only partially visible.
+                    // Pretend that no row is visible, so the caller will use the indexPath passed into RowSelected.
+                    return -1;
+                }
+                if (0 == visibleRows[0].Row) {
+                    // At the beginning.
+                    return 0;
+                } else {
+                    // At the end of the list.
+                    return visibleRows [1].Row;
+                }
+            }
+            if (3 == visibleRows.Length) {
+                // The normal case.  We are somewhere in the middle of the list.
+                return visibleRows [1].Row;
+            }
+            return -1;
+        }
+
         public override void RowSelected (UITableView tableView, NSIndexPath indexPath)
         {
+            // There appears to be a bug in Xamarin or iOS where the indexPath that is passed into RowSelected
+            // is sometimes incorrect.  I have not found the pattern for when the bug happens.  So we ignore
+            // the row that is passed in and figure out the message that is currently visible.  (This only works
+            // because the Hot view shows only one message at a time.  If the Hot view changes, this code will
+            // have to change.)
+            int selectedRow = VisibleRow (tableView);
+            if (0 > selectedRow) {
+                selectedRow = indexPath.Row;
+            }
+            if (selectedRow != indexPath.Row) {
+                Log.Warn (Log.LOG_UI, "HotListTableViewSource.RowSelected was passed a row index, {0}, that is not the currently visible cell, {1}", indexPath.Row, selectedRow);
+            }
             if (NoMessageThreads ()) {
                 return;
             }
-            var messageThread = messageThreads.GetEmailThread (indexPath.Row);
+            var messageThread = messageThreads.GetEmailThread (selectedRow);
             if (null == messageThread) {
                 return;
             }


### PR DESCRIPTION
There appears to be a bug in Xamarin or iOS where the indexPath that
is passed into HotListTableViewSource.RowSelected() is sometimes the
wrong row.  I haven't figured out the pattern of when the bug happens,
so the code has been changed to ignore the row that is passed in and
instead figure out which message is currently visible in the Hot view.

Fix #1336
