### PR TITLE
Don't crash when copying an attachment with null DisplayName

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McAbstrFileDesc.cs
+++ b/NachoClient.Android/NachoCore/Model/McAbstrFileDesc.cs
@@ -152,12 +152,15 @@ namespace NachoCore.Model
 
         public void SetDisplayName (string displayName)
         {
+            DisplayName = displayName;
+            LocalFileName = null;
+            if (null == displayName) {
+                return;
+            }
             string oldPath = null;
             if (0 < Id) {
                 oldPath = GetFilePath ();
             }
-            DisplayName = displayName;
-            LocalFileName = null;
             // See if we can make a legit LocalFileName. If we can't, leave it null.
             var tmp = NcModel.Instance.TmpPath (AccountId);
             Directory.CreateDirectory (tmp);


### PR DESCRIPTION
Fix nachocove/qa#106
