### PR TITLE
Change the hot event when the current hot event ends

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -142,6 +142,7 @@ namespace NachoClient.iOS
                 this.NavigationController.ToolbarHidden = true;
             }
             MaybeRefreshPriorityInbox ();
+            hotEventView.ViewWillAppear ();
         }
 
         public override void ViewDidAppear (bool animated)
@@ -188,6 +189,7 @@ namespace NachoClient.iOS
         public override void ViewWillDisappear (bool animated)
         {
             base.ViewWillDisappear (animated);
+            hotEventView.ViewWillDisappear ();
         }
 
         public override void PrepareForSegue (UIStoryboardSegue segue, NSObject sender)


### PR DESCRIPTION
When the event being displayed in the Hot event view comes to an end,
automatically change the view to show the next event on the calendar.

Fix #1573
