### PR TITLE
Fix nachocove/qa#120.  Dictation results come in without causing

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/UcAddressField.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/UcAddressField.cs
@@ -105,6 +105,12 @@ namespace NachoClient.iOS
             NcAssert.True (null != field);
             field.BecomeFirstResponder ();
         }
+
+        public override void DictationRecordingDidEnd ()
+        {
+            this.Delegate.ShouldChangeCharacters (this, new NSRange (0, this.Text.Length), this.Text);
+            this.Text = "";
+        }
     };
 }
 


### PR DESCRIPTION
Fix nachocove/qa#120.  Dictation results come in without causing an onChanged event so we hook the end of dictation & send all of the text to our onChanged handler.
