### PR TITLE
Fix #1600.  Say "You can add hot messages" instead of "Start adding...."

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
@@ -480,9 +480,9 @@ namespace NachoClient.iOS
             NSMutableAttributedString lastCardMessage = null;
 
             if (NoMessageThreads ()) {
-                lastCardMessage = new NSMutableAttributedString ("You do not have any Hot messages. \n \nStart adding Hot messages by tapping on the  ", stringAttributes);
+                lastCardMessage = new NSMutableAttributedString ("You do not have any Hot messages. \n \nYou can add Hot messages by tapping on the  ", stringAttributes);
             } else {
-                lastCardMessage = new NSMutableAttributedString ("Start adding Hot messages by tapping on the  ", stringAttributes);
+                lastCardMessage = new NSMutableAttributedString ("You can add Hot messages by tapping on the  ", stringAttributes);
             }
             var lastCardMessagePartTwo = new NSAttributedString ("  icon in your mail.", stringAttributes);
 


### PR DESCRIPTION
Fix #1600. We said "start adding hot messages" which might be confusing if they have hot messages or have already added hot messages, so we just say "You can add hot...."
