### PR TITLE
Show the correct attendees and user's response in event exceptions

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McAbstrCalendarRoot.cs
+++ b/NachoClient.Android/NachoCore/Model/McAbstrCalendarRoot.cs
@@ -106,6 +106,16 @@ namespace NachoCore.Model
             return HasReminder () ? Reminder : 0;
         }
 
+        public virtual bool HasResponseType ()
+        {
+            return ResponseTypeIsSet;
+        }
+
+        public virtual NcResponseType GetResponseType ()
+        {
+            return HasResponseType () ? ResponseType : NcResponseType.None;
+        }
+
         // Attendees that are stored in the database.
         private List<McAttendee> dbAttendees = null;
         // Attendees that were set by the app, either UI or sync.  They don't get saved to the database
@@ -113,7 +123,7 @@ namespace NachoCore.Model
         private IList<McAttendee> appAttendees = null;
 
         [Ignore]
-        public IList<McAttendee> attendees {
+        public virtual IList<McAttendee> attendees {
             get {
                 return GetAncillaryCollection (appAttendees, ref dbAttendees, ReadDbAttendees);
             }
@@ -159,7 +169,7 @@ namespace NachoCore.Model
         private IList<McCalendarCategory> appCategories = null;
 
         [Ignore]
-        public IList<McCalendarCategory> categories {
+        public virtual IList<McCalendarCategory> categories {
             get {
                 return GetAncillaryCollection (appCategories, ref dbCategories, ReadDbCategories);
             }

--- a/NachoClient.Android/NachoCore/Model/McException.cs
+++ b/NachoClient.Android/NachoCore/Model/McException.cs
@@ -43,15 +43,66 @@ namespace NachoCore.Model
             return this.ReminderIsSet ? this.Reminder : CalendarItemOrSelf ().Reminder;
         }
 
+        public override bool HasResponseType ()
+        {
+            return this.ResponseTypeIsSet || CalendarItemOrSelf ().ResponseTypeIsSet;
+        }
+
+        public override NcResponseType GetResponseType ()
+        {
+            return this.ResponseTypeIsSet ? this.ResponseType : CalendarItemOrSelf ().ResponseType;
+        }
+
+        [Ignore]
+        public override IList<McAttendee> attendees {
+            get {
+                var exceptionAttendees = base.attendees;
+                if (0 == exceptionAttendees.Count) {
+                    var calendarItem = CalendarItem ();
+                    if (null != calendarItem) {
+                        return calendarItem.attendees;
+                    }
+                }
+                return exceptionAttendees;
+            }
+            set {
+                base.attendees = value;
+            }
+        }
+
+        [Ignore]
+        public override IList<McCalendarCategory> categories {
+            get {
+                var exceptionCategories = base.categories;
+                if (0 == exceptionCategories.Count) {
+                    var calendarItem = CalendarItem ();
+                    if (null != calendarItem) {
+                        return calendarItem.categories;
+                    }
+                }
+                return exceptionCategories;
+            }
+            set {
+                base.categories = value;
+            }
+        }
+
+        private McCalendar cachedCal = null;
+
+        private McCalendar CalendarItem ()
+        {
+            if (0 == CalendarId || 0 != Deleted) {
+                return null;
+            }
+            if (null == cachedCal || CalendarId != cachedCal.Id) {
+                cachedCal = McCalendar.QueryById<McCalendar> ((int)CalendarId);
+            }
+            return cachedCal;
+        }
+
         private McAbstrCalendarRoot CalendarItemOrSelf ()
         {
-            if (0 != CalendarId && 0 == Deleted) {
-                var calendarItem = McCalendar.QueryById<McCalendar> ((int)CalendarId);
-                if (null != calendarItem) {
-                    return calendarItem;
-                }
-            }
-            return this;
+            return (McAbstrCalendarRoot)CalendarItem () ?? this;
         }
 
         public static List<McException> QueryForExceptionId (int calendarId, DateTime exceptionStartTime)

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -450,12 +450,13 @@ namespace NachoClient.iOS
             }
 
             /// There are three cases which ensure the user is the organizer of an event.  
-            /// 1. The users email and account id match the event's organizer email and event's account id.
-            /// 2. The events ResponseType is set and it is set to Organizer.
-            /// 3. The events MeetingStatus is "Meeting"
-            /// if any of these are true the user is the organizer of the event.
-            isOrganizer = ((account.EmailAddr == root.OrganizerEmail && account.Id == c.AccountId) || (c.ResponseTypeIsSet && NcResponseType.Organizer == c.ResponseType)
-            || (NcMeetingStatus.Meeting == c.MeetingStatus));
+            /// 1. The user's email and account ID match the event's organizer email and event's account ID.
+            /// 2. The event's ResponseType is set to Organizer.
+            /// 3. The event's MeetingStatus is "Meeting"
+            /// If any of these are true the user is the organizer of the event.
+            isOrganizer = (account.EmailAddr == root.OrganizerEmail && account.Id == c.AccountId) ||
+                (c.HasResponseType () && NcResponseType.Organizer == c.GetResponseType ()) ||
+                (NcMeetingStatus.Meeting == c.MeetingStatus);
 
             if (isOrganizer && !isRecurring) {
                 NavigationItem.RightBarButtonItem = editEventButton;
@@ -1113,8 +1114,8 @@ namespace NachoClient.iOS
                 declineLabel.Hidden = false;
                 rsvpSeparatorLine.Hidden = false;
 
-                if (c.ResponseTypeIsSet) {
-                    switch (c.ResponseType) {
+                if (c.HasResponseType ()) {
+                    switch (c.GetResponseType ()) {
                     case NcResponseType.Accepted:
                         acceptButton.Selected = true;
                         acceptButton.UserInteractionEnabled = false;


### PR DESCRIPTION
When a McException doesn't have a ResponseType, attendees, or
categories, then get those values from the underlying McCalendar item.

Fix nachocove/qa#140
