### PR TITLE
Fix nachocove/qa#150.

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -131,7 +131,7 @@ namespace NachoClient.iOS
                         var ex = e.ExceptionObject as Exception;
                         if (null != ex) {
                             // See if we can get the part of the stack that is getting lost in ThrowExceptionAsNative().
-                            Log.Error (Log.LOG_LIFECYCLE, "UnhandledException: {0}", ex.Message);
+                            Log.Error (Log.LOG_LIFECYCLE, "UnhandledException: {0}", ex);
                         }
                     } catch {
                     }


### PR DESCRIPTION
1. Do not rethrow OperationCanceledException. Instead of catching it, return it as an error in DoHttpRequest.
2. When parking, signal timeout cancellation so that the HTTP request itself is canceled.
3. Add missing park event in Parked state.
4. Log more than just the exception message in unhandled exception handler.
