### PR TITLE
Fix problem of contact's birthday being one day later than selected

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactEditViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactEditViewController.cs
@@ -2008,7 +2008,12 @@ namespace NachoClient.iOS
                     this.dateLabel.TextColor = A.Color_NachoTeal;
                     LayoutView ();
                 } else {
-                    dateAttribute.Value = datePicker.Date.ToDateTime ();
+                    // The user selected a date/time in the local time zone.  (The picker only showed the date, but
+                    // there was also a hidden time component.)  But datePicker.Date returns a date/time in UTC, which
+                    // might be on a different date.  So we need to convert back to local time, extract the date,
+                    // then construct a new DateTime with that date in UTC.
+                    DateTime selectedDate = datePicker.Date.ToDateTime ().ToLocalTime ().Date;
+                    dateAttribute.Value = new DateTime (selectedDate.Year, selectedDate.Month, selectedDate.Day, 0, 0, 0, DateTimeKind.Utc);
                     dateView.Hidden = true;
                     this.dateLabel.TextColor = A.Color_NachoGreen;
                     ConfigureView ();
@@ -2030,7 +2035,9 @@ namespace NachoClient.iOS
 
             protected void DateLabelClicked (object sender, EventArgs e)
             {
-                dateAttribute.Value = datePicker.Date.ToDateTime ();
+                // See comment in DateClicked(), above.
+                DateTime selectedDate = datePicker.Date.ToDateTime ().ToLocalTime ().Date;
+                dateAttribute.Value = new DateTime (selectedDate.Year, selectedDate.Month, selectedDate.Day, 0, 0, 0, DateTimeKind.Utc);
                 owner.View.EndEditing (true);
                 owner.editingBlockType = BlockType.Date;
                 owner.editingDateCell = this;

--- a/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
@@ -1135,7 +1135,7 @@ namespace NachoClient
         public static DateTime ToDateTime (this NSDate nsDate)
         {
             // TODO: Why not just a cast?
-            return (new DateTime (2001, 1, 1, 0, 0, 0)).AddSeconds (nsDate.SecondsSinceReferenceDate);
+            return (new DateTime (2001, 1, 1, 0, 0, 0, DateTimeKind.Utc)).AddSeconds (nsDate.SecondsSinceReferenceDate);
         }
 
         public static string PrettyPointF (CGPoint p)


### PR DESCRIPTION
If a user selected a birthday or anniversary for a contact, the date
would sometimes be one day earlier or later than what the user
selected.  This would happen if the local time was on a different day
from UTC, which is true in the evening in Pactific Time.  The problem
has been fixed by being more careful about which times are local and
which are UTC.

Fix nachocove/qa#141
