### PR TITLE
Fix nachocove/qa#149.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -240,7 +240,7 @@ namespace NachoCore.Model
                 Db.CreateTable<McMapEmailAddressEntry> ();
                 Db.CreateTable<McMigration> ();
             });
-            watch.Stop();
+            watch.Stop ();
             QueueLogInfo (string.Format ("NcModel: Db.CreateTables took {0}ms.", watch.ElapsedMilliseconds));
             ConfigureDb (Db);
         }
@@ -317,6 +317,12 @@ namespace NachoCore.Model
                     }
                 }
                 return instance; 
+            }
+        }
+
+        public static bool IsInitialized {
+            get {
+                return (null != instance);
             }
         }
 


### PR DESCRIPTION
When the first log in FinishedLaunching() is called, it tries to access NcModel.Instance which causes its constructor to be called. On fresh install of older devices (seen in Vikas's iPhone 5 and my iPad 2), the create table call is too slow and that triggers a log info of "SQLite-UI ..." that once again access NcModel.Instance and we go thru the whole constructor dance again. On 32-bit platform where the SQLite error callback is installed, this causes a callback because the db file is recreated by the 2nd constructor. The error log another message that leads to a busy. (Remember the table creations are now inside a transaction.) Then, the app crashes.

The root problem is that we should not allow recursion induced by logging. So ff NcModel instance is not initialized, queue the log event in order to avoid a recursion in the instnace constructor.
