### PR TITLE
Fix nachocove/qa#130

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcTokenizer.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcTokenizer.cs
@@ -119,6 +119,11 @@ namespace NachoCore.Brain
                     return ProcessAlternativeMultipart (multipart);
                 } else if (multipart.ContentType.Matches ("multipart", "mixed")) {
                     return ProcessMixedMultipart (multipart);
+                } else if (multipart.ContentType.Matches ("multipart", "related")) {
+                    // The handling of multipart/related is the same as multipart/mixed.
+                    // Just iterate through all its subparts and add the ones that can be
+                    // indexed.
+                    return ProcessMixedMultipart (multipart);
                 } else {
                     // Unsupported multipart
                     Log.Warn (Log.LOG_BRAIN, "ProcessMimeEntity: unsupported multipart type {0}/{1}",


### PR DESCRIPTION
Handle multipart/related just like multipart/mixed. It simply walks all subparts and add the ones that it can index into the part list.
