### PR TITLE
Fix event detail view when there are exactly five attendees

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -610,13 +610,13 @@ namespace NachoClient.iOS
 
                     spacing += (attendeeImageDiameter + iconPadding);
                     if (4 <= ++attendeeNum && 5 < c.attendees.Count) {
-                        // There is room for four attendees in the view.  If the meeting
+                        // There is room for five attendees in the view.  If the meeting
                         // has more than five attendees, only show four of them and save
                         // the last slot for showing the number of extra attendees.
                         break;
                     }
                 }
-                if (4 < c.attendees.Count) {
+                if (5 < c.attendees.Count) {
                     extraAttendeesButton = UIButton.FromType (UIButtonType.RoundedRect);
                     extraAttendeesButton.Layer.CornerRadius = attendeeImageDiameter / 2;
                     extraAttendeesButton.Layer.MasksToBounds = true;


### PR DESCRIPTION
When a meeting had exactly five attendees, the event detail view was
showing all five of them, but the fifth one had a circle with a +1
superimposed over it.  When there is exactly five attendees, we want
to simply show all five.  When there are more than five, then show
just for of them and use the last slot to indicate how many more
attendees are not being shown in this view.

This same bug was fixed a while ago in BodyCalendarView, but not in
EventViewController.
