### PR TITLE
Park PA SM on a force stop as well.

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
@@ -1313,6 +1313,9 @@ namespace NachoCore.ActiveSync
 
         public override void ForceStop ()
         {
+            if (null != PushAssist) {
+                PushAssist.Park ();
+            }
             Sm.PostEvent ((uint)CtlEvt.E.Park, "FORCESTOP");
             if (null != PendingOnTimeTimer) {
                 PendingOnTimeTimer.Dispose ();


### PR DESCRIPTION
PA SM is not being properly parked when background fetch is done because during background fetch ForceStop() is used not DoPark(). Add a PA SM call to park it there.
