### PR TITLE
Execute PA SM from Start state as well. When AS SM drives, start PA SM.

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
@@ -1273,6 +1273,11 @@ namespace NachoCore.ActiveSync
 
         private void DoDrive ()
         {
+            if (null != PushAssist) {
+                if (PushAssist.IsStartOrParked ()) {
+                    PushAssist.Execute ();
+                }
+            }
             switch (ProtocolState.ProtoControlState) {
             case (uint)Lst.UiCertOkW:
             case (uint)Lst.UiDCrdW:
@@ -1304,7 +1309,7 @@ namespace NachoCore.ActiveSync
             if (null != PushAssist) {
                 if (PushAssist.IsActive ()) {
                     PushAssist.Defer ();
-                } else if (PushAssist.IsParked ()) {
+                } else if (PushAssist.IsStartOrParked ()) {
                     PushAssist.Execute ();
                 }
             }

--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -512,6 +512,16 @@ namespace NachoCore
             return ((uint)Lst.Parked == Sm.State);
         }
 
+        public bool IsStart ()
+        {
+            return ((uint)St.Start == Sm.State);
+        }
+
+        public bool IsStartOrParked ()
+        {
+            return IsStart () || IsParked ();
+        }
+
         private void PostEvent (SmEvt.E evt, string mnemonic)
         {
             Sm.PostEvent ((uint)evt, mnemonic);


### PR DESCRIPTION
See a case where PA SM is not started during a quick sync. This happens because if we park PA SM before it goes to Active, it actually goes back to Start. So, a PA SM launch conditioned on a Parked state will not start it at all.
