### PR TITLE
Tool to create a large meeting with lots of attendees and exceptions

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ManageItemsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ManageItemsViewController.cs
@@ -11,6 +11,7 @@ namespace NachoClient.iOS
     public class ManageItemsViewController : NcUIViewControllerNoLeaks
     {
         private UIButton populateCalendarButton;
+        private UIButton megaMeetingButton;
         private UIButton cleanCalendarButton;
 
         public ManageItemsViewController ()
@@ -41,8 +42,16 @@ namespace NachoClient.iOS
             populateCalendarButton.TouchUpInside += PopulateCalendar;
             View.AddSubview (populateCalendarButton);
 
+            megaMeetingButton = new UIButton (UIButtonType.System);
+            megaMeetingButton.Frame = new CGRect (10, 70, 200, 50);
+            megaMeetingButton.SetTitle ("Mega Meeting", UIControlState.Normal);
+            megaMeetingButton.SetTitle ("Creating meeting...", UIControlState.Selected);
+            megaMeetingButton.HorizontalAlignment = UIControlContentHorizontalAlignment.Left;
+            megaMeetingButton.TouchUpInside += MegaMeeting;
+            View.AddSubview (megaMeetingButton);
+
             cleanCalendarButton = new UIButton (UIButtonType.System);
-            cleanCalendarButton.Frame = new CGRect (10, 70, 200, 50);
+            cleanCalendarButton.Frame = new CGRect (10, 130, 200, 50);
             cleanCalendarButton.SetTitle ("Clean Calendar", UIControlState.Normal);
             cleanCalendarButton.SetTitle ("Cleaning Calendar...", UIControlState.Selected);
             cleanCalendarButton.HorizontalAlignment = UIControlContentHorizontalAlignment.Left;
@@ -57,14 +66,21 @@ namespace NachoClient.iOS
         protected override void Cleanup ()
         {
             populateCalendarButton.TouchUpInside -= PopulateCalendar;
+            megaMeetingButton.TouchUpInside -= MegaMeeting;
             cleanCalendarButton.TouchUpInside -= CleanCalendar;
             populateCalendarButton = null;
+            megaMeetingButton = null;
             cleanCalendarButton = null;
         }
 
         private void PopulateCalendar (object sender, EventArgs args)
         {
             ButtonTouched (populateCalendarButton, ManageItems.PopulateCalendar, "FillCalendar");
+        }
+
+        private void MegaMeeting (object sender, EventArgs args)
+        {
+            ButtonTouched (megaMeetingButton, ManageItems.MegaMeeting, "MegaMeeting");
         }
 
         private void CleanCalendar (object sender, EventArgs args)


### PR DESCRIPTION
Enhance the tool to fill a calendar in two ways:
1. When filling the calendar with lots of events, have some of the
   events be meetings, not just appointments.
2. Add a button to generate a mega-meeting, with 99 attendees and 95
   exceptions, where each exception has a slightly different list of 99
   attendees.  The purpose of this meeting is to maximize the number of
   database operations needed to save the meeting.
