### PR TITLE
Fix some cases where push notifications are missing

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -553,6 +553,7 @@ namespace NachoClient.iOS
 
             case NcResult.SubKindEnum.Info_SyncSucceeded:
                 Log.Info (Log.LOG_LIFECYCLE, "FetchStatusHandler:Info_SyncSucceeded");
+                BadgeNotifUpdate ();
                 CompletePerformFetch ();
                 break;
 
@@ -709,7 +710,7 @@ namespace NachoClient.iOS
             StatusIndEventArgs ea = (StatusIndEventArgs)e;
             // Use Info_SyncSucceeded rather than Info_NewUnreadEmailMessageInInbox because
             // we want to remove a notification if the server marks a message as read.
-            if (NcResult.SubKindEnum.Info_SyncSucceeded == ea.Status.SubKind && null != ea.Account && ea.Account.Id == NcApplication.Instance.Account.Id) {
+            if (NcResult.SubKindEnum.Info_SyncSucceeded == ea.Status.SubKind) {
                 BadgeNotifUpdate ();
             }
         }
@@ -871,6 +872,7 @@ namespace NachoClient.iOS
         {
             Log.Info (Log.LOG_UI, "BadgeNotifUpdate: called");
             if (!BadgeNotifAllowed) {
+                Log.Info (Log.LOG_UI, "BadgeNotifUpdate: early exit");
                 return;
             }
             var datestring = McMutables.GetOrCreate (McAccount.GetDeviceAccount ().Id, "IOS", "GoInactiveTime", DateTime.UtcNow.ToString ());


### PR DESCRIPTION
Do not check account id before updating badge for couple reasons. First, some sync succeed indications are sent without account. Second, for multi account support, that account check is not right anyway. 

During fetch completion, call badge update to make sure it is updated. This may be redundant but calling BadgeNotifUpdate() does no harm (other than waste a little bit of battery) and the extra call is to make sure that quick sync exits with badge updated.
