### PR TITLE
Message list performance changes

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/INachoEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/INachoEmailMessages.cs
@@ -15,7 +15,11 @@ namespace NachoCore
         /// </summary>
         bool Refresh (out List<int> adds, out List<int> deletes);
 
+        // Returns the thread, not the messages
         McEmailMessageThread GetEmailThread (int i);
+
+        // Need to use the same query to fetch the thread
+        List<McEmailMessageThread> GetEmailThreadMessages (int i);
 
         string DisplayName ();
 

--- a/NachoClient.Android/NachoCore/Adapters/NachoDeferredEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoDeferredEmailMessages.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NachoCore;
 using NachoCore.Model;
 using NachoCore.Brain;
+using NachoCore.Utils;
 
 namespace NachoCore
 {
@@ -39,7 +40,19 @@ namespace NachoCore
         public McEmailMessageThread GetEmailThread (int i)
         {
             var t = threadList.ElementAt (i);
+            t.Source = this;
             return t;
+        }
+
+        public List<McEmailMessageThread> GetEmailThreadMessages (int id)
+        {
+            var message = McEmailMessage.QueryById<McEmailMessage> (id);
+            if (null == message) {
+                return new List<McEmailMessageThread> ();
+            } else {
+                var thread = McEmailMessage.QueryDeferredMessageItemsAllAccountsByThreadId (message.ConversationId);
+                return thread;
+            }
         }
 
         public string DisplayName ()
@@ -90,7 +103,18 @@ namespace NachoCore
         public McEmailMessageThread GetEmailThread (int i)
         {
             var t = threadList.ElementAt (i);
+            t.Source = this;
             return t;
+        }
+
+        public List<McEmailMessageThread> GetEmailThreadMessages (int id)
+        {
+            var thread = new List<McEmailMessageThread> ();
+            var m = new McEmailMessageThread ();
+            m.FirstMessageId = id;
+            m.MessageCount = 1;
+            thread.Add (m);
+            return thread;
         }
 
         public string DisplayName ()

--- a/NachoClient.Android/NachoCore/Adapters/NachoEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoEmailMessages.cs
@@ -50,7 +50,19 @@ namespace NachoCore
                 return null;
             }
             var t = threadList.ElementAt (i);
+            t.Source = this;
             return t;
+        }
+
+        public List<McEmailMessageThread> GetEmailThreadMessages (int id)
+        {
+            var message = McEmailMessage.QueryById<McEmailMessage> (id);
+            if (null == message) {
+                return new List<McEmailMessageThread> ();
+            } else {
+                var thread = McEmailMessage.QueryActiveMessageItemsByThreadId (folder.AccountId, folder.Id, message.ConversationId);
+                return thread;
+            }
         }
 
         public string DisplayName ()

--- a/NachoClient.Android/NachoCore/Adapters/NachoThreadedEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoThreadedEmailMessages.cs
@@ -44,7 +44,18 @@ namespace NachoCore
         public McEmailMessageThread GetEmailThread (int i)
         {
             var t = threadList.ElementAt (i);
+            t.Source = this;
             return t;
+        }
+
+        public List<McEmailMessageThread> GetEmailThreadMessages (int id)
+        {
+            var thread = new List<McEmailMessageThread> ();
+            var m = new McEmailMessageThread ();
+            m.FirstMessageId = id;
+            m.MessageCount = 1;
+            thread.Add (m);
+            return thread;
         }
 
         public string DisplayName ()

--- a/NachoClient.Android/NachoCore/Adapters/NcEmailManager.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcEmailManager.cs
@@ -68,6 +68,12 @@ namespace NachoCore
                 return null;
             }
 
+            public List<McEmailMessageThread> GetEmailThreadMessages (int id)
+            {
+                NcAssert.CaseError ();
+                return null;
+            }
+
             public string DisplayName ()
             {
                 return displayName;

--- a/NachoClient.Android/NachoCore/Adapters/UserInteractionEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/UserInteractionEmailMessages.cs
@@ -24,7 +24,7 @@ namespace NachoCore
             List<int> deletes;
             Refresh (out adds, out deletes);
         }
-            
+
         public bool Refresh (out List<int> adds, out List<int> deletes)
         {
             adds = null;
@@ -55,7 +55,21 @@ namespace NachoCore
         public McEmailMessageThread GetEmailThread (int i)
         {
             var t = threadList.ElementAt (i);
+            t.Source = this;
             return t;
+        }
+
+
+        // Add messages make up the thread, just the user ones
+        public List<McEmailMessageThread> GetEmailThreadMessages (int id)
+        {
+            var message = McEmailMessage.QueryById<McEmailMessage> (id);
+            if (null == message) {
+                return new List<McEmailMessageThread> ();
+            } else {
+                var thread = McEmailMessage.QueryActiveMessageItemsByThreadId (folder.AccountId, folder.Id, message.ConversationId);
+                return thread;
+            }
         }
 
         public string DisplayName ()

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -1082,7 +1082,6 @@ namespace NachoCore.ActiveSync
             }
             emailMessage.Categories = categories;
             if (null == emailMessage.ConversationId) {
-                Log.Info (Log.LOG_AS, "ProcessEmailItem conversation id is null: {0}", emailMessage.ServerId);
                 emailMessage.ConversationId = System.Guid.NewGuid ().ToString ();
             }
             return NcResult.OK (emailMessage);

--- a/NachoClient.Android/NachoCore/Brain/NcMessageThreads.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcMessageThreads.cs
@@ -14,41 +14,24 @@ namespace NachoCore.Brain
         {
         }
 
-        static public List<McEmailMessageThread> ThreadByConversation (List<NcEmailMessageIndex> list)
+        static public List<McEmailMessageThread> ThreadByConversation (List<McEmailMessageThread> list)
         {
             if (null == list) {
                 return new List<McEmailMessageThread> ();
+            } else {
+                return list;
             }
-            var conversationList = new List<McEmailMessageThread> ();
-            var conversationId = new Dictionary<string, McEmailMessageThread> ();
-            for (int i = 0; i < list.Count; i++) {
-                McEmailMessageThread message;
-                if (!conversationId.TryGetValue (list [i].ThreadId, out message)) {
-                    message = new McEmailMessageThread ();
-                    conversationList.Add (message);
-                    conversationId.Add (list [i].ThreadId, message);
-                }
-                message.Add (list [i]);
-            }
-            return conversationList;
         }
 
-        static public List<McEmailMessageThread> ThreadByMessage (List<NcEmailMessageIndex> list)
+        static public List<McEmailMessageThread> ThreadByMessage (List<McEmailMessageThread> list)
         {
             if (null == list) {
                 return new List<McEmailMessageThread> ();
+            } else {
+                return list;
             }
-            var threadList = new List<McEmailMessageThread> ();
-            for (var i = 0; i < list.Count; i++) {
-                var newEmailMessageIndex = new NcEmailMessageIndex ();
-                newEmailMessageIndex.Id = list [i].Id;
-                var newEmailMessageThread = new McEmailMessageThread ();
-                newEmailMessageThread.Add (newEmailMessageIndex);
-                threadList.Add (newEmailMessageThread);
-            }
-            return threadList;
         }
-
+            
         // Return true or false if old and new lists are different.
         // Return 'deletes' if a series of deletes can transform oldList into newList.
         protected static bool CheckForDeletes (List<McEmailMessageThread> oldList, List<McEmailMessageThread> newList, out List<int> deletes)
@@ -68,8 +51,8 @@ namespace NachoCore.Brain
             int oldListIndex = 0;
             int newListIndex = 0;
             while ((oldListIndex < oldList.Count) && (newListIndex < newList.Count)) {
-                var oldId = oldList [oldListIndex].GetEmailMessageIndex (0).Id;
-                var newId = newList [newListIndex].GetEmailMessageIndex (0).Id;
+                var oldId = oldList [oldListIndex].FirstMessageSpecialCaseIndex ();
+                var newId = newList [newListIndex].FirstMessageSpecialCaseIndex ();
                 if (oldId != newId) {
                     deletes.Add (oldListIndex);
                 } else {
@@ -117,8 +100,8 @@ namespace NachoCore.Brain
             int newListIndex = 0;
 
             while ((oldListIndex < oldList.Count) && (newListIndex < newList.Count)) {
-                var oldId = oldList [oldListIndex].GetEmailMessageIndex (0).Id;
-                var newId = newList [newListIndex].GetEmailMessageIndex (0).Id;
+                var oldId = oldList [oldListIndex].FirstMessageSpecialCaseIndex ();
+                var newId = newList [newListIndex].FirstMessageSpecialCaseIndex ();
                 if (oldId != newId) {
                     adds.Add (newListIndex);
                 } else {

--- a/NachoClient.iOS/NachoCore/Adapters/NachoDeadlineEmailMessages.cs
+++ b/NachoClient.iOS/NachoCore/Adapters/NachoDeadlineEmailMessages.cs
@@ -39,7 +39,19 @@ namespace NachoCore
         public McEmailMessageThread GetEmailThread (int i)
         {
             var t = threadList.ElementAt (i);
+            t.Source = this;
             return t;
+        }
+
+        public List<McEmailMessageThread> GetEmailThreadMessages (int id)
+        {
+            var message = McEmailMessage.QueryById<McEmailMessage> (id);
+            if (null == message) {
+                return new List<McEmailMessageThread> ();
+            } else {
+                var thread = McEmailMessage.QueryDueDateMessageItemsAllAccountsByThreadId (message.ConversationId);
+                return thread;
+            }
         }
 
         public string DisplayName ()
@@ -90,7 +102,18 @@ namespace NachoCore
         public McEmailMessageThread GetEmailThread (int i)
         {
             var t = threadList.ElementAt (i);
+            t.Source = this;
             return t;
+        }
+
+        public List<McEmailMessageThread> GetEmailThreadMessages (int id)
+        {
+            var thread = new List<McEmailMessageThread> ();
+            var m = new McEmailMessageThread ();
+            m.FirstMessageId = id;
+            m.MessageCount = 1;
+            thread.Add (m);
+            return thread;
         }
 
         public string DisplayName ()

--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -290,7 +290,7 @@ namespace NachoClient.iOS
             }
             if (NcResult.SubKindEnum.Info_EmailSearchCommandSucceeded == s.Status.SubKind) {
                 Log.Debug (Log.LOG_UI, "StatusIndicatorCallback: Info_EmailSearchCommandSucceeded");
-                UpdateSearchResultsFromServer (s.Status.GetValue<List<NcEmailMessageIndex>> ());
+                UpdateSearchResultsFromServer (s.Status.GetValue<List<McEmailMessageThread>> ());
             }
         }
 
@@ -523,7 +523,7 @@ namespace NachoClient.iOS
             }
         }
 
-        protected void UpdateSearchResultsFromServer (List<NcEmailMessageIndex> list)
+        protected void UpdateSearchResultsFromServer (List<McEmailMessageThread> list)
         {
             searchResultsMessages.UpdateServerMatches (list);
             List<int> adds;

--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -178,9 +178,8 @@ namespace NachoClient.iOS
                 var messageId = int.Parse (emailNotification.Value);
                 emailNotification.Delete ();
                 var t = new McEmailMessageThread ();
-                var m = new NcEmailMessageIndex ();
-                m.Id = messageId;
-                t.Add (m);
+                t.FirstMessageId = messageId;
+                t.MessageCount = 1;
                 PerformSegue ("NachoNowToMessageView", new SegueHolder (t));
                 return;
             }

--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -79,17 +79,6 @@ namespace NachoClient.iOS
             return messageThreads.GetAdapterForThread (threadId);
         }
 
-        public McEmailMessageThread GetFirstThread ()
-        {
-            if (null == this.messageThreads) {
-                return null;
-            }
-            if (0 == this.messageThreads.Count ()) {
-                return null;
-            }
-            return this.messageThreads.GetEmailThread (0);
-        }
-
         public bool RefreshEmailMessages (out List<int> adds, out List<int> deletes)
         {
             RefreshCapture.Start ();

--- a/Test.Android/NcMessageThreadsTest.cs
+++ b/Test.Android/NcMessageThreadsTest.cs
@@ -27,22 +27,22 @@ namespace Test.Common
             var list = new List<McEmailMessageThread> ();
 
             foreach (var v in values) {
-                var n = new NcEmailMessageIndex ();
-                n.Id = v;
-                var e = new McEmailMessageThread ();
-                e.Add (n);
-                list.Add (e);
+                var n = new McEmailMessageThread ();
+                n.FirstMessageId = v;
+                n.MessageCount = 1;
+                list.Add (n);
             }
             return list;
         }
 
         public List<McEmailMessageThread> CreateMessageIndexList (params int[] values)
         {
-            var list = new List<NcEmailMessageIndex> ();
+            var list = new List<McEmailMessageThread> ();
 
             foreach (var v in values) {
-                var n = new NcEmailMessageIndex ();
-                n.Id = v;
+                var n = new McEmailMessageThread ();
+                n.FirstMessageId = v;
+                n.MessageCount = 1;
                 list.Add (n);
             }
             return NcMessageThreads.ThreadByMessage (list);
@@ -139,26 +139,26 @@ namespace Test.Common
 
         }
 
-        [Test]
-        public void NoDups()
-        {
-            var t = new McEmailMessageThread ();
-            var m1a = new NcEmailMessageIndex ();
-            m1a.Id = 1;
-            t.Add (m1a);
-            var m1b = new NcEmailMessageIndex ();
-            m1b.Id = 1;
-            t.Add (m1b);
-            Assert.AreEqual (1, t.Count);
-            var m2a = new NcEmailMessageIndex ();
-            m2a.Id = 2;
-            t.Add (m2a);
-            Assert.AreEqual (2, t.Count);
-            var m2b = new NcEmailMessageIndex ();
-            m2b.Id = 2;
-            t.Add (m2b);
-            Assert.AreEqual (2, t.Count);
-        }
+//        [Test]
+//        public void NoDups()
+//        {
+//            var t = new McEmailMessageThread ();
+//            var m1a = new NcEmailMessageIndex ();
+//            m1a.Id = 1;
+//            t.Add (m1a);
+//            var m1b = new NcEmailMessageIndex ();
+//            m1b.Id = 1;
+//            t.Add (m1b);
+//            Assert.AreEqual (1, t.Count);
+//            var m2a = new NcEmailMessageIndex ();
+//            m2a.Id = 2;
+//            t.Add (m2a);
+//            Assert.AreEqual (2, t.Count);
+//            var m2b = new NcEmailMessageIndex ();
+//            m2b.Id = 2;
+//            t.Add (m2b);
+//            Assert.AreEqual (2, t.Count);
+//        }
     }
 }
 


### PR DESCRIPTION
Change the message-list queries to return threaded
results instead of all messages, which then needed
to be arranged into thread. Now the queries return
a list of thread headers instead of a full list of
message. Lot of code was slightly adapted for this
change with a major change --  a message index for
for a message in a thread is read on-demand.
