### PR TITLE
Fix nachocove/qa#167.  Make sure to always refresh the list view when it becomes visible.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -217,6 +217,8 @@ namespace NachoClient.iOS
 
         protected void MaybeRefreshThreads ()
         {
+            bool refreshVisibleCells = true;
+
             if (threadsNeedsRefresh) {
                 threadsNeedsRefresh = false;
                 NachoCore.Utils.NcAbate.HighPriority ("MessageListViewController MaybeRefreshThreads");
@@ -225,23 +227,26 @@ namespace NachoClient.iOS
                 List<int> deletes;
                 if (messageSource.RefreshEmailMessages (out adds, out deletes)) {
                     Util.UpdateTable (TableView, adds, deletes);
-                } else {
-                    messageSource.ReconfigureVisibleCells (TableView);
+                    refreshVisibleCells = false;
                 }
                 if (messageSource.NoMessageThreads ()) {
-                    MaybeDismissView ();
+                    refreshVisibleCells = !MaybeDismissView ();
                 }
                 if (searchDisplayController.Active) {
                     UpdateSearchResults ();
+                    refreshVisibleCells = false;
                 }
                 ReloadCapture.Stop ();
                 NachoCore.Utils.NcAbate.RegularPriority ("MessageListViewController MaybeRefreshThreads");
             }
+            if (refreshVisibleCells) {
+                messageSource.ReconfigureVisibleCells (TableView);
+            }
         }
 
-        public virtual void MaybeDismissView ()
+        public virtual bool MaybeDismissView ()
         {
-            // Nope, message views show 'empty'
+            return false;
         }
 
         public override void ViewWillAppear (bool animated)

--- a/NachoClient.iOS/NachoUI.iOS/MessageThreadViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageThreadViewController.cs
@@ -13,10 +13,11 @@ namespace NachoClient.iOS
 		{
 		}
 
-        public override void MaybeDismissView()
+        public override bool MaybeDismissView()
         {
             // Yes, thread views disappear when empty
             NavigationController.PopViewController (true);
+            return true;
         }
 	}
 }


### PR DESCRIPTION
Fix nachocove/qa#167.  Make sure to always refresh the list view when it becomes visible in case some values have changed.  Affects, for example, the bit that shows if a message is already read or is not/hot.
