### PR TITLE
Minor cleanup

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -494,6 +494,9 @@ namespace NachoCore
 
         public void Park ()
         {
+            if (!IsActive () && !IsStartOrParked ()) {
+                Log.Warn (Log.LOG_PUSH, "A start session is not established before being parked. Notifications will not be pushed.");
+            }
             PostEvent (PAEvt.E.Park, "PAPARK");
         }
 

--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -104,8 +104,6 @@ namespace NachoCore
             }
         }
 
-        private bool StartupMarked;
-
         public bool IsUp ()
         {
             return (ExecutionContextEnum.Migrating != ExecutionContext) && (ExecutionContextEnum.Initializing != ExecutionContext);
@@ -759,7 +757,6 @@ namespace NachoCore
                 var timestamp = String.Format ("{0}\n", DateTime.UtcNow);
                 var bytes = Encoding.ASCII.GetBytes (timestamp);
                 fileStream.Write (bytes, 0, bytes.Length);
-                StartupMarked = true;
             }
         }
 
@@ -769,7 +766,6 @@ namespace NachoCore
             if (File.Exists (startupLog)) {
                 try {
                     File.Delete (startupLog);
-                    StartupMarked = false;
                 } catch (Exception e) {
                     Log.Warn (Log.LOG_LIFECYCLE, "fail to delete starutp log (file={0}, exception={1})", startupLog, e.Message);
                 }


### PR DESCRIPTION
- Fix a compilation warning by removing an obsoleted variable.
- Add a warning to catch if we park PA SM before the pinger session is armed.
