### PR TITLE
More pinger / notification fixes

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -725,6 +725,10 @@ namespace NachoCore
             } else {
                 SessionToken = response.Token;
                 ClearRetry ();
+                NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () { 
+                    Status = NcResult.Info (NcResult.SubKindEnum.Info_PushAssistArmed),
+                    Account = Owner.Account,
+                });
                 PostSuccess ("START_SESSION_OK");
             }
         }

--- a/NachoClient.Android/NachoCore/Utils/NcResult.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcResult.cs
@@ -167,6 +167,7 @@ namespace NachoCore.Utils
             Info_NetworkStatus,
             Info_PushAssistDeviceToken,
             Info_PushAssistClientToken,
+            Info_PushAssistArmed,
         };
 
         public enum WhyEnum


### PR DESCRIPTION
- For sync failed to complete status indication, update badge as it may pick up some new emails.
- Move completion handler after final shutdown is called. As any processing after that may trigger OS killing the app. (Don't have hard evidence but some console logs suggest this.)
- Make sure that both sync is complete and pinger session is armed before early exit background fetch.
