### PR TITLE
non-UI half of #682

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -375,6 +375,7 @@
     <Compile Include="NachoCore\Model\Migration\NcMigration9.cs" />
     <Compile Include="NachoCore\Utils\ManageItems.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration10.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration11.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/NachoClient.Android/NachoCore/Model/McAccount.cs
+++ b/NachoClient.Android/NachoCore/Model/McAccount.cs
@@ -24,6 +24,11 @@ namespace NachoCore.Model
             GoogleExchange,
         };
 
+        public McAccount ()
+        {
+            DaysToSyncEmail = Xml.Provision.MaxAgeFilterCode.OneMonth_5;
+        }
+
         public AccountTypeEnum AccountType { get; set; }
 
         public AccountServiceEnum AccountService { get; set; }
@@ -40,8 +45,10 @@ namespace NachoCore.Model
 
         public string Culture { get; set; }
 
+        // Default is OneMonth_5. The only other supported valued is SyncAll_0.
         public ActiveSync.Xml.Provision.MaxAgeFilterCode DaysToSyncEmail { get; set; }
 
+        // DaysToSyncCalendar NYI.
         public ActiveSync.Xml.Provision.MaxAgeFilterCode DaysToSyncCalendar { get; set; }
 
         public int PreferredConferenceId { get; set; }

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration11.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration11.cs
@@ -1,0 +1,32 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+using System.Linq;
+using NachoCore.Utils;
+
+namespace NachoCore.Model
+{
+    public class NcMigration11 : NcMigration
+    {
+        public override int GetNumberOfObjects ()
+        {
+            return Db.Table<McAccount> ().Where (x => x.AccountType == McAccount.AccountTypeEnum.Exchange).Count ();
+        }
+
+        public override void Run (System.Threading.CancellationToken token)
+        {
+            foreach (var account in Db.Table<McAccount> ().Where (x => x.AccountType == McAccount.AccountTypeEnum.Exchange)) {
+                token.ThrowIfCancellationRequested ();
+                account.DaysToSyncEmail = NachoCore.ActiveSync.Xml.Provision.MaxAgeFilterCode.OneMonth_5;
+                account.Update ();
+                var protocolState = McProtocolState.QueryByAccountId<McProtocolState> (account.Id).FirstOrDefault ();
+                if (null != protocolState) {
+                    // to avoid a flood of soft deletes.
+                    protocolState.StrategyRung = 5;
+                    protocolState.Update ();
+                }
+                UpdateProgress (1);
+            }
+        }
+    }
+}

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1284,6 +1284,9 @@
     <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration10.cs">
       <Link>NachoCore\Model\Migration\NcMigration10.cs</Link>
     </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration11.cs">
+      <Link>NachoCore\Model\Migration\NcMigration11.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/Test.Android/AsStrategyTest.cs
+++ b/Test.Android/AsStrategyTest.cs
@@ -240,6 +240,14 @@ namespace Test.iOS
             conFolder.UpdateSet_AsSyncMetaToClientExpected (false);
             result = Strategy.CanAdvance (Account.Id, 5);
             Assert.True (result);
+            result = Strategy.CanAdvance (Account.Id, 6);
+            Assert.False (result);
+            Account.DaysToSyncEmail = Xml.Provision.MaxAgeFilterCode.SyncAll_0;
+            Account.Update ();
+            result = Strategy.CanAdvance (Account.Id, 6);
+            Assert.True (result);
+            Account.DaysToSyncEmail = Xml.Provision.MaxAgeFilterCode.OneMonth_5;
+            Account.Update ();
             // Add a McPending.
             var pending = new McPending (Account.Id) {
                 Operation = McPending.Operations.ContactDelete,


### PR DESCRIPTION
- We only support one month and all sync levels for email.
- We don't allow the user to adjust the cal sync level.
- Default is still one month.
- (bug) If you set it to all and let it sync up, and then change the setting to one month, we don't wind it backdown to one month, yet.
