### PR TITLE
Prevent events that end before they start

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -421,10 +421,12 @@ namespace NachoClient.iOS
             };
 
             doneButton.Clicked += (sender, e) => {
-                ExtractValues ();
-                SyncMeetingRequest ();
-                PrepareInvites ();
-                DismissView ();
+                if (CanBeSaved ()) {
+                    ExtractValues ();
+                    SyncMeetingRequest ();
+                    PrepareInvites ();
+                    DismissView ();
+                }
             };
 
             NavigationItem.LeftBarButtonItem = cancelButton;
@@ -1317,6 +1319,26 @@ namespace NachoClient.iOS
             var frame = view.Frame;
             frame.Y = yOffset;
             view.Frame = frame;
+        }
+
+        /// <summary>
+        /// Check if the data that the user entered is valid and can be saved as an event.  If not,
+        /// throw up a dialog explaining the problem to the user.
+        /// </summary>
+        /// <returns><c>true</c> if this instance can be saved; otherwise, <c>false</c>.</returns>
+        protected bool CanBeSaved ()
+        {
+            if (string.IsNullOrEmpty (titleField.Text)) {
+                var alert = new UIAlertView ("Cannot Save Event", "The title of the event must not be empty.", null, "OK");
+                alert.Show ();
+                return false;
+            }
+            if (startDate > endDate) {
+                var alert = new UIAlertView ("Cannot Save Event", "The starting time must be no later than the ending time.", null, "OK");
+                alert.Show ();
+                return false;
+            }
+            return true;
         }
 
         protected void ExtractValues ()


### PR DESCRIPTION
Add some validation when the user taps the Send or Done button in the
edit event view.  If the title of the event is empty, or if the ending
time of the event is earlier than the starting time, then tapping the
button doesn't save the event or dismiss the view.  Instead, an alert
pops up explaining the problem and the user is left in the editor.

Fix #1495
