### PR TITLE
Fix #1575.  Make sure that the tab bar is highlighted when there's an error.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcResult.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcResult.cs
@@ -168,6 +168,7 @@ namespace NachoCore.Utils
             Info_PushAssistDeviceToken,
             Info_PushAssistClientToken,
             Info_PushAssistArmed,
+            Info_UserInterventionFlagChanged,
         };
 
         public enum WhyEnum

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -779,7 +779,6 @@ namespace NachoClient.iOS
                 // called if server name is wrong
                 // cancel should call "exit program, enter new server name should be updated server
 
-                Util.GetActiveTabBar ().SetSettingsBadge (true);
                 LoginHelpers.SetDoesBackEndHaveIssues (LoginHelpers.GetCurrentAccountId (), true);
 
                 var Mo = NcModel.Instance;
@@ -796,7 +795,6 @@ namespace NachoClient.iOS
                     var parent = (UIAlertView)a;
                     if (b.ButtonIndex == 0) {
 
-                        Util.GetActiveTabBar ().SetSettingsBadge (false);
                         LoginHelpers.SetDoesBackEndHaveIssues (LoginHelpers.GetCurrentAccountId (), false);
 
                         var txt = parent.GetTextField (0).Text;
@@ -861,7 +859,6 @@ namespace NachoClient.iOS
 
         protected void DisplayCredentialsFixView ()
         {
-            Util.GetActiveTabBar ().SetSettingsBadge (true);
             LoginHelpers.SetDoesBackEndHaveIssues (LoginHelpers.GetCurrentAccountId (), true);
 
             UIStoryboard x = UIStoryboard.FromName ("MainStoryboard_iPhone", null);

--- a/NachoClient.iOS/NachoUI.iOS/CredentialsAskViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/CredentialsAskViewController.cs
@@ -165,7 +165,6 @@ namespace NachoClient.iOS
                     BackEnd.Instance.CredResp(UsersAccount.Id);
                     View.EndEditing(true);
                     DismissViewController(true, null);
-                    this.sendersTabBar.SetSettingsBadge(false);
                     LoginHelpers.SetDoesBackEndHaveIssues (LoginHelpers.GetCurrentAccountId (), false);
                 }else{
                     errorMessage.Text = "The email address you entered is not valid. Please update and try again.";
@@ -283,7 +282,6 @@ namespace NachoClient.iOS
         public void AcceptCertificate ()
         {
             NcApplication.Instance.CertAskResp (LoginHelpers.GetCurrentAccountId (), true);
-            Util.GetActiveTabBar().SetSettingsBadge(false);
             LoginHelpers.SetDoesBackEndHaveIssues (LoginHelpers.GetCurrentAccountId (), false);
             View.EndEditing(true);
             DismissViewController(true, null);

--- a/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
@@ -179,6 +179,17 @@ namespace NachoClient.iOS
 //                AppDelegate.TestScheduleCalendarNotification ();
 //            };
 //            yOffset = testCalendarNotificationButton.Frame.Bottom;
+//
+//            var testUserNotificationButton = new UIButton (UIButtonType.RoundedRect);
+//            testUserNotificationButton.SetTitle ("Test user error notification", UIControlState.Normal);
+//            testUserNotificationButton.BackgroundColor = UIColor.Red;
+//            testUserNotificationButton.Frame = new CGRect (33, yOffset + 12, 284, 30);
+//            contentView.AddSubview (testUserNotificationButton);
+//            testUserNotificationButton.TouchUpInside += (object sender, EventArgs e) => {
+//                var flip = !LoginHelpers.DoesBackEndHaveIssues (NcApplication.Instance.Account.Id);
+//                LoginHelpers.SetDoesBackEndHaveIssues (NcApplication.Instance.Account.Id, flip);
+//            };
+//            yOffset = testUserNotificationButton.Frame.Bottom;
         }
 
         protected override void ConfigureAndLayout ()

--- a/NachoClient.iOS/NachoUI.iOS/Support/LoginHelpers.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/LoginHelpers.cs
@@ -39,6 +39,11 @@ namespace NachoClient.iOS
             Log.Info (Log.LOG_UI, "SetDoesBackEndHaveIssues: {0}={1}", accountId, toWhat);
             NcAssert.True (GetCurrentAccountId () == accountId);
             McMutables.SetBool (accountId, MODULE, "doesBackEndHaveIssues", toWhat);
+            NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () {
+                Status = NcResult.Info (NcResult.SubKindEnum.Info_UserInterventionFlagChanged),
+                Account = McAccount.QueryById<McAccount> (accountId),
+                Tokens = new string[] { DateTime.Now.ToString () },
+            });
         }
 
         static public bool DoesBackEndHaveIssues (int accountId)


### PR DESCRIPTION
Fix #1575.  Make sure that the tab bar is highlighted when
there's an issue that needs the user's attention. Simplify
notifications and choosing the correct tabs.
