### PR TITLE
Limit the range of date pickers to avoid dates that will crash app

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactEditViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactEditViewController.cs
@@ -1959,6 +1959,8 @@ namespace NachoClient.iOS
 
                 datePicker = new UIDatePicker (new CGRect (0, 0, owner.View.Frame.Width, 216));
                 datePicker.Mode = UIDatePickerMode.Date;
+                // This date picker is used to select birthdays, so set the minimum date to 110 years in the past.
+                Util.ConstrainDatePicker (datePicker, DateTime.UtcNow.AddYears (-110));
                 dateView.AddSubview (datePicker);
 
                 trashButton = new UIButton (new CGRect (owner.moreButtonIndent, 7, 30, 30));

--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -1010,6 +1010,7 @@ namespace NachoClient.iOS
             }
             startDate = c.StartTime;
             startDatePicker.Date = c.StartTime.ToNSDate ();
+            Util.ConstrainDatePicker (startDatePicker, startDate);
             startDateLabelView.SizeToFit ();
             startDateLabelView.Frame = new CGRect (SCREEN_WIDTH - startDateLabel.Frame.Width - 15, 12.438f, startDateLabel.Frame.Width, TEXT_LINE_HEIGHT);
 
@@ -1027,6 +1028,7 @@ namespace NachoClient.iOS
                 endDate = c.EndTime;
                 endDatePicker.Date = c.EndTime.ToNSDate ();
             }
+            Util.ConstrainDatePicker (endDatePicker, endDate);
             endDateLabelView.SizeToFit ();
             endDateLabelView.Frame = new CGRect (SCREEN_WIDTH - endDateLabel.Frame.Width - 15, 12.438f, endDateLabel.Frame.Width, TEXT_LINE_HEIGHT);
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
@@ -1129,6 +1129,29 @@ namespace NachoClient
             return (new DateTime (2001, 1, 1, 0, 0, 0, DateTimeKind.Utc)).AddSeconds (nsDate.SecondsSinceReferenceDate);
         }
 
+        /// <summary>
+        /// Set the minimum and maximum dates for a date picker.  By default, the range is from ten years
+        /// in the past to 100 years in the future.  But extend that range as necessary so it includes the
+        /// year surrounding a given date.
+        /// </summary>
+        public static void ConstrainDatePicker (UIDatePicker datePicker, DateTime referenceDate)
+        {
+            DateTime pickerMin = DateTime.UtcNow.AddYears (-10);
+            DateTime pickerMax = DateTime.UtcNow.AddYears (100);
+            if (DateTime.MinValue != referenceDate) {
+                DateTime referenceMin = referenceDate.AddYears (-1);
+                if (referenceMin < pickerMin) {
+                    pickerMin = referenceMin;
+                }
+                DateTime referenceMax = referenceDate.AddYears (1);
+                if (referenceMax > pickerMax) {
+                    pickerMax = referenceMax;
+                }
+            }
+            datePicker.MinimumDate = pickerMin.ToNSDate ();
+            datePicker.MaximumDate = pickerMax.ToNSDate ();
+        }
+
         public static string PrettyPointF (CGPoint p)
         {
             return String.Format ("({0},{1})", p.X, p.Y);


### PR DESCRIPTION
Set minimum and maximum dates for date pickers.  This prevents users
from selecting dates that would crash the app (such as year 1 or year
10000).  For calendar events, the limits are ten years in the past to
100 years in the future.  For contacts (where a date picker is used to
select birthdays and anniversaries), the limits are 110 years in the
past to 100 years in the future.

Fix nachocove/qa#183
Fix nachocove/qa#185
Fix nachocove/qa#190
Fix nachocove/qa#191
