### PR TITLE
Fix nachocove/qa#124. Change search to support partial matches.

### DIFF
--- a/NachoClient.Android/NachoCore/Index/Index.cs
+++ b/NachoClient.Android/NachoCore/Index/Index.cs
@@ -169,6 +169,26 @@ namespace NachoCore.Index
             }
             return matchedItems;
         }
+
+        public List<MatchedItem> SearchAllFields (string queryString, int maxMatches = 1000)
+        {
+            List<MatchedItem> matchedItems = new List<MatchedItem> ();
+            try {
+                using (var reader = IndexReader.Open (IndexDirectory, true)) {
+                    var fields = new string[] { "body", "from", "subject", };
+                    var parser = new MultiFieldQueryParser (Lucene.Net.Util.Version.LUCENE_30, fields, Analyzer);
+                    var query = parser.Parse (queryString);
+                    var searcher = new IndexSearcher (reader);
+                    var matches = searcher.Search (query, maxMatches);
+                    foreach (var scoreDoc in matches.ScoreDocs) {
+                        matchedItems.Add (new MatchedItem (searcher.Doc (scoreDoc.Doc)));
+                    }
+                }
+            } catch (Lucene.Net.Store.NoSuchDirectoryException) {
+                // This can happen if a search is done before anything is written to the index.
+            }
+            return matchedItems;
+        }
     }
 
     public class MatchedItem

--- a/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
@@ -1184,7 +1184,7 @@ namespace NachoClient.iOS
 
         public void SetEmailMessages (INachoEmailMessages messageThreads)
         {
-            this.messageSource.SetEmailMessages (messageThreads);
+            this.messageSource.SetEmailMessages (messageThreads, "No interactions");
         }
 
         public void SaveNote (int accountId, string noteText)

--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -14,6 +14,7 @@ namespace NachoClient.iOS
 {
     public class MessageTableViewSource : UITableViewSource, INachoMessageEditorParent, INachoFolderChooserParent
     {
+        string messageWhenEmpty;
         INachoEmailMessages messageThreads;
         protected const string UICellReuseIdentifier = "UICell";
         protected const string EmailMessageReuseIdentifier = "EmailMessage";
@@ -112,10 +113,11 @@ namespace NachoClient.iOS
             RefreshCapture = NcCapture.Create (RefreshCaptureName);
         }
 
-        public void SetEmailMessages (INachoEmailMessages messageThreads)
+        public void SetEmailMessages (INachoEmailMessages messageThreads, string messageWhenEmpty)
         {
             ClearCache ();
             this.messageThreads = messageThreads;
+            this.messageWhenEmpty = messageWhenEmpty;
         }
 
         public string GetDisplayName ()
@@ -477,7 +479,7 @@ namespace NachoClient.iOS
         protected void ConfigureCell (UITableView tableView, UITableViewCell cell, NSIndexPath indexPath)
         {
             if (cell.ReuseIdentifier.ToString ().Equals (UICellReuseIdentifier)) {
-                cell.TextLabel.Text = "No messages";
+                cell.TextLabel.Text = messageWhenEmpty;
                 return;
             }
 
@@ -633,9 +635,15 @@ namespace NachoClient.iOS
                 cell = CellWithReuseIdentifier (tableView, cellIdentifier);
             }
 
-            cell.Layer.CornerRadius = 15;
-            cell.Layer.MasksToBounds = true;
-            cell.SelectionStyle = UITableViewCellSelectionStyle.Default;
+            if (NoMessageThreads ()) {
+                cell.BackgroundColor = A.Color_NachoBackgroundGray;
+                cell.ContentView.BackgroundColor = A.Color_NachoBackgroundGray;
+                cell.UserInteractionEnabled = false;
+            } else {
+                cell.Layer.CornerRadius = 15;
+                cell.Layer.MasksToBounds = true;
+                cell.SelectionStyle = UITableViewCellSelectionStyle.Default;
+            }
 
             ConfigureCell (tableView, cell, indexPath);
             return cell;

--- a/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
@@ -330,7 +330,10 @@ namespace NachoClient
 
         public static UIColor ColorForUser (int index)
         {
-            NcAssert.True (0 < index);
+            if (0 > index) {
+                NachoCore.Utils.Log.Warn (NachoCore.Utils.Log.LOG_UI, "ColorForUser not set");
+                index = 1;
+            }
             return colors [index];
         }
 


### PR DESCRIPTION
Fix nachocove/qa#124. Change search to support partial matches using a trailing wildcard.  Lucene, by default, does not allow a leading wildcard. Clean up the 'empty' views to look better.
