### PR TITLE
Refresh views when the system time zone changes

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcResult.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcResult.cs
@@ -169,6 +169,7 @@ namespace NachoCore.Utils
             Info_PushAssistClientToken,
             Info_PushAssistArmed,
             Info_UserInterventionFlagChanged,
+            Info_SystemTimeZoneChanged,
         };
 
         public enum WhyEnum

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -1029,6 +1029,21 @@ namespace NachoClient.iOS
             NcApplication.Instance.MonitorReport ();
         }
 
+        public override void ApplicationSignificantTimeChange (UIApplication application)
+        {
+            // This is called in a variety of situations, including at midnight, when changing to or from
+            // daylight saving time, or when the system time changes.  We are only interested in time zone
+            // changes, so check for that before invoking the app's time zone change status indicator.
+            var oldLocal = TimeZoneInfo.Local;
+            TimeZoneInfo.ClearCachedData ();
+            var newLocal = TimeZoneInfo.Local;
+            if (oldLocal.Id != newLocal.Id || oldLocal.BaseUtcOffset != newLocal.BaseUtcOffset) {
+                NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () {
+                    Account = ConstMcAccount.NotAccountSpecific,
+                    Status = NcResult.Info (NcResult.SubKindEnum.Info_SystemTimeZoneChanged),
+                });
+            }
+        }
 
     }
 

--- a/NachoClient.iOS/NachoUI.iOS/AttachmentsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/AttachmentsViewController.cs
@@ -109,6 +109,10 @@ namespace NachoClient.iOS
                 Log.Debug (Log.LOG_UI, "StatusIndicatorCallback: AttachmentsSetChanged");
                 RefreshTableSource ();
             }
+            if (NcResult.SubKindEnum.Info_SystemTimeZoneChanged == s.Status.SubKind) {
+                // Refresh the view so that the displayed times will reflect the new time zone.
+                RefreshTableSource ();
+            }
         }
 
         private void CreateView ()

--- a/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
@@ -156,8 +156,9 @@ namespace NachoClient.iOS
             var s = (StatusIndEventArgs)e;
             switch (s.Status.SubKind) {
 
-            // When the events change, refresh the UI to reflect the changes.
+            // When the events change, or when the time zone changes, refresh the UI to reflect the changes.
             case NcResult.SubKindEnum.Info_EventSetChanged:
+            case NcResult.SubKindEnum.Info_SystemTimeZoneChanged:
                 calendarSource.Refresh (delegate {
                     ReloadDataWithoutScrolling ();
                     UpdateDateDotView ();

--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -310,18 +310,19 @@ namespace NachoClient.iOS
         public void StatusIndicatorCallback (object sender, EventArgs e)
         {
             var s = (StatusIndEventArgs)e;
-            if (NcResult.SubKindEnum.Info_EmailMessageSetChanged == s.Status.SubKind) {
+            switch (s.Status.SubKind) {
+
+            case NcResult.SubKindEnum.Info_EmailMessageSetChanged:
+            case NcResult.SubKindEnum.Info_EmailMessageSetFlagSucceeded:
+            case NcResult.SubKindEnum.Info_EmailMessageClearFlagSucceeded:
+            case NcResult.SubKindEnum.Info_SystemTimeZoneChanged:
                 RefreshThreadsIfVisible ();
-            }
-            if (NcResult.SubKindEnum.Info_EmailMessageSetFlagSucceeded == s.Status.SubKind) {
-                RefreshThreadsIfVisible ();
-            }
-            if (NcResult.SubKindEnum.Info_EmailMessageClearFlagSucceeded == s.Status.SubKind) {
-                RefreshThreadsIfVisible ();
-            }
-            if (NcResult.SubKindEnum.Info_EmailSearchCommandSucceeded == s.Status.SubKind) {
+                break;
+
+            case NcResult.SubKindEnum.Info_EmailSearchCommandSucceeded:
                 Log.Debug (Log.LOG_UI, "StatusIndicatorCallback: Info_EmailSearchCommandSucceeded");
                 UpdateSearchResultsFromServer (s.Status.GetValue<List<NcEmailMessageIndex>> ());
+                break;
             }
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -58,11 +58,7 @@ namespace NachoClient.iOS
         const int VIEW_INSET = 4;
         const int ATTACHMENTVIEW_INSET = 10;
         nfloat HEADER_TOP_MARGIN = 0;
-        
-
-
-
-#else
+        #else
         const int VIEW_INSET = 0;
         const int ATTACHMENTVIEW_INSET = 15;
         nfloat HEADER_TOP_MARGIN = 0;

--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -282,18 +282,15 @@ namespace NachoClient.iOS
 
         public void StatusIndicatorCallback (object sender, EventArgs e)
         {
-            var s = (StatusIndEventArgs)e;
-            if (NcResult.SubKindEnum.Info_EmailMessageSetChanged == s.Status.SubKind) {
+            switch (((StatusIndEventArgs)e).Status.SubKind) {
+
+            case NcResult.SubKindEnum.Info_EmailMessageSetChanged:
+            case NcResult.SubKindEnum.Info_EmailMessageScoreUpdated:
+            case NcResult.SubKindEnum.Info_EmailMessageSetFlagSucceeded:
+            case NcResult.SubKindEnum.Info_EmailMessageClearFlagSucceeded:
+            case NcResult.SubKindEnum.Info_SystemTimeZoneChanged:
                 RefreshPriorityInboxIfVisible ();
-            }
-            if (NcResult.SubKindEnum.Info_EmailMessageScoreUpdated == s.Status.SubKind) {
-                RefreshPriorityInboxIfVisible ();
-            }
-            if (NcResult.SubKindEnum.Info_EmailMessageSetFlagSucceeded == s.Status.SubKind) {
-                RefreshPriorityInboxIfVisible ();
-            }
-            if (NcResult.SubKindEnum.Info_EmailMessageClearFlagSucceeded == s.Status.SubKind) {
-                RefreshPriorityInboxIfVisible ();
+                break;
             }
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
@@ -160,6 +160,7 @@ namespace NachoClient.iOS
             switch (statusEvent.Status.SubKind) {
 
             case NcResult.SubKindEnum.Info_EventSetChanged:
+            case NcResult.SubKindEnum.Info_SystemTimeZoneChanged:
                 Configure ();
                 break;
             }


### PR DESCRIPTION
Add a listener to detect when the system time zone changes.  Change
the event listener for most of the list views to refresh the view when
the time zone changes, so that any times on the views will be
correctly updated.  (The message detail and event detail views will
not update, because those views are not designed to be refreshed.
Adding the code to refresh them is not worth the effort.)

Fix nachocove/qa#196
