### PR TITLE
Run the status indication handler to avoid HTTP request made from UI thread

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -877,20 +877,24 @@ namespace NachoCore
             StatusIndEventArgs siea = (StatusIndEventArgs)ea;
             switch (siea.Status.SubKind) {
             case NcResult.SubKindEnum.Info_PushAssistDeviceToken:
-                if (null == siea.Status.Value) {
-                    // Because we aren't interlocking the DB delete and the SM event, all code
-                    // must check device token before using it.
-                    PostEvent (PAEvt.E.DevTokLoss, "DEV_TOK_LOSS");
-                } else {
-                    PostEvent (PAEvt.E.DevTok, "DEV_TOK_SET");
-                }
+                NcTask.Run (() => {
+                    if (null == siea.Status.Value) {
+                        // Because we aren't interlocking the DB delete and the SM event, all code
+                        // must check device token before using it.
+                        PostEvent (PAEvt.E.DevTokLoss, "DEV_TOK_LOSS");
+                    } else {
+                        PostEvent (PAEvt.E.DevTok, "DEV_TOK_SET");
+                    }
+                }, "PushAssistDeviceToken");
                 break;
             case NcResult.SubKindEnum.Info_PushAssistClientToken:
-                if (null == siea.Status.Value) {
-                    PostEvent (PAEvt.E.CliTokLoss, "CLI_TOK_LOST");
-                } else {
-                    DoGetCliTok ();
-                }
+                NcTask.Run (() => {
+                    if (null == siea.Status.Value) {
+                        PostEvent (PAEvt.E.CliTokLoss, "CLI_TOK_LOST");
+                    } else {
+                        DoGetCliTok ();
+                    }
+                }, "PushAssistClientToken");
                 break;
             }
         }


### PR DESCRIPTION
PostEvent() can cut thru if the queue is empty. Also, the status indication handler is invoked from UI thread. If it posts an event that get cut thru, the action function is invoked directly from UI thread. So, the HTTP request is made from UI thread and can block for a while. Move the handler inside NcTask to avoid this from happening.
