### PR TITLE
Fix #1216.  Don't archive messages in the archive folder.

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcMessageArchiver.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcMessageArchiver.cs
@@ -34,7 +34,7 @@ namespace NachoCore
         public static void Archive (McEmailMessage message)
         {
             McFolder archiveFolder = McFolder.GetOrCreateArchiveFolder (message.AccountId);
-            BackEnd.Instance.MoveEmailCmd (message.AccountId, message.Id, archiveFolder.Id);
+            Move (message, archiveFolder); // Do not archive messages in Archive folder
         }
 
         public static void Archive (McEmailMessageThread thread)


### PR DESCRIPTION
Fix #1216.  Don't archive messages in the archive folder.
Use the check that's implemented in the move command.
