### PR TITLE
Do not read CurrentUserNotificationSettings when iOS version is less than 8.0.

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -71,7 +71,12 @@ namespace NachoClient.iOS
 
         private ulong UserNotificationSettings {
             get {
-                return (ulong)UIApplication.SharedApplication.CurrentUserNotificationSettings.Types;
+                if (UIDevice.CurrentDevice.CheckSystemVersion (8, 0)) {
+                    return (ulong)UIApplication.SharedApplication.CurrentUserNotificationSettings.Types;
+                }
+                // Older iOS does not have this property. So, just assume it's ok and let 
+                // iOS to reject it.
+                return (ulong)KNotificationSettings;
             }
         }
 


### PR DESCRIPTION
Fix crashes when getting notifications in devices older than iOS 8.0.
