### PR TITLE
Clearing out a thread view might pop to root view or just crash.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageThreadViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageThreadViewController.cs
@@ -18,7 +18,14 @@ namespace NachoClient.iOS
         // It just pops the stack. PopViewController
         // just keeps popping, not just this view but for
         // others on top.
-        static bool alreadyDismissed = false;
+        bool alreadyDismissed;
+
+        public override void ViewDidLoad ()
+        {
+            base.ViewDidLoad ();
+
+            alreadyDismissed = false;
+        }
 
         public override bool MaybeDismissView()
         {


### PR DESCRIPTION
Fix nachocove/qa#145. If multiple files are removed
from a thread view (e.g. multi-select) MaybeDismiss
is called a few times in a row because the view has
not yet been dismissed so without a guard, pop view
controller gets called several times and pops views
all the way up to the root view controller.
