### PR TITLE
Fix nachocove/qa#218

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/BackEnd.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/BackEnd.cs
@@ -162,7 +162,7 @@ namespace NachoCore
         }
 
         // Service must be Stop()ed before calling RemoveService().
-        private void RemoveService (int accountId)
+        public void RemoveService (int accountId)
         {
             ProtoControl service = null;
             if (Services.TryGetValue (accountId, out service)) {
@@ -170,12 +170,6 @@ namespace NachoCore
                 Log.Info (Log.LOG_LIFECYCLE, "RemoveService {0}", accountId);
                 if (!Services.TryRemove (accountId, out service)) {
                     Log.Error (Log.LOG_LIFECYCLE, "BackEnd.RemoveService({0}) could not remove service.", accountId);
-                }
-                var account = McAccount.QueryById<McAccount> (accountId);
-                if (null != account) {
-                    account.Delete ();
-                } else {
-                    Log.Warn (Log.LOG_LIFECYCLE, "BackEnd.RemoveService({0}) McAccount missing.", accountId);
                 }
             } else {
                 Log.Warn (Log.LOG_LIFECYCLE, "BackEnd.RemoveService({0}) could not find service.", accountId);
@@ -312,14 +306,14 @@ namespace NachoCore
         }
 
         public NcResult ForwardEmailCmd (int accountId, int newEmailMessageId, int forwardedEmailMessageId,
-                                       int folderId, bool originalEmailIsEmbedded)
+                                         int folderId, bool originalEmailIsEmbedded)
         {
             return ServiceFromAccountId (accountId, (service) => service.ForwardEmailCmd (newEmailMessageId, forwardedEmailMessageId,
                 folderId, originalEmailIsEmbedded));
         }
 
         public NcResult ReplyEmailCmd (int accountId, int newEmailMessageId, int repliedToEmailMessageId,
-                                     int folderId, bool originalEmailIsEmbedded)
+                                       int folderId, bool originalEmailIsEmbedded)
         {
             return ServiceFromAccountId (accountId, (service) => service.ReplyEmailCmd (newEmailMessageId, repliedToEmailMessageId,
                 folderId, originalEmailIsEmbedded));
@@ -399,7 +393,7 @@ namespace NachoCore
         }
 
         public NcResult SetEmailFlagCmd (int accountId, int emailMessageId, string flagType, 
-                                       DateTime start, DateTime utcStart, DateTime due, DateTime utcDue)
+                                         DateTime start, DateTime utcStart, DateTime due, DateTime utcDue)
         {
             return ServiceFromAccountId (accountId, (service) => service.SetEmailFlagCmd (emailMessageId, flagType, 
                 start, utcStart, due, utcDue));
@@ -411,7 +405,7 @@ namespace NachoCore
         }
 
         public NcResult MarkEmailFlagDone (int accountId, int emailMessageId,
-                                         DateTime completeTime, DateTime dateCompleted)
+                                           DateTime completeTime, DateTime dateCompleted)
         {
             return ServiceFromAccountId (accountId, (service) => service.MarkEmailFlagDone (emailMessageId,
                 completeTime, dateCompleted));

--- a/NachoClient.Android/NachoCore/Utils/NcAccountHandler.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcAccountHandler.cs
@@ -16,7 +16,7 @@ namespace NachoCore.Model
     {
         private static volatile NcAccountHandler instance;
         private static object syncRoot = new Object ();
-        public static string[] exemptTables = new string[]  { 
+        public static string[] exemptTables = new string[] { 
             "McAccount", "sqlite_sequence", "McMigration",
         };
 
@@ -32,6 +32,7 @@ namespace NachoCore.Model
                 return instance; 
             }
         }
+
         public NcAccountHandler ()
         {
         }
@@ -62,32 +63,29 @@ namespace NachoCore.Model
             });
         }
 
-        // delete the file 
+        // delete the file
         public bool DeleteRemovingAccountFile ()
         {
             var RemovingAccountLockFile = NcModel.Instance.GetRemovingAccountLockFilePath ();
-            try
-            {
-                File.Delete(RemovingAccountLockFile);
+            try {
+                File.Delete (RemovingAccountLockFile);
                 return true;
-            }
-            catch (IOException)
-            {
+            } catch (IOException) {
                 return false;
             }
         }
 
         // remove all the db data referenced by the account related to the given id
-        public void RemoveAccountDBData(int AccountId)
+        public void RemoveAccountDBData (int AccountId)
         {
             Log.Info (Log.LOG_DB, "RemoveAccount: removing db data for account {0}", AccountId);
             List<string> DeleteStatements = new List<string> ();
 
             List<McSQLiteMaster> AllTables = McSQLiteMaster.QueryAllTables ();
             foreach (McSQLiteMaster Table in AllTables) {
-                if (!((IList<string>) exemptTables).Contains (Table.name)) {
+                if (!((IList<string>)exemptTables).Contains (Table.name)) {
                     Log.Info (Log.LOG_DB, "RemoveAccount: Will be removing rows from Table {0} for account {1}", Table.name, AccountId);
-                    Regex r = new Regex("^[a-zA-Z0-9]*$");
+                    Regex r = new Regex ("^[a-zA-Z0-9]*$");
                     if (r.IsMatch (Table.name)) {
                         DeleteStatements.Add ("DELETE FROM " + Table.name + " WHERE AccountId = ?");
                     } else {
@@ -102,7 +100,7 @@ namespace NachoCore.Model
                 }
                 Log.Info (Log.LOG_DB, "RemoveAccount: removed McAccount for id {0}", AccountId);
                 var account = McAccount.QueryById<McAccount> (AccountId);
-                if (account != null){
+                if (account != null) {
                     account.Delete ();
                 }
             });
@@ -114,21 +112,19 @@ namespace NachoCore.Model
         }
 
         // remove all the files referenced by the account related to the given id
-        public void RemoveAccountFiles(int AccountId)
+        public void RemoveAccountFiles (int AccountId)
         {
             Log.Info (Log.LOG_DB, "RemoveAccount: removing file data for account {0}", AccountId);
             String AccountDirPath = NcModel.Instance.GetAccountDirPath (AccountId);
-            try{
-                Directory.Delete(AccountDirPath, true);
-            }
-            catch (Exception e)
-            {
+            try {
+                Directory.Delete (AccountDirPath, true);
+            } catch (Exception e) {
                 Log.Error (Log.LOG_DB, "RemoveAccount: cannot remove file data for account {0}. {1}", AccountId, e.Message);
             }
         }
 
         // remove all the db data and files referenced by the account related to the given id
-        public void RemoveAccountDBAndFilesForAccountId(int AccountId)
+        public void RemoveAccountDBAndFilesForAccountId (int AccountId)
         {
             // remove password from keychain
             var cred = McCred.QueryByAccountId<McCred> (AccountId).SingleOrDefault ();
@@ -165,6 +161,7 @@ namespace NachoCore.Model
                     Log.Info (Log.LOG_UI, "RemoveAccount: StopBasalServices complete");
                 }
 
+                BackEnd.Instance.RemoveService (NcApplication.Instance.Account.Id);
                 RemoveAccountDBAndFilesForAccountId (NcApplication.Instance.Account.Id);
 
                 if (stopStartServices) {


### PR DESCRIPTION
- NcAccountHandler.RemoveAccount() removes all files and db records associated with the account but leaves the AS SM and PA SM around. So, when backend is restarted, they run and AS SM's getAccount threw an exception.
- Call RemoveService() to get rid of the AsProtoControl (and PushAssist) objects for the deleted account.
- The actual diff is only 7 lines. Most of the changes are from Xamarin Studio's auto formatting.
