### PR TITLE
Several fixes for the compose view and a fix for message threading.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/UcAddressBlock.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/UcAddressBlock.cs
@@ -49,7 +49,7 @@ namespace NachoClient.iOS
 
         protected nfloat parentWidth;
         protected string openTopLeftString;
-        protected string closedTopLeftString;
+        protected string alternateTopLeftString;
         protected IUcAddressBlockDelegate owner;
 
         protected int suppliedCount;
@@ -57,6 +57,7 @@ namespace NachoClient.iOS
         protected UILabel topLeftLabel;
         protected UIButton chooserButton;
         protected UcAddressField entryTextField;
+        protected bool showAlternateTopLeftLabel;
 
         protected List<UcAddressField> list;
 
@@ -79,11 +80,11 @@ namespace NachoClient.iOS
             CHOOSER_BUTTON_TAG,
         };
 
-        public UcAddressBlock (IUcAddressBlockDelegate owner, string openLabel, string closedLabel, nfloat width)
+        public UcAddressBlock (IUcAddressBlockDelegate owner, string openLabel, string alternateLabel, nfloat width)
         {
             this.owner = owner;
             this.openTopLeftString = openLabel;
-            this.closedTopLeftString = closedLabel;
+            this.alternateTopLeftString = alternateLabel;
             this.parentWidth = width;
             this.BackgroundColor = UIColor.White;
             this.list = new List<UcAddressField> ();
@@ -96,10 +97,11 @@ namespace NachoClient.iOS
             CreateView ();
         }
 
-        public void SetCompact (bool isCompact, int moreCount)
+        public void SetCompact (bool isCompact, int moreCount, bool showAlternateTopLeftLabel = false)
         {
             this.isCompact = isCompact;
             this.suppliedCount = moreCount;
+            this.showAlternateTopLeftLabel = showAlternateTopLeftLabel;
         }
 
         public void SetEditable (bool isEditable)
@@ -135,6 +137,11 @@ namespace NachoClient.iOS
                 }
                 return l;
             }
+        }
+
+        public bool IsEmpty ()
+        {
+            return (0 == list.Count);
         }
 
         protected void InsertInternal (int index, string text, NcEmailAddress address, int type)
@@ -270,8 +277,8 @@ namespace NachoClient.iOS
         public void ConfigureView ()
         {
             var topLeftLabelString = openTopLeftString;
-            if (isCompact && (null != closedTopLeftString)) {
-                topLeftLabelString = closedTopLeftString;
+            if (isCompact && showAlternateTopLeftLabel) {
+                topLeftLabelString = alternateTopLeftString;
             }
 
             topLeftLabel.Text = topLeftLabelString;
@@ -384,13 +391,8 @@ namespace NachoClient.iOS
                 xOffset += topLeftLabel.Frame.Width;
             }
 
-            if (0 == isActive) {
-                chooserButton.Hidden = true;
-            } else {
-                chooserButton.Hidden = false;
-                AdjustXY (chooserButton, chooserButton.Frame.X, yOffset);
-                xLimit = chooserButton.Frame.X;
-            }
+            chooserButton.Hidden = (0 == isActive);
+            xLimit = chooserButton.Frame.X;
 
             bool firstLine = true;
             xOffset = leftAddressIndent;

--- a/NachoClient.iOS/NachoUI.iOS/Support/ViewHelper.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/ViewHelper.cs
@@ -405,6 +405,12 @@ namespace NachoClient.iOS
             return MayUpdate ();
         }
 
+        public ViewFramer CenterY(nfloat y, nfloat sectionHeight)
+        {
+            Frame.Y = y + (sectionHeight / 2) - (Frame.Height / 2);
+            return MayUpdate ();
+        }
+
         public ViewFramer Size (CGSize size)
         {
             Frame.Width = size.Width;


### PR DESCRIPTION
Fix nachocove/qa#96. Fix #1274. Fix nachocove/qa#230.
Clean up the compose view. Move platform independent
code to email helpers, set up the references and the
in-reply-to header fields, make sure the attachments
line is always visible, and fix up cc/bcc visibility
to show cc and/or bcc if either list is not empty.
