### PR TITLE
Fix nachocove/qa#122. Clean up initialization and migration screens.

### DIFF
--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -286,11 +286,11 @@ namespace NachoCore
             }
         }
 
-        public void ContinueRemoveAccountIfNeeded()
+        public void ContinueRemoveAccountIfNeeded ()
         {
             // if not done removing account, finish up 
             int AccountId = NcModel.Instance.GetRemovingAccountIdFromFile ();
-            if (AccountId > 0 ) {
+            if (AccountId > 0) {
                 Log.Info (Log.LOG_UI, "RemoveAccount: Continuing to remove data for account {0} after restart", AccountId);
                 NcAccountHandler.Instance.RemoveAccountDBAndFilesForAccountId (AccountId);
             }
@@ -325,11 +325,8 @@ namespace NachoCore
             // lazy initialized. So, we don't need pay any attention. But if that changes in the future,
             // we need to sequence these properly.
             NcMigration.Setup ();
-
             if (ShouldEnterSafeMode ()) {
-                if (!NcMigration.WillStartService ()) {
-                    ExecutionContext = ExecutionContextEnum.Initializing;
-                }
+                ExecutionContext = ExecutionContextEnum.Initializing;
                 SafeMode = true;
                 NcTask.Run (() => {
                     if (!MonitorUploads ()) {
@@ -340,6 +337,7 @@ namespace NachoCore
                         StartBasalServicesCompletion ();
                     } else {
                         Log.Info (Log.LOG_LIFECYCLE, "Starting migration after exiting safe mode");
+                        ExecutionContext = ExecutionContextEnum.Migrating;
                         NcMigration.StartService (
                             StartBasalServicesCompletion,
                             (percentage) => {
@@ -370,6 +368,7 @@ namespace NachoCore
 
             // Start Migrations, if any.
             if (NcMigration.WillStartService ()) {
+                ExecutionContext = ExecutionContextEnum.Migrating;
                 NcMigration.StartService (
                     StartBasalServicesCompletion,
                     (percentage) => {
@@ -663,6 +662,11 @@ namespace NachoCore
             #else
             throw new PlatformNotSupportedException ();
             #endif
+        }
+
+        public bool InSafeMode ()
+        {
+            return SafeMode;
         }
 
         private bool ShouldEnterSafeMode ()

--- a/NachoClient.iOS/NachoUI.iOS/MainStoryboard_iPhone.storyboard
+++ b/NachoClient.iOS/NachoUI.iOS/MainStoryboard_iPhone.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="Ds7-Ad-QXl">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="Ds7-Ad-QXl">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
     </dependencies>
     <scenes>
         <!--Advanced Login View Controller-->
@@ -30,7 +30,7 @@
             <objects>
                 <viewController storyboardIdentifier="NachoNowViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="ygr-ff-C2f" customClass="NachoNowViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="BSK-Fb-RSa">
-                        <rect key="frame" x="0.0" y="64" width="320" height="455"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
@@ -452,7 +452,7 @@
             <objects>
                 <tableViewController storyboardIdentifier="MessageListViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="kq1-eO-X0p" customClass="MessageListViewController" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="PBw-9w-NMN">
-                        <rect key="frame" x="0.0" y="64" width="320" height="455"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <connections>
@@ -1222,7 +1222,7 @@
             </objects>
             <point key="canvasLocation" x="3" y="860"/>
         </scene>
-        <!--Startup-->
+        <!--Startup View Controller-->
         <scene sceneID="Zmz-eo-l65">
             <objects>
                 <viewController storyboardIdentifier="StartupViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="WSh-aW-ysu" customClass="StartupViewController" sceneMemberID="viewController">
@@ -1232,8 +1232,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
-                    <navigationItem key="navigationItem" title="Startup" id="kho-Lu-JgG"/>
-                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
+                    <navigationItem key="navigationItem" id="kho-Lu-JgG"/>
                     <connections>
                         <segue destination="6rF-Ad-StO" kind="custom" identifier="SegueToLaunch" customClass="FadeCustomSegue" id="A0a-NV-skH"/>
                         <segue destination="OQ8-xH-iKh" kind="custom" identifier="SegueToHome" customClass="FadeCustomSegue" id="g4G-tD-G9H"/>
@@ -1584,34 +1583,34 @@
         <simulatedScreenMetrics key="destination" type="retina4"/>
     </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
-        <segue reference="xrp-ey-B0j"/>
-        <segue reference="p7w-hx-Y70"/>
         <segue reference="22b-Az-fdF"/>
         <segue reference="lbY-YF-b2b"/>
+        <segue reference="sa2-Em-8sH"/>
+        <segue reference="emO-35-rbd"/>
         <segue reference="iqA-wd-xqD"/>
         <segue reference="g4G-tD-G9H"/>
         <segue reference="XZZ-AT-ZHc"/>
+        <segue reference="Bq3-C6-QI6"/>
+        <segue reference="rew-s7-VAQ"/>
         <segue reference="Aba-pv-mzB"/>
         <segue reference="WNu-7Y-s9s"/>
         <segue reference="mLY-u0-R5O"/>
         <segue reference="Ar9-Nl-fq9"/>
         <segue reference="wZy-ga-YEb"/>
         <segue reference="Kfq-r2-VA6"/>
-        <segue reference="zby-Sy-Y3J"/>
-        <segue reference="tkk-6o-6oa"/>
+        <segue reference="p7w-hx-Y70"/>
         <segue reference="ay2-o2-R8l"/>
-        <segue reference="Bq3-C6-QI6"/>
-        <segue reference="Kmd-x6-iCJ"/>
-        <segue reference="rew-s7-VAQ"/>
+        <segue reference="xrp-ey-B0j"/>
+        <segue reference="zby-Sy-Y3J"/>
         <segue reference="c2Q-C8-ZgX"/>
         <segue reference="i6d-Pz-anv"/>
         <segue reference="lof-V2-Nc4"/>
-        <segue reference="qB9-ce-7gT"/>
         <segue reference="twQ-jE-jZd"/>
-        <segue reference="B5b-jg-ZNg"/>
-        <segue reference="w67-dy-XSq"/>
+        <segue reference="qB9-ce-7gT"/>
         <segue reference="m2D-2n-RiV"/>
+        <segue reference="w67-dy-XSq"/>
         <segue reference="7sK-rg-HQL"/>
+        <segue reference="B5b-jg-ZNg"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.062745101749897003" green="0.27450981736183167" blue="0.30980393290519714" alpha="1" colorSpace="deviceRGB"/>
 </document>

--- a/NachoClient.iOS/NachoUI.iOS/StartupViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/StartupViewController.cs
@@ -14,6 +14,9 @@ namespace NachoClient.iOS
     {
         UIProgressView MigrationProgressBar = null;
         UITextView MigrationMessageTextView = null;
+        UIActivityIndicatorView MigrationSpinner = null;
+
+        bool StatusIndCallbackIsSet = false;
 
         public StartupViewController (IntPtr handle) : base (handle)
         {
@@ -25,14 +28,19 @@ namespace NachoClient.iOS
         public override void ViewDidLoad ()
         {
             base.ViewDidLoad ();
+
+            CreateView ();
+
             if (NcApplication.Instance.IsUp ()) {
                 var segueIdentifer = NextSegue ();
                 Log.Info (Log.LOG_UI, "svc: PerformSegue({0})", segueIdentifer);
                 PerformSegue (NextSegue (), this);
             } else {
-                CreateView ();
+                StatusIndCallbackIsSet = true;
                 NcApplication.Instance.StatusIndEvent += StatusIndicatorCallback;
             }
+
+            this.View.BackgroundColor = A.Color_NachoGreen;
         }
 
         public static string NextSegue ()
@@ -80,20 +88,28 @@ namespace NachoClient.iOS
             if (null != this.NavigationController) {
                 this.NavigationController.ToolbarHidden = true;
             }
+            if (!StatusIndCallbackIsSet) {
+                NcApplication.Instance.StatusIndEvent += StatusIndicatorCallback;
+            }
+            ConfigureView ();
         }
 
         public override void ViewDidAppear (bool animated)
         {
             base.ViewDidAppear (animated);
-            ConfigureView ();
+        }
+
+        public override void ViewWillDisappear (bool animated)
+        {
+            base.ViewWillDisappear (animated);
+            if (this.IsViewLoaded && null == this.NavigationController) {
+                NcApplication.Instance.StatusIndEvent -= StatusIndicatorCallback;
+                StatusIndCallbackIsSet = false;
+            }
         }
 
         public void CreateView ()
         {
-            // We need to migrate. Put up a spinner until this is done.
-            this.NavigationItem.Title = "Upgrade";
-            this.View.BackgroundColor = A.Color_NachoGreen;
-
             if (!NcMigration.IsCompatible ()) {
                 // Display an alert view and wait to get out
                 NcAlertView.ShowMessage (this, "Incompatible Version",
@@ -104,27 +120,33 @@ namespace NachoClient.iOS
             var frame = this.View.Frame;
             var halfHeight = frame.Height / 2.0f;
 
-            MigrationMessageTextView = new UITextView ();
-            ViewFramer.Create (MigrationMessageTextView)
-                .X (0)
-                .Y (halfHeight - 35.0f)
-                .Width (frame.Width)
-                .Height (35.0f);
+            MigrationMessageTextView = new UITextView (new CoreGraphics.CGRect (0, halfHeight - 35, frame.Width, 35));
             MigrationMessageTextView.TextColor = UIColor.White;
             MigrationMessageTextView.Font = A.Font_AvenirNextRegular14;
-            MigrationMessageTextView.Text = String.Format ("Updating your app with latest features... (1 of {0})",
-                NcMigration.NumberOfMigrations);
             MigrationMessageTextView.BackgroundColor = A.Color_NachoGreen;
             MigrationMessageTextView.TextAlignment = UITextAlignment.Center;
-            MigrationMessageTextView.Hidden = (0 == NcMigration.NumberOfMigrations);
 
-            MigrationProgressBar = new UIProgressView (frame);
-            ViewFramer.Create (MigrationProgressBar).Y (halfHeight + 10.0f).AdjustHeight (20.0f);
+            MigrationProgressBar = new UIProgressView (new CoreGraphics.CGRect (0, halfHeight + 10, frame.Width, 20));
             MigrationProgressBar.ProgressTintColor = A.Color_NachoYellow;
             MigrationProgressBar.TrackTintColor = A.Color_NachoIconGray;
-            MigrationProgressBar.Hidden = (0 == NcMigration.NumberOfMigrations);
+
+            MigrationSpinner = new UIActivityIndicatorView (UIActivityIndicatorViewStyle.Gray);
+            MigrationSpinner.Center = new CoreGraphics.CGPoint (frame.Width / 2, frame.Height / 4);
+            MigrationSpinner.ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.WhiteLarge;
+            MigrationSpinner.HidesWhenStopped = true;
+
             this.Add (MigrationMessageTextView);
             this.Add (MigrationProgressBar);
+            this.Add (MigrationSpinner);
+        }
+
+        void BlankScreen()
+        {
+            this.NavigationItem.Title = "";
+            MigrationMessageTextView.Text = "";
+            MigrationMessageTextView.Hidden = true;
+            MigrationProgressBar.Hidden = true;
+            MigrationSpinner.StopAnimating ();
         }
 
         void ConfigureView ()
@@ -132,17 +154,35 @@ namespace NachoClient.iOS
             if (!NcMigration.IsCompatible ()) {
                 return;
             }
-            if (NcApplication.ExecutionContextEnum.Migrating == NcApplication.Instance.ExecutionContext) {
+            switch (NcApplication.Instance.ExecutionContext) {
+            case NcApplication.ExecutionContextEnum.Migrating:
                 this.NavigationItem.Title = "Upgrade";
                 MigrationMessageTextView.Hidden = false;
                 MigrationProgressBar.Hidden = false;
-            } else if (NcApplication.ExecutionContextEnum.Initializing == NcApplication.Instance.ExecutionContext) {
-                this.NavigationItem.Title = "Initializing";
-                MigrationMessageTextView.Hidden = true;
-                MigrationProgressBar.Hidden = true;
-            } else {
-                this.NavigationItem.Title = "Initialization";
+                MigrationMessageTextView.Text = String.Format ("Updating your app with latest features... (1 of {0})", NcMigration.NumberOfMigrations);
+                MigrationSpinner.StopAnimating ();
+                break;
+            case NcApplication.ExecutionContextEnum.Initializing:
+                if (NcApplication.Instance.InSafeMode ()) {
+                    this.NavigationItem.Title = "Initializing";
+                    MigrationMessageTextView.Text = String.Format ("We are sorry a crash occurred. We are recovering.");
+                    MigrationMessageTextView.Hidden = false;
+                    MigrationProgressBar.Hidden = true;
+                    MigrationSpinner.StartAnimating ();
+                } else {
+                    BlankScreen ();
+                }
+                break;
+            default:
+                // Rare and will be quick
+                BlankScreen();
+
+                break;
             }
+            ViewFramer.Create (MigrationMessageTextView).Width (View.Frame.Width);
+            MigrationMessageTextView.SizeToFit ();
+            ViewFramer.Create (MigrationMessageTextView).Width (View.Frame.Width);
+            ViewFramer.Create (MigrationProgressBar).Y (MigrationMessageTextView.Frame.Bottom + 10);
             Log.Info (Log.LOG_UI, "svc: {0}", NcApplication.Instance.ExecutionContext);
         }
 
@@ -154,7 +194,7 @@ namespace NachoClient.iOS
                 if (NcApplication.Instance.IsUp ()) {
                     InvokeOnMainThread (() => {
                         if (null != MigrationProgressBar) {
-                            MigrationProgressBar.Hidden = false;
+                            MigrationProgressBar.Hidden = true;
                         }
                         PerformSegue (NextSegue (), this);
                     });
@@ -180,12 +220,6 @@ namespace NachoClient.iOS
                     });
                 }
             }
-        }
-
-        public override void ViewWillDisappear (bool animated)
-        {
-            base.ViewWillDisappear (animated);
-            NcApplication.Instance.StatusIndEvent -= StatusIndicatorCallback;
         }
 
         public override void PrepareForSegue (UIStoryboardSegue segue, NSObject sender)


### PR DESCRIPTION
iFix nachocove/qa#122. No beer mug, but cleaned up the
nitialization and migration pages.  Now initializing
is set during safe mode whether or not a migration is
pending. The execution state transitions to migration
when migration starts. There is a brief transition to
initialization after migration, so the initialization
ui looks at "safe' mode to display the right stuff.
