### PR TITLE
Don't crash when adding a new note to an event

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -1262,6 +1262,7 @@ namespace NachoClient.iOS
                 Note = McNote.QueryByTypeId (c.Id, McNote.NoteType.Event).FirstOrDefault ();
                 if (null == Note) {
                     Note = new McNote ();
+                    Note.AccountId = c.AccountId;
                     Note.DisplayName = (c.GetSubject () + " - " + Pretty.ShortDateString (DateTime.UtcNow));
                     Note.TypeId = c.Id;
                     Note.noteType = McNote.NoteType.Event;


### PR DESCRIPTION
When a new note was added to an event, the McNote.AccountId field was
never filled in, which caused an assertion failure during the
Insert().  That oversight has been fixed.

Fix nachocove/qa#236
