### PR TITLE
Fix nachocove/qa#242

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrainActions.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainActions.cs
@@ -117,7 +117,7 @@ namespace NachoCore.Brain
                 if (!File.Exists (messagePath)) {
                     Log.Warn (Log.LOG_BRAIN, "IndexEmailMessage: {0} does not exist (emailMessageId={1}, bodyId={2}, isValid={3}, filePresence={4})",
                         messagePath, emailMessage.Id, body.Id, body.IsValid, body.FilePresence);
-                    body.Reset ();
+                    body.DeleteFile ();
                     return false;
                 }
 

--- a/NachoClient.Android/NachoCore/Model/McAbstrFileDesc.cs
+++ b/NachoClient.Android/NachoCore/Model/McAbstrFileDesc.cs
@@ -382,13 +382,5 @@ namespace NachoCore.Model
         {
             return (IsComplete (file) && !file.Truncated);
         }
-
-        public void Reset ()
-        {
-            DeleteFile ();
-            FilePresence = FilePresenceEnum.None;
-            FilePresenceFraction = 0;
-            Update ();
-        }
     }
 }


### PR DESCRIPTION
- Add a McBody.Reset() API to reset a McBody back to the original not downloaded state.
- If indexer fails to find the file, call that API to either redownload the body or skip indexing that email.
