### PR TITLE
Fix nachocove/qa#250

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
@@ -935,6 +935,7 @@ namespace NachoCore.ActiveSync
             NcCommStatus.Instance.CommStatusServerEvent -= ServerStatusEventHandler;
             if (null != PushAssist) {
                 PushAssist.Dispose ();
+                PushAssist = null;
             }
             base.Remove ();
         }

--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -246,6 +246,14 @@ namespace NachoCore
             }
         }
 
+        public static void RemovePAObjectByContext (string context)
+        {
+            WeakReference dummy;
+            if (!ContextObjectMap.TryRemove (context, out dummy)) {
+                Log.Warn (Log.LOG_PUSH, "Cannot remove unknown context {0}", context);
+            }
+        }
+
         public PushAssist (IPushAssistOwner owner)
         {
             LockObj = new object ();
@@ -496,6 +504,7 @@ namespace NachoCore
         {
             if (!IsDisposed) {
                 IsDisposed = true;
+                RemovePAObjectByContext (ClientContext);
                 NcApplication.Instance.StatusIndEvent -= TokensWatcher;
                 DisposeRetryTimer ();
                 DisposeTimeoutTimer ();


### PR DESCRIPTION
- It seems the AsProtoControl / PushAssist objects linger around after they are removed before GC collects them. During that window, PushAssist.ContextObjectMap still points to that PA object. When processing a remote notification (in background), it will use a PA object whose account no longer exists.
- The fix is to remove the PushAssist object reference from the context map so that it cannot be found if GC has not collected it. Also, set AsProtoControl.PushAssist to null in an attempt to speed up being GC collected.
