### PR TITLE
Fix a background crash when pinger requests a new registration

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -234,10 +234,8 @@ namespace NachoCore
 
                 switch (context.Value) {
                 case PingerNotification.NEW:
-                    fetch (pa.AccountId);
-                    break;
                 case PingerNotification.REGISTER:
-                    pa.DeviceTokenLost ();
+                    fetch (pa.AccountId);
                     break;
                 default:
                     Log.Error (Log.LOG_PUSH, "Unknown action {0} for context {1}", context.Value, context.Key);


### PR DESCRIPTION
- When the client receives a register from the pinger, it tries to re-establish a pinger session without performing a fetch. The problem is that it does not call the completion handler. So, it keeps running until it over runs and iOS kills it.
- The solution is to just perform a fetch. If the pinger restarts, we may have missed some emails already. So, performing a fetch is reasonable.
