### PR TITLE
Deal with attachments in drafts.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
@@ -138,6 +138,12 @@ namespace NachoClient.iOS
                 }
             }
             showQuotedTextButton.Hidden = draftMessage.ReferencedBodyIsIncluded;
+
+            foreach (var mimeAttachment in mimeMessage.Attachments) {
+                var attachment = McAttachment.InsertFile (draftMessage.AccountId, (stream) => mimeAttachment.ContentObject.DecodeTo (stream));
+                attachment.SetDisplayName (mimeAttachment.FileName);
+                attachmentView.Append (attachment);
+            }
         }
 
         public void SaveDraft ()
@@ -163,6 +169,10 @@ namespace NachoClient.iOS
                                   new NSAttributedStringDocumentAttributes { DocumentType = NSDocumentType.HTML },
                                   ref error);
             body.HtmlBody = htmlData.ToString ();
+
+            foreach (var attachment in attachmentView.AttachmentList) {
+                body.Attachments.Add (attachment.GetFilePath ());
+            }
 
             mimeMessage.Body = body.ToMessageBody ();
 


### PR DESCRIPTION
For drafts, save attachments in the mime body as if the attachment
was going to be sent.  For drafts or for sent messages that are in
drafts, extract and decode the attachments to a McAttachment file.

We might thing about keeping the components of a message in
separate components until the message is actually sent.  By that
I mean that instead of combining things into a mime message for
storage, keep the attachments and bodies separate until the message
starts to be sent, and at that time, assemble the components into a
single message to be sent.
