### PR TITLE
Fix nachocove/qa#262

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -386,6 +386,8 @@
     <Compile Include="NachoCore\Adapters\NachoDraftMessages.cs" />
     <Compile Include="NachoCore\Model\McLicenseInformation.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration16.cs" />
+    <Compile Include="NachoCore\Brain\NcBrainApi.cs" />
+    <Compile Include="NachoCore\Model\McBrainEvent.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/NachoClient.Android/NachoCore/Brain/NcBrainActions.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainActions.cs
@@ -151,13 +151,10 @@ namespace NachoCore.Brain
             return true;
         }
 
-        public void UnindexEmailMessage (McEmailMessage emailMessage)
+        protected void UnindexEmailMessage (int accountId, int emailMessageId)
         {
-            if ((null == emailMessage) || (0 == emailMessage.Id) || (0 == emailMessage.AccountId)) {
-                return;
-            }
-            var index = Index (emailMessage.AccountId);
-            index.Remove ("message", emailMessage.Id.ToString ());
+            var index = Index (accountId);
+            index.Remove ("message", emailMessageId.ToString ());
         }
     }
 }

--- a/NachoClient.Android/NachoCore/Brain/NcBrainApi.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainApi.cs
@@ -1,0 +1,44 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+using NachoCore.Utils;
+using NachoCore.Model;
+
+namespace NachoCore.Brain
+{
+    public partial class NcBrain
+    {
+        public static void NewEmailMessageSynced (object sender, EventArgs args)
+        {
+            StatusIndEventArgs eventArgs = args as StatusIndEventArgs;
+            if (NcResult.SubKindEnum.Info_EmailMessageSetChanged != eventArgs.Status.SubKind) {
+                return;
+            }
+            NcBrain.SharedInstance.Enqueue (new NcBrainStateMachineEvent (eventArgs.Account.Id));
+        }
+
+        public static void UpdateAddressScore (Int64 emailAddressId, bool forcedUpdateDependentMessages = false)
+        {
+            NcBrainEvent e = new NcBrainUpdateAddressScoreEvent (emailAddressId, forcedUpdateDependentMessages);
+            NcBrain.SharedInstance.Enqueue (e);
+        }
+
+        public static void UpdateMessageScore (Int64 accountId, Int64 emailMessageId)
+        {
+            NcBrainEvent e = new NcBrainUpdateMessageScoreEvent (accountId, emailMessageId);
+            NcBrain.SharedInstance.Enqueue (e);
+        }
+
+        public static void UnindexEmailMessage (McEmailMessage emailMessage)
+        {
+            if ((null == emailMessage) || (0 == emailMessage.Id) || (0 == emailMessage.AccountId)) {
+                return;
+            }
+            var brainEvent = new NcBrainUnindexMessageEvent (emailMessage.AccountId, emailMessage.Id);
+            var dbEvent = new McBrainEvent (brainEvent);
+            dbEvent.Insert ();
+        }
+
+    }
+}
+

--- a/NachoClient.Android/NachoCore/Brain/NcBrainEvent.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainEvent.cs
@@ -16,10 +16,11 @@ namespace NachoCore.Brain
         MESSAGE_FLAGS,
         INITIAL_RIC,
         UPDATE_ADDRESS_SCORE,
-        UPDATE_MESSAGE_SCORE}
+        UPDATE_MESSAGE_SCORE,
+        UNINDEX_MESSAGE,
+    };
 
-    ;
-
+    [Serializable]
     public class NcBrainEvent : NcQueueElement
     {
         public NcBrainEventType Type { get; set; }
@@ -47,10 +48,10 @@ namespace NachoCore.Brain
 
     public enum NcBrainUIEventType
     {
-        MESSAGE_VIEW}
+        MESSAGE_VIEW,
+    };
 
-    ;
-
+    [Serializable]
     public class NcBrainUIEvent : NcBrainEvent
     {
 
@@ -72,6 +73,7 @@ namespace NachoCore.Brain
         }
     }
 
+    [Serializable]
     public class NcBrainUIMessageViewEvent : NcBrainUIEvent
     {
         public DateTime Start;
@@ -90,6 +92,7 @@ namespace NachoCore.Brain
         }
     }
 
+    [Serializable]
     public class NcBrainInitialRicEvent : NcBrainEvent
     {
         public Int64 AccountId;
@@ -107,6 +110,7 @@ namespace NachoCore.Brain
 
     /// This event is used when an UI / backend action causes the score of 
     /// an email address to be updated.
+    [Serializable]
     public class NcBrainUpdateAddressScoreEvent : NcBrainEvent
     {
         public Int64 EmailAddressId;
@@ -130,34 +134,15 @@ namespace NachoCore.Brain
         }
     }
 
-    /// This event is used when an UI / backend action causes the score of 
-    /// an email message to be updated.
-    public class NcBrainUpdateMessageScoreEvent : NcBrainEvent
-    {
-        public Int64 EmailMessageId;
-
-        public NcBrainUpdateMessageScoreEvent (Int64 emailMessageId)
-            : base (NcBrainEventType.UPDATE_MESSAGE_SCORE)
-        {
-            EmailMessageId = emailMessageId;
-        }
-
-        public override string ToString ()
-        {
-            return String.Format ("[NcBrainUpdateMessageScoreEvent: type={0}, emailMessageId={1}",
-                GetEventType (), EmailMessageId);
-        }
-    }
-
-    /// This event tells brain that user has changed either the due date or the deferred until date.
-    /// Upon receiving this, brain will re-evaluate the time variance state machine for the
-    /// email message
-    public class NcBrainMessageFlagEvent : NcBrainEvent
+    [Serializable]
+    public class NcBrainMessageEvent : NcBrainEvent
     {
         public Int64 AccountId;
+
         public Int64 EmailMessageId;
 
-        public NcBrainMessageFlagEvent (Int64 accountId, Int64 emailMessageId) : base (NcBrainEventType.MESSAGE_FLAGS)
+        public NcBrainMessageEvent (NcBrainEventType eventType, Int64 accountId, Int64 emailMessageId)
+            : base (eventType)
         {
             AccountId = accountId;
             EmailMessageId = emailMessageId;
@@ -165,11 +150,44 @@ namespace NachoCore.Brain
 
         public override string ToString ()
         {
-            return String.Format ("[NcBrainMessageFlagEvent: type={0}, accountId={1}, emailMessageId={2}]",
-                GetEventType (), AccountId, EmailMessageId);
+            return String.Format ("[{0}: type={1}, accountId={2}, emailMessageId={3}",
+                GetType ().Name, AccountId, EmailMessageId);
         }
     }
 
+    /// This event is used when an UI / backend action causes the score of 
+    /// an email message to be updated.
+    [Serializable]
+    public class NcBrainUpdateMessageScoreEvent : NcBrainMessageEvent
+    {
+        public NcBrainUpdateMessageScoreEvent (Int64 accountId, Int64 emailMessageId)
+            : base (NcBrainEventType.UPDATE_MESSAGE_SCORE, accountId, emailMessageId)
+        {
+        }
+    }
+
+    /// This event tells brain that user has changed either the due date or the deferred until date.
+    /// Upon receiving this, brain will re-evaluate the time variance state machine for the
+    /// email message
+    [Serializable]
+    public class NcBrainMessageFlagEvent : NcBrainMessageEvent
+    {
+        public NcBrainMessageFlagEvent (Int64 accountId, Int64 emailMessageId)
+            : base (NcBrainEventType.MESSAGE_FLAGS, accountId, emailMessageId)
+        {
+        }
+    }
+
+    [Serializable]
+    public class NcBrainUnindexMessageEvent : NcBrainMessageEvent
+    {
+        public NcBrainUnindexMessageEvent (Int64 accountId, Int64 emailMessageId)
+            : base (NcBrainEventType.UNINDEX_MESSAGE, accountId, emailMessageId)
+        {
+        }
+    }
+
+    [Serializable]
     public class NcBrainStateMachineEvent : NcBrainEvent
     {
         public Int64 AccountId;

--- a/NachoClient.Android/NachoCore/Model/McBrainEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McBrainEvent.cs
@@ -1,0 +1,49 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Runtime.Serialization;
+using System.IO;
+using NachoCore.Brain;
+
+namespace NachoCore.Model
+{
+    public class McBrainEvent : McAbstrObject
+    {
+        public byte[] Data { set; get; }
+
+        public NcBrainEventType Type { set; get; }
+
+        public McBrainEvent ()
+        {
+            Type = NcBrainEventType.UNKNOWN;
+        }
+
+        public McBrainEvent (NcBrainEvent brainEvent)
+        {
+            // Serialize to memory stream. The assumption is that there
+            // never will be a large event.
+            MemoryStream binaryStream = new MemoryStream ();
+            BinaryFormatter serializer = new BinaryFormatter ();
+            serializer.Serialize (binaryStream, brainEvent);
+            Data = binaryStream.ToArray ();
+            Type = brainEvent.Type;
+        }
+
+        public static McBrainEvent QueryNext ()
+        {
+            return NcModel.Instance.Db.Query<McBrainEvent> (
+                "SELECT e.* FROM McBrainEvent AS e ORDER BY e.Id ASC LIMIT 1").SingleOrDefault ();
+        }
+
+        public NcBrainEvent BrainEvent ()
+        {
+            MemoryStream binaryStream = new MemoryStream (Data);
+            BinaryFormatter serializer = new BinaryFormatter ();
+            var brainEvent = (NcBrainEvent)serializer.Deserialize (binaryStream);
+            return brainEvent;
+        }
+    }
+}
+

--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
@@ -595,9 +595,9 @@ namespace NachoCore.Model
         public static List<McEmailMessage> QueryByThreadTopic (int accountId, string topic)
         {
             return NcModel.Instance.Db.Query<McEmailMessage> ("SELECT * FROM McEmailMessage WHERE " +
-                " likelihood (AccountId = ?, 1.0) AND " +
-                " likelihood (IsAwaitingDelete = ?, 1.0) AND " +
-                " likelihood (ThreadTopic = ?, 0.01) ",
+            " likelihood (AccountId = ?, 1.0) AND " +
+            " likelihood (IsAwaitingDelete = ?, 1.0) AND " +
+            " likelihood (ThreadTopic = ?, 0.01) ",
                 accountId, false, topic);
         }
 
@@ -1061,7 +1061,7 @@ namespace NachoCore.Model
         public override int Delete ()
         {
             int returnVal = base.Delete ();
-            NcBrain.SharedInstance.UnindexEmailMessage (this);
+            NcBrain.UnindexEmailMessage (this);
             return returnVal;
         }
 

--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -322,6 +322,7 @@ namespace NachoCore.Model
                 Db.CreateTable<McMapEmailAddressEntry> ();
                 Db.CreateTable<McMigration> ();
                 Db.CreateTable<McLicenseInformation> ();
+                Db.CreateTable<McBrainEvent> ();
             });
             watch.Stop ();
             QueueLogInfo (string.Format ("NcModel: Db.CreateTables took {0}ms.", watch.ElapsedMilliseconds));

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1345,6 +1345,12 @@
       <DependentUpon>NotificationChooserViewController.cs</DependentUpon>
     </Compile>
     <Compile Include="NachoUI.iOS\Support\NcUIBarButtonItem.cs" />
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\McBrainEvent.cs">
+      <Link>NachoCore\Model\McBrainEvent.cs</Link>
+    </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Brain\NcBrainApi.cs">
+      <Link>NachoCore\Brain\NcBrainApi.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/NachoClient.iOS/NachoCore/Utils/ScoringHelpers.cs
+++ b/NachoClient.iOS/NachoCore/Utils/ScoringHelpers.cs
@@ -33,7 +33,7 @@ namespace NachoCore.Utils
                 Status = NachoCore.Utils.NcResult.Info (NcResult.SubKindEnum.Info_EmailMessageScoreUpdated),
                 Account = ConstMcAccount.NotAccountSpecific,
             });
-            NcBrain.UpdateMessageScore (message.Id);
+            NcBrain.UpdateMessageScore (message.AccountId, message.Id);
         }
 
         public static void ToggleHotOrNot (McEmailMessageThread thread)


### PR DESCRIPTION
- Create persisted requests for brain. Currently, it is only used for saving email messages that need to be unindexed. In the future, we will make additional events persistent.
- Make McEmailMessage.Delete() insert a persisted NcBrainUnindexMessageEvent() instead of calling the index removal routine directly.
- Move public API used by UI or BE into its own file.
- Refactor multiple brain events that relate to email messages to a single base class.
- Add a 5-sec timeout for locking the index for add or remove transaction.
