### PR TITLE
Back button not enabled

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/NcUIBarButtonItem.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/NcUIBarButtonItem.cs
@@ -34,8 +34,12 @@ namespace NachoClient.iOS
             Clicked += Record;
         }
 
-        public NcUIBarButtonItem (UIImage image, UIBarButtonItemStyle style, EventHandler handler) : base (image, style, handler)
+        // Xammit?  Apparent bug in overloading keeps the button disabled
+        public NcUIBarButtonItem (UIImage image, UIBarButtonItemStyle style, EventHandler handler) : base ()
         {
+            this.Image = image;
+            this.Style = style;
+            this.Clicked += handler;
             Clicked += Record;
         }
     }


### PR DESCRIPTION
Fix nachocove/qa#267.  Looks like Xamarin made a mistake with an
overload of UIBarButtonItem. Workaround: don't use the overload.
