### PR TITLE
Fix a push assist errors in telemetry reports

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -305,10 +305,10 @@ namespace NachoCore
                             (uint)PAEvt.E.CliTok,
                             (uint)PAEvt.E.CliTokLoss,
                             (uint)PAEvt.E.Defer,
-                        },
-                        Invalid = new [] {
                             (uint)SmEvt.E.Success,
                             (uint)SmEvt.E.TempFail,
+                        },
+                        Invalid = new [] {
                             (uint)SmEvt.E.HardFail,
                         },
                         On = new [] {


### PR DESCRIPTION
Due to the HTTP request being asynchronous, it is possible its success / temp fail may be received in DevTokW state. Drop them instead of considering them invalid.
