### PR TITLE
A bandaid fix for NcUIBarButtonItem created with Enabled = false.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/NcUIBarButtonItem.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/NcUIBarButtonItem.cs
@@ -17,21 +17,25 @@ namespace NachoClient.iOS
         public NcUIBarButtonItem ()
         {
             Clicked += Record;
+            Enabled = true;
         }
 
         public NcUIBarButtonItem (UIBarButtonSystemItem item) : base (item)
         {
             Clicked += Record;
+            Enabled = true;
         }
 
         public NcUIBarButtonItem (UIBarButtonSystemItem item, EventHandler handler) : base (item, handler)
         {
             Clicked += Record;
+            Enabled = true;
         }
 
         public NcUIBarButtonItem (UIBarButtonSystemItem item, NSObject obj, ObjCRuntime.Selector selector) : base (item, obj, selector)
         {
             Clicked += Record;
+            Enabled = true;
         }
 
         // Xammit?  Apparent bug in overloading keeps the button disabled
@@ -41,6 +45,7 @@ namespace NachoClient.iOS
             this.Style = style;
             this.Clicked += handler;
             Clicked += Record;
+            Enabled = true;
         }
     }
 }


### PR DESCRIPTION
Somehow, some UIBarButtonItems are created with Enabled = false. One example is the add contact button ("+") in contact list view (in alpha build 307). Not sure how this is happens. A bandaid is to manually set Enabled to true after the base class constructor is invoked.
