### PR TITLE
Change the default notification flag to include inbox and remove all.

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -390,6 +390,7 @@
     <Compile Include="NachoCore\Model\McBrainEvent.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration17.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration18.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration19.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/NachoClient.Android/NachoCore/Model/McAccount.cs
+++ b/NachoClient.Android/NachoCore/Model/McAccount.cs
@@ -24,6 +24,7 @@ namespace NachoCore.Model
             GoogleExchange,
         };
 
+        // This type is stored in the db; add to the end
         public enum NotificationConfigurationEnum : int
         {
             ALLOW_ALL_1 = 1,
@@ -32,15 +33,16 @@ namespace NachoCore.Model
             ALLOW_CUSTOM_8 = 8,
             ALLOW_INVITES_16 = 16,
             ALLOW_REMINDERS_32 = 32,
+            ALLOW_INBOX_64 = 64,
         };
 
         public const NotificationConfigurationEnum DefaultNotificationConfiguration =
-            NotificationConfigurationEnum.ALLOW_ALL_1 |
             NotificationConfigurationEnum.ALLOW_HOT_2 |
             NotificationConfigurationEnum.ALLOW_VIP_4 |
             NotificationConfigurationEnum.ALLOW_CUSTOM_8 |
             NotificationConfigurationEnum.ALLOW_INVITES_16 |
-            NotificationConfigurationEnum.ALLOW_REMINDERS_32;
+            NotificationConfigurationEnum.ALLOW_REMINDERS_32 |
+            NotificationConfigurationEnum.ALLOW_INBOX_64;
 
         public McAccount ()
         {

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration19.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration19.cs
@@ -1,0 +1,23 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+
+namespace NachoCore.Model
+{
+    public class NcMigration19 : NcMigration
+    {
+        public override int GetNumberOfObjects ()
+        {
+            return 1;
+        }
+
+        // After discussion, decided on a different default for Notifications
+        public override void Run (System.Threading.CancellationToken token)
+        {
+            NcModel.Instance.Db.Execute (
+                "UPDATE McAccount SET NotificationConfiguration = ?", (int)McAccount.DefaultNotificationConfiguration);
+            UpdateProgress (1);
+        }
+    }
+}
+

--- a/NachoClient.Android/NachoCore/Utils/Pretty.cs
+++ b/NachoClient.Android/NachoCore/Utils/Pretty.cs
@@ -676,28 +676,32 @@ namespace NachoCore.Utils
             return "";
         }
 
+        // Some of these are hidden on purpose, see notification code
         public static string NotificationConfiguration (McAccount.NotificationConfigurationEnum code)
         {
             var list = new List<string> ();
-            if (McAccount.NotificationConfigurationEnum.ALLOW_ALL_1 == (McAccount.NotificationConfigurationEnum.ALLOW_ALL_1 & code)) {
-                list.Add ("All");
-            }
+//            if (McAccount.NotificationConfigurationEnum.ALLOW_ALL_1 == (McAccount.NotificationConfigurationEnum.ALLOW_ALL_1 & code)) {
+//                list.Add ("All");
+//            }
             if (McAccount.NotificationConfigurationEnum.ALLOW_HOT_2 == (McAccount.NotificationConfigurationEnum.ALLOW_HOT_2 & code)) {
                 list.Add ("Hot");
             }
             if (McAccount.NotificationConfigurationEnum.ALLOW_VIP_4 == (McAccount.NotificationConfigurationEnum.ALLOW_VIP_4 & code)) {
                 list.Add ("VIPs");
             }
-            if (McAccount.NotificationConfigurationEnum.ALLOW_INVITES_16 == (McAccount.NotificationConfigurationEnum.ALLOW_INVITES_16 & code)) {
-                list.Add ("Invitations");
+            if (McAccount.NotificationConfigurationEnum.ALLOW_INBOX_64 == (McAccount.NotificationConfigurationEnum.ALLOW_INBOX_64 & code)) {
+                list.Add ("Inbox");
             }
-            if (McAccount.NotificationConfigurationEnum.ALLOW_REMINDERS_32 == (McAccount.NotificationConfigurationEnum.ALLOW_REMINDERS_32 & code)) {
-                list.Add ("Reminders");
-            }
+//            if (McAccount.NotificationConfigurationEnum.ALLOW_INVITES_16 == (McAccount.NotificationConfigurationEnum.ALLOW_INVITES_16 & code)) {
+//                list.Add ("Invitations");
+//            }
+//            if (McAccount.NotificationConfigurationEnum.ALLOW_REMINDERS_32 == (McAccount.NotificationConfigurationEnum.ALLOW_REMINDERS_32 & code)) {
+//                list.Add ("Reminders");
+//            }
             if (0 == list.Count) {
                 return "None";
             } else {
-                return String.Join (",", list);
+                return String.Join (", ", list);
             }
         }
 

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1358,6 +1358,9 @@
       <Link>NachoCore\Model\Migration\NcMigration18.cs</Link>
     </Compile>
     <Compile Include="NachoUI.iOS\Support\UcLocationView.cs" />
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration19.cs">
+      <Link>NachoCore\Model\Migration\NcMigration19.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/NachoClient.iOS/NachoUI.iOS/NotificationChooserViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NotificationChooserViewController.cs
@@ -126,11 +126,9 @@ namespace NachoClient.iOS
 
             List<McAccount.NotificationConfigurationEnum> choices = new List<McAccount.NotificationConfigurationEnum> () {
                 0,
-                McAccount.NotificationConfigurationEnum.ALLOW_ALL_1,
                 McAccount.NotificationConfigurationEnum.ALLOW_HOT_2,
                 McAccount.NotificationConfigurationEnum.ALLOW_VIP_4,
-                McAccount.NotificationConfigurationEnum.ALLOW_INVITES_16,
-                McAccount.NotificationConfigurationEnum.ALLOW_REMINDERS_32
+                McAccount.NotificationConfigurationEnum.ALLOW_INBOX_64,
             };
 
             public NotificationChoicesSource (NotificationChooserViewController owner)


### PR DESCRIPTION
Change the default notification flag to include inbox and remove all.
Keep the calendar notifications as part of default, but they are not
displayed, assumed to be either always displayed or auto-hot'd, will
be decided by the code that looks at these flags.
