### PR TITLE
Fix #1299.  Contact colors should be consistent

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -428,6 +428,9 @@ namespace NachoCore.Model
             McEmailAddress emailAddress;
             if (McEmailAddress.Get (AccountId, value, out emailAddress)) {
                 f.EmailAddress = emailAddress.Id;
+                if (0 == this.CircleColor) {
+                    this.CircleColor = emailAddress.ColorIndex;
+                }
             }
             EmailAddresses.Add (f);
             return f;
@@ -664,7 +667,9 @@ namespace NachoCore.Model
 
         public override int Insert ()
         {
-            CircleColor = NachoPlatform.PlatformUserColorIndex.PickRandomColorForUser ();
+            if (0 == CircleColor) {
+                CircleColor = NachoPlatform.PlatformUserColorIndex.PickRandomColorForUser ();
+            }
             EvaluateSelfEclipsing ();
             int retval = 0;
             NcModel.Instance.RunInTransaction (() => {


### PR DESCRIPTION
Fix #1299. Pick a color for a contact from one of the contact's
email addresses. The email addresses are added in order Email1,
Email2, etc. so the first address has priority. And for this to
work, don't overwrite the color when inserting the contact into
the db.
