### PR TITLE
Fix #758. Display attachment download errors.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/ErrorHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/ErrorHelper.cs
@@ -6,8 +6,34 @@ namespace NachoCore.Utils
 {
     public class ErrorHelper
     {
-        public ErrorHelper ()
+        public static bool ExtractErrorString (NcResult nr, out string errorString)
         {
+            string message = null;
+            switch (nr.SubKind) {
+            case NcResult.SubKindEnum.Error_NetworkUnavailable:
+                message = "The network is unavailable.";
+                break;
+            case NcResult.SubKindEnum.Error_NoSpace:
+                message = "Your device is out of space.";
+                break;
+            case NcResult.SubKindEnum.Error_EmailMessageBodyDownloadFailed:
+                message = "Message download failed.";
+                break;
+            case NcResult.SubKindEnum.Error_CalendarBodyDownloadFailed:
+                message = "Calendar body download failed.";
+                break;
+            case NcResult.SubKindEnum.Error_AttDownloadFailed:
+                message = "Attachment download failed.";
+                break;
+            case NcResult.SubKindEnum.Error_AuthFailBlocked:
+                message = "Authorization failed.";
+                break;
+            case NcResult.SubKindEnum.Error_AuthFailPasswordExpired:
+                message = "Your password has expired.";
+                break;
+            }
+            errorString = message;
+            return (null != message);
         }
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -335,6 +335,7 @@ namespace NachoClient.iOS
             attachmentListView.SetHeader ("ATTACHMENTS", A.Font_AvenirNextMedium12, A.Color_NachoLightText, imageView, A.Font_AvenirNextMedium12, A.Color_NachoLightText, UIColor.White, 0f);
             attachmentListView.SetAttachmentCellIndent (42f);
             attachmentListView.OnAttachmentSelected = AttachmentsOnSelected;
+            attachmentListView.OnAttachmentError = AttachmentOnError;
             attachmentListView.OnStateChanged = AttachmentsOnStateChange;
             eventCardView.AddSubview (attachmentListView);
 
@@ -1399,6 +1400,15 @@ namespace NachoClient.iOS
             if (McAbstrFileDesc.FilePresenceEnum.Complete == attachment.FilePresence) {
                 PlatformHelpers.DisplayAttachment (this, attachment);
             }
+        }
+
+        private void AttachmentOnError(McAttachment attachment, NcResult result)
+        {
+            string message;
+            if(!ErrorHelper.ExtractErrorString(result, out message)) {
+                message = "Download failed.";
+            }
+            NcAlertView.ShowMessage (this, "Attachment error", message);
         }
 
         private void AttachmentsOnStateChange (bool isExpanded)

--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -318,6 +318,7 @@ namespace NachoClient.iOS
                 headerView.Frame.Width - ATTACHMENTVIEW_INSET, 50));
             attachmentListView.SetHeader ("Attachments", A.Font_AvenirNextRegular17, A.Color_NachoTextGray, null, A.Font_AvenirNextDemiBold14, UIColor.White, A.Color_909090, 10f);
             attachmentListView.OnAttachmentSelected = AttachmentsOnSelected;
+            attachmentListView.OnAttachmentError = AttachmentOnError;
             attachmentListView.OnStateChanged = AttachmentsOnStateChange;
             attachmentListView.Tag = (int)TagType.ATTACHMENT_VIEW_TAG;
             headerView.AddSubview (attachmentListView);
@@ -852,6 +853,15 @@ namespace NachoClient.iOS
             if (McAbstrFileDesc.FilePresenceEnum.Complete == attachment.FilePresence) {
                 PlatformHelpers.DisplayAttachment (this, attachment);
             }
+        }
+
+        private void AttachmentOnError(McAttachment attachment, NcResult result)
+        {
+            string message;
+            if(!ErrorHelper.ExtractErrorString(result, out message)) {
+                message = "Download failed.";
+            }
+            NcAlertView.ShowMessage (this, "Attachment error", message);
         }
 
         private void AttachmentsOnStateChange (bool isExpanded)

--- a/NachoClient.iOS/NachoUI.iOS/Support/AttachmentListView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/AttachmentListView.cs
@@ -27,6 +27,7 @@ namespace NachoClient.iOS
         static readonly nfloat TOP_MARGIN = 5.0f;
         protected nfloat attachmentCellIndent = 0f;
 
+        public AttachmentView.AttachmentErrorCallback OnAttachmentError;
         public AttachmentView.AttachmentSelectedCallback OnAttachmentSelected;
 
         protected List<AttachmentView> attachmentViews;
@@ -61,6 +62,7 @@ namespace NachoClient.iOS
             var frame = new CGRect (attachmentCellIndent, ExpandedHeight + 1.0f, Frame.Width - attachmentCellIndent, AttachmentView.VIEW_HEIGHT);
             var attachmentView = new AttachmentView (frame, attachment);
             attachmentView.OnAttachmentSelected = OnAttachmentSelected;
+            attachmentView.OnAttachmentError = OnAttachmentError;
             attachmentViews.Add (attachmentView);
             AddSubview (attachmentView);
             UpdateNumber ();

--- a/NachoClient.iOS/NachoUI.iOS/Support/AttachmentView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/AttachmentView.cs
@@ -18,6 +18,7 @@ namespace NachoClient.iOS
     public class AttachmentView : UIView
     {
         public delegate void AttachmentSelectedCallback (McAttachment attachment);
+        public delegate void AttachmentErrorCallback (McAttachment attachment, NcResult nr);
 
         protected McAttachment attachment;
         protected UIImageView imageView;
@@ -32,6 +33,7 @@ namespace NachoClient.iOS
         private bool statusIndicatorIsRegistered = false;
         private string downloadToken = null;
 
+        public AttachmentErrorCallback OnAttachmentError;
         public AttachmentSelectedCallback OnAttachmentSelected;
 
         const float ICON_SIZE = 24.0f;
@@ -218,6 +220,9 @@ namespace NachoClient.iOS
             var nr = PlatformHelpers.DownloadAttachment (attachment);
             downloadToken = nr.GetValue<String> ();
             if (null == downloadToken) {
+                if (null != OnAttachmentError) {
+                    OnAttachmentError (attachment, nr);
+                }
                 RefreshStatus ();
                 return;
             }
@@ -243,6 +248,9 @@ namespace NachoClient.iOS
                             }
                         }
                     }, "DelFailedMcPendingAttachmentDnld");
+                    if (null != OnAttachmentError) {
+                        OnAttachmentError (attachment, statusEvent.Status);
+                    }
                 }
                 RefreshStatus ();
                 downloadToken = null;

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -439,33 +439,9 @@ namespace NachoClient.iOS
             spinner.StopAnimating ();
             string preview = item.GetBodyPreviewOrEmpty ();
             bool hasPreview = !string.IsNullOrEmpty (preview);
-            // TODO: Refactor
-            string message = "Download failed.";
-            switch (nr.SubKind) {
-            case NcResult.SubKindEnum.Error_NetworkUnavailable:
-                message += " The network is unavailable.";
-                break;
-            case NcResult.SubKindEnum.Error_NoSpace:
-                message += " Your device is out of space.";
-                break;
-            case NcResult.SubKindEnum.Error_EmailMessageBodyDownloadFailed:
-                message += " Message download failed.";
-                break;
-            case NcResult.SubKindEnum.Error_CalendarBodyDownloadFailed:
-                message += " Calendar body download failed.";
-                break;
-            case NcResult.SubKindEnum.Error_AttDownloadFailed:
-                message += " Attachment download failed.";
-                break;
-            case NcResult.SubKindEnum.Error_AuthFailBlocked:
-                message += " Authorization failed.";
-                break;
-            case NcResult.SubKindEnum.Error_AuthFailPasswordExpired:
-                message += " Your password has expired.";
-                break;
-            default:
-                message += " Download failed.";
-                break;
+            string message;
+            if (!ErrorHelper.ExtractErrorString (nr, out message)) {
+                message = "Download failed.";
             }
             if (UserInteractionEnabled) {
                 message += " Tap here to retry.";

--- a/Test.Android/ErrorHelperTest.cs
+++ b/Test.Android/ErrorHelperTest.cs
@@ -10,6 +10,24 @@ namespace Test.Common
     public class ErrorHelperTest : NcTestBase
     {
 
+        [Test]
+        public void Basic()
+        {
+            string s;
+            NcResult nr;
+
+            s = null;
+            nr = NcResult.Error (NcResult.SubKindEnum.Error_NetworkUnavailable);
+            Assert.True (ErrorHelper.ExtractErrorString (nr, out s));
+            Assert.AreEqual ("The network is unavailable.", s);
+
+            s = "monkey";
+            nr = NcResult.OK ();
+            Assert.False (ErrorHelper.ExtractErrorString (nr, out s));
+            Assert.IsNull (s);
+
+        }
+
     }
 }
 


### PR DESCRIPTION
Fix #758. Check for errors on attachment download & call up the chain to display the error message.  Refactor the error message extraction code, which still needs work.  Add simple unit test.
