### PR TITLE
For nachocore/qa#116

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcXmlFilter.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcXmlFilter.cs
@@ -316,9 +316,13 @@ namespace NachoCore.Wbxml
 
                     // Look for the filter node for this element
                     if (null != current.ParentNode) {
-                        current.ParentNode = current.ParentNode.FindChildNode (element);
-                        if (null == current.ParentNode) {
-                            Log.Warn (Log.LOG_XML_FILTER, "Unknown element tag {0}", element.Name);
+                        if (RedactionType.FULL != current.ParentNode.ElementRedaction) {
+                            current.ParentNode = current.ParentNode.FindChildNode (element);
+                            if (null == current.ParentNode) {
+                                Log.Warn (Log.LOG_XML_FILTER, "Unknown element tag {0}", element.Name);
+                            }
+                        } else {
+                            current.ParentNode = null;
                         }
                     }
                 }


### PR DESCRIPTION
- See nachocove/qa#116 for detail analysis.
- Fix unknown {Search}And tag. If the current element redaction mode is full, do not bother to search for its child tag.
