### PR TITLE
Move our on-device drafts and outbox to the default folder list.

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -394,6 +394,7 @@
     <Compile Include="NachoCore\Utils\NotificationHelper.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration19.cs" />
     <Compile Include="NachoCore\Utils\ErrorHelper.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration20.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/NachoClient.Android/NachoCore/Adapters/NachoDraftMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoDraftMessages.cs
@@ -58,10 +58,10 @@ namespace NachoCore
 
         public string DisplayName ()
         {
-            if (folder.IsOutboxFolder ()) {
+            if (folder.IsClientOwnedOutboxFolder ()) {
                 return "Outbox";
             }
-            if (folder.IsEmailDraftsFolder ()) {
+            if (folder.IsClientOwnedDraftsFolder ()) {
                 return "Drafts";
             }
             NachoCore.Utils.NcAssert.CaseError (folder.DisplayName);
@@ -71,12 +71,12 @@ namespace NachoCore
 
         public bool HasOutboxSemantics ()
         {
-            return folder.IsOutboxFolder ();
+            return folder.IsClientOwnedOutboxFolder ();
         }
 
         public bool HasDraftsSemantics ()
         {
-            return folder.IsEmailDraftsFolder ();
+            return folder.IsClientOwnedDraftsFolder ();
         }
 
         public void StartSync ()

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
@@ -876,7 +876,7 @@ namespace NachoCore.ActiveSync
             // Make the application-defined folders.
             McFolder freshMade;
             NcModel.Instance.RunInTransaction (() => {
-                if (null == McFolder.GetOutboxFolder (AccountId)) {
+                if (null == McFolder.GetClientOwnedOutboxFolder (AccountId)) {
                     freshMade = McFolder.Create (AccountId, true, false, true, "0",
                         McFolder.ClientOwned_Outbox, "On-Device Outbox",
                         Xml.FolderHierarchy.TypeCode.UserCreatedMail_12);
@@ -884,9 +884,9 @@ namespace NachoCore.ActiveSync
                 }
             });
             NcModel.Instance.RunInTransaction (() => {
-                if (null == McFolder.GetEmailDraftsFolder (AccountId)) {
+                if (null == McFolder.GetClientOwnedDraftsFolder (AccountId)) {
                     freshMade = McFolder.Create (AccountId, true, false, true, "0",
-                        McFolder.ClientOwned_EmailDrafts, "On-Device Email Drafts",
+                        McFolder.ClientOwned_EmailDrafts, "On-Device Drafts",
                         Xml.FolderHierarchy.TypeCode.UserCreatedMail_12);
                     freshMade.Insert ();
                 }

--- a/NachoClient.Android/NachoCore/Model/McFolder.cs
+++ b/NachoClient.Android/NachoCore/Model/McFolder.cs
@@ -162,12 +162,12 @@ namespace NachoCore.Model
             return McFolder.GetClientOwnedFolder (McAccount.GetDeviceAccount ().Id, ClientOwned_DeviceCalendars);
         }
 
-        public static McFolder GetOutboxFolder (int accountId)
+        public static McFolder GetClientOwnedOutboxFolder (int accountId)
         {
             return McFolder.GetClientOwnedFolder (accountId, ClientOwned_Outbox);
         }
 
-        public static McFolder GetEmailDraftsFolder (int accountId)
+        public static McFolder GetClientOwnedDraftsFolder (int accountId)
         {
             return McFolder.GetClientOwnedFolder (accountId, ClientOwned_EmailDrafts);
         }
@@ -192,7 +192,7 @@ namespace NachoCore.Model
             return McFolder.GetClientOwnedFolder (accountId, ClientOwned_LostAndFound);
         }
 
-        public bool IsEmailDraftsFolder ()
+        public bool IsClientOwnedDraftsFolder ()
         {
             if (NachoCore.ActiveSync.Xml.FolderHierarchy.TypeCode.UserCreatedMail_12 == this.Type) {
                 if (ClientOwned_EmailDrafts == this.ServerId) {
@@ -202,7 +202,7 @@ namespace NachoCore.Model
             return false;
         }
 
-        public bool IsOutboxFolder ()
+        public bool IsClientOwnedOutboxFolder ()
         {
             if (NachoCore.ActiveSync.Xml.FolderHierarchy.TypeCode.UserCreatedMail_12 == this.Type) {
                 if (ClientOwned_Outbox == this.ServerId) {

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration20.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration20.cs
@@ -1,0 +1,27 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+
+namespace NachoCore.Model
+{
+    public class NcMigration20 : NcMigration
+    {
+        public override int GetNumberOfObjects ()
+        {
+            return 1;
+        }
+
+        public override void Run (System.Threading.CancellationToken token)
+        {
+            var accounts = NcModel.Instance.Db.Table<McAccount> ();
+            foreach (var account in accounts) {
+                var folder = McFolder.GetClientOwnedDraftsFolder (account.Id);
+                if (null != folder) {
+                    folder.UpdateSet_DisplayName ("On-Device Drafts");
+                }
+            }
+            UpdateProgress (1);
+        }
+    }
+}
+

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration7.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration7.cs
@@ -18,7 +18,7 @@ namespace NachoCore.Model
         public override void Run (System.Threading.CancellationToken token)
         {
             foreach (var account in Db.Table<McAccount>()) {
-                var outbox = McFolder.GetOutboxFolder (account.Id);
+                var outbox = McFolder.GetClientOwnedOutboxFolder (account.Id);
                 if (null != outbox) {
                     if (outbox.IsClientOwned) {
                         MakeThisHidden (outbox);

--- a/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
@@ -28,7 +28,7 @@ namespace NachoCore.Utils
         // Message is saved into Outbox
         public static void SendTheMessage (Action action, McEmailMessage messageToSend, bool originalEmailIsEmbedded, McEmailMessage referencedMessage, bool calendarInviteIsSet, McAbstrCalendarRoot calendarInviteItem)
         {
-            var outbox = McFolder.GetOutboxFolder (messageToSend.AccountId);
+            var outbox = McFolder.GetClientOwnedOutboxFolder (messageToSend.AccountId);
             if (null != outbox) {
                 outbox.Link (messageToSend);
             } else {
@@ -115,8 +115,8 @@ namespace NachoCore.Utils
                 BackEnd.Instance.Cancel (message.AccountId, pending.Token);
             }
             // Move files in client-owned folders manually
-            var draftsFolder = McFolder.GetEmailDraftsFolder (message.AccountId);
-            var outboxFolder = McFolder.GetOutboxFolder (message.AccountId);
+            var draftsFolder = McFolder.GetClientOwnedDraftsFolder (message.AccountId);
+            var outboxFolder = McFolder.GetClientOwnedOutboxFolder (message.AccountId);
             outboxFolder.Unlink (message);
             draftsFolder.Link (message);
             // Send status ind after the message is moved
@@ -158,7 +158,7 @@ namespace NachoCore.Utils
 
         public static void SaveEmailMessageInDrafts (McEmailMessage message)
         {
-            var draftsFolder = McFolder.GetEmailDraftsFolder (message.AccountId);
+            var draftsFolder = McFolder.GetClientOwnedDraftsFolder (message.AccountId);
             if (null != draftsFolder) {
                 draftsFolder.Link (message);
             } else {

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1367,6 +1367,9 @@
     <Compile Include="..\NachoClient.Android\NachoCore\Utils\ErrorHelper.cs">
       <Link>NachoCore\Utils\ErrorHelper.cs</Link>
     </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration20.cs">
+      <Link>NachoCore\Model\Migration\NcMigration20.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/Test.Android/McFolderTest.cs
+++ b/Test.Android/McFolderTest.cs
@@ -53,7 +53,7 @@ namespace Test.iOS
                 // Lost and Found
                 McFolder expectedLostFound = FolderOps.CreateFolder (accountId, serverId: McFolder.ClientOwned_LostAndFound, isClientOwned: true);
 
-                McFolder actualFolder1 = McFolder.GetOutboxFolder (accountId);
+                McFolder actualFolder1 = McFolder.GetClientOwnedOutboxFolder (accountId);
                 FoldersAreEqual (expectedOutbox, actualFolder1, "Should be able to query for distinguished folder (Outbox)");
 
                 McFolder actualFolder2 = McFolder.GetCalDraftsFolder (accountId);


### PR DESCRIPTION
Move our on-device drafts and outbox to the default folder list.
Move the unused outbox and drafts folders to the list of regular
folders.  Change the name of the "On-device Email Drafts" to "On
-device Drafts".  Rename functions to differentiate between the
device's folders and the client-owned folders.
