### PR TITLE
Fixes for multiple issues in safe mode

### DIFF
--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -78,6 +78,12 @@ namespace NachoCore
             }
         }
 
+        public bool IsInitializing {
+            get {
+                return (ExecutionContextEnum.Initializing == ExecutionContext);
+            }
+        }
+
         // This string needs to be filled out by platform-dependent code when the app is first launched.
         public string CrashFolder { get; set; }
 
@@ -342,6 +348,7 @@ namespace NachoCore
             if (ShouldEnterSafeMode ()) {
                 ExecutionContext = ExecutionContextEnum.Initializing;
                 SafeMode = true;
+                Telemetry.SharedInstance.Throttling = false;
                 NcTask.Run (() => {
                     if (!MonitorUploads ()) {
                         Log.Info (Log.LOG_LIFECYCLE, "NcApplication: safe mode canceled");

--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -904,7 +904,7 @@ namespace NachoCore.Utils
                             }
                         }
 
-                        if (MAX_QUERY_ITEMS > dbEvents.Count) {
+                        if ((MAX_QUERY_ITEMS > dbEvents.Count) && !(dbEvents [0] is McTelemetrySupportEvent)) {
                             // We have completely caught up. Don't want to continue
                             // to the next message immediately because we want to
                             // send multiple messages at a time. This leads to a more

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -447,11 +447,14 @@ namespace NachoClient.iOS
         public override void OnResignActivation (UIApplication application)
         {
             Log.Info (Log.LOG_LIFECYCLE, "OnResignActivation: time remaining: {0}", application.BackgroundTimeRemaining);
+            bool isInitializing = NcApplication.Instance.IsInitializing;
             NcApplication.Instance.PlatformIndication = NcApplication.ExecutionContextEnum.Background;
             BadgeNotifGoInactive ();
             NcApplication.Instance.StatusIndEvent += BgStatusIndReceiver;
 
-            NcApplication.Instance.StopClass4Services ();
+            if (!isInitializing) {
+                NcApplication.Instance.StopClass4Services ();
+            }
             Log.Info (Log.LOG_LIFECYCLE, "OnResignActivation: StopClass4Services complete");
 
             Log.Info (Log.LOG_LIFECYCLE, "OnResignActivation: Exit");


### PR DESCRIPTION
- If still in initializing exec. context, do not stop class 4 services as it is deferred and has not been started yet. This prevents the app from crashing when backgrounding in safe mode.
- In safe mode, immediately disable telemetry throttling. This prevents telemetry runs artificially slow.
- If the telemetry upload list is 1 but the event type is TelemetrySupportEvent, do not take the 5 sec pause as there can be many regular events waiting.
