### PR TITLE
Links in plain text messages are now clickable

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyTextView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyTextView.cs
@@ -26,21 +26,22 @@ namespace NachoClient.iOS
             Selectable = true;
             AttributedText = text;
             base.ContentSize = SizeThatFits (Frame.Size);
-           
-            // Workaround a bug.  UITextView, which is a kind of UIScrollView, only allows
-            // scrolling programatically if ScrollEnabled is true.  If ScrollEnabled is
-            // false, then setting ContentOffset has no effect (or the wrong effect). To
-            // work around this, set ScrollEnabled to true but UserInteraction to false.
-            // This allows scrolling programatically but doesn't intercept any of the
-            // scroll gestures.
-            ScrollEnabled = true;
-            UserInteractionEnabled = false;
-            ShowsHorizontalScrollIndicator = false;
-            ShowsVerticalScrollIndicator = false;
 
-            // Render at most one screenful of text at a time.
-            ViewFramer.Create (this)
-                .Height (NMath.Min (ContentSize.Height, UIScreen.MainScreen.Bounds.Height));
+            // There is a bug in UITextView where scrolling programatically (i.e. setting
+            // ContentOffset) doesn't work if ScrollEnabled is false.  If both ScrollEnabled
+            // and UserInteractionEnabled are true, then the UITextView will intercept the
+            // scrolling gestures that should be handled by an outer UIScrollView.  If
+            // ScrollEnabled is true and UserInteractionEnabled is false, then scrolling
+            // programatically will work, but links within the text are not clickable.
+            // The only way to have clickable links and to not mess up the scrolling is to
+            // have UserInteractionEnabled be true and ScrollEnabled be false.  But that
+            // means we can't scroll programatically and instead have to render the entire
+            // UITextView.  That will result in greater memory usage for large pieces of
+            // text.  But really large plain text is much less common than really large
+            // UIWebView, so this is not expected to be a serious problem.
+            ScrollEnabled = false;
+            UserInteractionEnabled = true;
+            ViewFramer.Create (this).Height (base.ContentSize.Height);
         }
 
         public UIView uiView ()
@@ -56,8 +57,9 @@ namespace NachoClient.iOS
 
         public void ScrollingAdjustment (CGRect frame, CGPoint contentOffset)
         {
-            this.Frame = frame;
-            this.ContentOffset = contentOffset;
+            // Scrolling and resizing is not supported.  The only thing that can be adjusted
+            // is the view's origin.
+            ViewFramer.Create (this).X (frame.X - contentOffset.X).Y (frame.Y - contentOffset.Y);
         }
 
         protected override void Dispose (bool disposing)


### PR DESCRIPTION
Change the implementation of BodyTextView so that links within plain
text messages or event bodies are now clickable.  Clicking on a link
in such a message will open the link in a browser.

Fix #1184
