### PR TITLE
Allow user to cancel one instance of a recurring meeting

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McAbstrCalendarRoot.cs
+++ b/NachoClient.Android/NachoCore/Model/McAbstrCalendarRoot.cs
@@ -116,6 +116,14 @@ namespace NachoCore.Model
             return HasResponseType () ? ResponseType : NcResponseType.None;
         }
 
+        /// <summary>
+        /// Return the UID for this event.  This method must be overridden by derived classes.
+        /// </summary>
+        public virtual string GetUID ()
+        {
+            return "";
+        }
+
         // Attendees that are stored in the database.
         private List<McAttendee> dbAttendees = null;
         // Attendees that were set by the app, either UI or sync.  They don't get saved to the database

--- a/NachoClient.Android/NachoCore/Model/McCalendar.cs
+++ b/NachoClient.Android/NachoCore/Model/McCalendar.cs
@@ -46,6 +46,11 @@ namespace NachoCore.Model
             return McAbstrFolderEntry.ClassCodeEnum.Calendar;
         }
 
+        public override string GetUID ()
+        {
+            return UID;
+        }
+
         private List<McException> dbExceptions = null;
         private IList<McException> appExceptions = null;
 

--- a/NachoClient.Android/NachoCore/Model/McException.cs
+++ b/NachoClient.Android/NachoCore/Model/McException.cs
@@ -61,6 +61,15 @@ namespace NachoCore.Model
             return this.ResponseTypeIsSet ? this.ResponseType : CalendarItemOrSelf ().ResponseType;
         }
 
+        public override string GetUID ()
+        {
+            var cal = CalendarItem ();
+            if (null == cal) {
+                return "";
+            }
+            return cal.GetUID ();
+        }
+
         [Ignore]
         public override IList<McAttendee> attendees {
             get {

--- a/NachoClient.Android/NachoCore/Model/McMeetingRequest.cs
+++ b/NachoClient.Android/NachoCore/Model/McMeetingRequest.cs
@@ -121,7 +121,7 @@ namespace NachoCore.Model
         /// https://msdn.microsoft.com/en-us/library/hh338153(v=exchg.80).aspx for the conversion
         /// algorithm.
         /// </remarks>
-        public string GetUID ()
+        public override string GetUID ()
         {
             if (string.IsNullOrEmpty (GlobalObjId)) {
                 return "";


### PR DESCRIPTION
Allow the user to cancel one instance of a recurring meeting where the
user is the organizer of the meeting.  A cancellation notice will be
sent out to all the attendees.  The cancel button appears at the
bottom of the event detail view (but only when the event is an
occurrence of a recurring meeting where the user is the organizer).
The user is prompted to confirm the operation before the cancellation
happens.

Fix nachocove/qa#68
