### PR TITLE
Do not glean from email drafts folders.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/EmailMessageScore.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/EmailMessageScore.cs
@@ -303,8 +303,9 @@ namespace NachoCore.Model
             var query = "SELECT e.* FROM McEmailMessage AS e " +
                         " JOIN McMapFolderFolderEntry AS m ON e.Id = m.FolderEntryId " +
                         " WHERE likelihood (HasBeenGleaned < ?, 0.1) ";
-            if (null != McFolder.JunkFolderListSqlString ()) {
-                query += String.Format (" AND likelihood (m.FolderId NOT IN {0}, 0.9) ", McFolder.JunkFolderListSqlString ());
+            var sqlSet = McFolder.GleaningExemptedFolderListSqlString (); 
+            if (null != sqlSet) {
+                query += String.Format (" AND likelihood (m.FolderId NOT IN {0}, 0.9) ", sqlSet);
             }
             if (0 <= accountId) {
                 query += " AND likelihood (e.AccountId = ?, 1.0) LIMIT ?";

--- a/NachoClient.Android/NachoCore/Model/McFolder.cs
+++ b/NachoClient.Android/NachoCore/Model/McFolder.cs
@@ -139,6 +139,13 @@ namespace NachoCore.Model
             return 0;
         }
 
+        public static List<McFolder> GetClientOwnedFolders (string serverId)
+        {
+            return NcModel.Instance.Db.Table<McFolder> ().Where (x => 
+                serverId == x.ServerId &&
+            true == x.IsClientOwned).ToList ();
+        }
+
         public static McFolder GetClientOwnedFolder (int accountId, string serverId)
         {
             return NcModel.Instance.Db.Table<McFolder> ().Where (x => 
@@ -146,6 +153,7 @@ namespace NachoCore.Model
             serverId == x.ServerId &&
             true == x.IsClientOwned).SingleOrDefault ();
         }
+
         /*
          * SYNCED FOLDERS:
          * Folder Get...Folder functions for distinguished folders that aren't going to 
@@ -173,6 +181,11 @@ namespace NachoCore.Model
         public static McFolder GetClientOwnedDraftsFolder (int accountId)
         {
             return McFolder.GetClientOwnedFolder (accountId, ClientOwned_EmailDrafts);
+        }
+
+        public static List<McFolder> GetClientOwnedDraftsFolders ()
+        {
+            return McFolder.GetClientOwnedFolders (ClientOwned_EmailDrafts);
         }
 
         public static McFolder GetCalDraftsFolder (int accountId)
@@ -878,6 +891,22 @@ namespace NachoCore.Model
                 return null;
             }
             return "(" + string.Join (",", JunkFolderIds.Keys) + ")";
+        }
+
+        public static string GleaningExemptedFolderListSqlString ()
+        {
+            var folderList = new List<int> ();
+            if (0 < JunkFolderIds.Count) {
+                folderList.AddRange (JunkFolderIds.Keys);
+            }
+            var draftFolders = GetClientOwnedDraftsFolders ();
+            if (0 < draftFolders.Count) {
+                folderList.AddRange (draftFolders.Select (x => x.Id));
+            }
+            if (0 == folderList.Count) {
+                return null;
+            }
+            return "(" + string.Join (",", folderList) + ")";
         }
     }
 }

--- a/Test.Android/McFolderTest.cs
+++ b/Test.Android/McFolderTest.cs
@@ -27,10 +27,21 @@ namespace Test.iOS
                 int accountId = 1;
                 string serverId = "TestServer";
                 McFolder expectedFolder = FolderOps.CreateFolder (accountId, serverId: serverId, isClientOwned: true);
+                McFolder expectedFolder2 = FolderOps.CreateFolder (accountId + 1, serverId: serverId, isClientOwned: true);
 
                 var actualFolder = McFolder.GetClientOwnedFolder (accountId, serverId);
 
                 FoldersAreEqual (expectedFolder, actualFolder, "Should be able to do basic query of client-owned folder");
+
+                var actualFolders = McFolder.GetClientOwnedFolders (serverId);
+                Assert.AreEqual (2, actualFolders.Count);
+                if (actualFolders [0].Id == expectedFolder.Id) {
+                    FoldersAreEqual (expectedFolder, actualFolders [0], "1st folder should be equal to expected folder");
+                    FoldersAreEqual (expectedFolder2, actualFolders [1], "2nd folder should be equal to expected folder #2");
+                } else {
+                    FoldersAreEqual (expectedFolder, actualFolders [1], "2nd folder should be equal to expected folder");
+                    FoldersAreEqual (expectedFolder2, actualFolders [0], "1st folder should be equal to expected folder #2");
+                }
             }
 
             [Test]
@@ -53,6 +64,10 @@ namespace Test.iOS
                 // Lost and Found
                 McFolder expectedLostFound = FolderOps.CreateFolder (accountId, serverId: McFolder.ClientOwned_LostAndFound, isClientOwned: true);
 
+                // EmailDrafts
+                McFolder expectedEmailDrafts = FolderOps.CreateFolder (accountId, serverId: McFolder.ClientOwned_EmailDrafts, isClientOwned: true);
+                McFolder expectedEmailDrafts2 = FolderOps.CreateFolder (accountId + 1, serverId: McFolder.ClientOwned_EmailDrafts, isClientOwned: true);
+
                 McFolder actualFolder1 = McFolder.GetClientOwnedOutboxFolder (accountId);
                 FoldersAreEqual (expectedOutbox, actualFolder1, "Should be able to query for distinguished folder (Outbox)");
 
@@ -67,6 +82,19 @@ namespace Test.iOS
 
                 McFolder lostAndFound = McFolder.GetLostAndFoundFolder (accountId);
                 FoldersAreEqual (expectedLostFound, lostAndFound, "Should be able to query for distinguished folder (Lost And Found)");
+
+                McFolder emailDrafts = McFolder.GetClientOwnedDraftsFolder (accountId);
+                FoldersAreEqual (expectedEmailDrafts, emailDrafts, "Should be able to query for distinguished folder (Email Drafts)");
+
+                var emailDraftsFolders = McFolder.GetClientOwnedDraftsFolders ();
+                Assert.AreEqual (2, emailDraftsFolders.Count);
+                if (emailDraftsFolders [0].Id == expectedEmailDrafts.Id) {
+                    FoldersAreEqual (expectedEmailDrafts, emailDraftsFolders [0], "1st folder should be equal to expected folder");
+                    FoldersAreEqual (expectedEmailDrafts2, emailDraftsFolders [1], "2nd fodler should be equal to expected folder #2");
+                } else {
+                    FoldersAreEqual (expectedEmailDrafts, emailDraftsFolders [1], "2nd folder should be equal to expected folder");
+                    FoldersAreEqual (expectedEmailDrafts2, emailDraftsFolders [0], "1st fodler should be equal to expected folder #2");
+                }
             }
         }
 


### PR DESCRIPTION
- This is a follow up of Steve's review comment in #1867.
- Take the JunkFolderIds and all folder ids returned by GetClientOwnedDraftsFolders() and create a SQL string for the set of exempted folder ids.
- Add unit tests for the query.
