### PR TITLE
Do not run WAL checkpoint during quick sync as it may delay processing past the 30-sec window.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -464,6 +464,9 @@ namespace NachoCore.Model
 //                    walCheckpointCount = (walCheckpointCount + 1) & 0xfff;
 
                     lock (WriteNTransLockObj) {
+                        if (NcApplication.Instance.IsQuickSync) {
+                            return;
+                        }
                         List<CheckpointResult> results = thisDb.Query<CheckpointResult> (checkpointCmd);
                         if ((0 < results.Count) && (0 != results [0].busy)) {
                             Log.Error (Log.LOG_DB, "Checkpoint busy of {0}", db.DatabasePath);

--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -84,6 +84,12 @@ namespace NachoCore
             }
         }
 
+        public bool IsQuickSync {
+            get {
+                return (ExecutionContextEnum.QuickSync == ExecutionContext);
+            }
+        }
+
         // This string needs to be filled out by platform-dependent code when the app is first launched.
         public string CrashFolder { get; set; }
 


### PR DESCRIPTION
This addresses crash 4 in nachocove/qa#256.
