### PR TITLE
Mark meeting as canceled when processing a meeting cancelation message

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncEmailCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncEmailCommand.cs
@@ -80,6 +80,18 @@ namespace NachoCore.ActiveSync
                     emailMessage.Update ();
                 }
             });
+
+            if (!emailMessage.IsIncomplete) {
+
+                // Extra work that needs to be done, but doesn't need to be in the same database transaction.
+
+                // If this message is a cancellation notice, mark the event as cancelled.  (The server may
+                // have already done this, but some servers don't.)
+                if ("IPM.Schedule.Meeting.Canceled" == emailMessage.MessageClass && null != emailMessage.MeetingRequest) {
+                    CalendarHelper.MarkEventAsCancelled (emailMessage.MeetingRequest);
+                }
+            }
+
             return emailMessage;
         }
     }


### PR DESCRIPTION
Most servers change a meeting's status to canceled when the server
processes an incoming meeting cancelation message.  But some servers
don't do that in all cases.  So change the app to do it.  When the app
processes an incoming meeting cancelation message, it will mark the
meeting as canceled.  The change is only made locally; it is not
syched to the server.

This was tested with servers that mark the meeting as canceled,
servers that don't (Exchange 2007), and servers that delete the
meeting as soon as the cancelation notice arrives (Google).  It was
tested with regular meetings, recurring meetings, and individual
occurrences of recurring meetings.

Fix #1420
