### PR TITLE
Fix bogus download failure message for empty event descriptions

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -482,6 +482,9 @@ namespace NachoClient.iOS
             descriptionView.AddSubview (descriptionTextView);
             descriptionView.AddSubview (descriptionPlaceHolder);
 
+            // If a new event is being created, mark the description as having been edited so that the
+            // new event will always have a body, even if the user leaves the description field blank.
+            descriptionWasEdited = CalendarItemEditorAction.create == action;
 
             //All Day Event
             allDayView = new UIView (new CGRect (0, (LINE_OFFSET * 2) + (CELL_HEIGHT * 2) + TEXT_LINE_HEIGHT, SCREEN_WIDTH, CELL_HEIGHT));


### PR DESCRIPTION
When an event with an empty description was created within the app,
the McCalendar item wouldn't have any McBody at all.  This would
result in a "Download failed. Tap here to retry." message when
displaying the event details.

Tweak EditEventViewController so that a McBody is always created for a
new event.

Fix nachocove/qa#312
