### PR TITLE
An iOS 8 action sheet needs extra configuration on an iPad.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/AccountSettingsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/AccountSettingsViewController.cs
@@ -805,7 +805,7 @@ namespace NachoClient.iOS
 
         protected void DaysToSyncTapHandler (NSObject sender)
         {
-            NcActionSheet.Show (View, this,
+            NcActionSheet.Show (DaysToSyncBlock, this,
                 new NcAlertAction (Pretty.MaxAgeFilter (NachoCore.ActiveSync.Xml.Provision.MaxAgeFilterCode.OneMonth_5), () => {
                     UpdateDaysToSync (LoginHelpers.GetCurrentAccountId (), NachoCore.ActiveSync.Xml.Provision.MaxAgeFilterCode.OneMonth_5);
                 }),

--- a/NachoClient.iOS/NachoUI.iOS/Support/NcActionSheet.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/NcActionSheet.cs
@@ -29,6 +29,12 @@ namespace NachoClient.iOS
                         }
                     }));
                 }
+                var ppc = alertController.PopoverPresentationController;
+                if (null != ppc) {
+                    ppc.SourceView = parentView;
+                    ppc.SourceRect = parentView.Bounds;
+                    ppc.PermittedArrowDirections = UIPopoverArrowDirection.Any;
+                }
                 parentViewController.PresentViewController (alertController, true, null);
 
             } else {


### PR DESCRIPTION
An iOS 8 action sheet is converted to a popover on an iPad which
requires a style, a view and a location or else there's a crash.
