### PR TITLE
Avoid "Download failure" messages for events with empty bodies

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -21,6 +21,18 @@ namespace NachoCore.ActiveSync
             var xmlTruncated = xmlBody.ElementAnyNs (Xml.AirSyncBase.Truncated);
             var xmlPreview = xmlBody.ElementAnyNs (Xml.AirSyncBase.Preview);
 
+            // An Exchange 2007 server might send a <Body> element without any <Data> element for calendar events
+            // that have an empty description.  This should be treated as if it were an empty <Data> element.
+            // The <Data> element can also be missing if a preview was requested.  We have to be careful to not
+            // confuse the two cases.
+            if (null == xmlData && null == xmlPreview &&
+                null != xmlEstimatedDataSize && 0 == xmlEstimatedDataSize.Value.ToInt() &&
+                (null == xmlTruncated || !ToBoolean(xmlTruncated.Value)))
+            {
+                // The easiest thing is to create an empty <Data> element, then let the normal processing happen.
+                xmlData = new XElement (Xml.AirSyncBase.Data, "");
+            }
+
             if (null != xmlPreview) {
                 item.BodyPreview = xmlPreview.Value;
             }


### PR DESCRIPTION
Exchange 2007 servers will sometimes send a Body element with no Data
element for calendar events that have an empty description. The app
was interpreting this as if the body had not yet been downloaded. This
resulted in a "Download failure" message in the event detail view
because any attempt to download calendar bodies will fail.

Change the code that parses Body elements to notice this situation and
treat it as if the Data element were empty rather than missing.

Fix nachocove/qa#323
