### PR TITLE
Fix nachocove/qa#314

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcEmailAddress.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcEmailAddress.cs
@@ -198,7 +198,7 @@ namespace NachoCore.Utils
             }
         }
 
-        public MailboxAddress ToMailboxAddress ()
+        public MailboxAddress ToMailboxAddress (bool mustUseAddress = false)
         {
             // Must have a contact or an address
             NcAssert.True ((null != this.contact) || (null != this.address));
@@ -206,10 +206,10 @@ namespace NachoCore.Utils
             string candidate;
             MailboxAddress mailbox;
 
-            if (null != this.contact) {
-                candidate = this.contact.GetEmailAddress ();
-            } else {
+            if (mustUseAddress || (null == this.contact)) {
                 candidate = this.address;
+            } else {
+                candidate = this.contact.GetEmailAddress ();
             }
 
             if (!MailboxAddress.TryParse (candidate, out mailbox)) {

--- a/NachoClient.iOS/NachoUI.iOS/ContactChooserViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactChooserViewController.cs
@@ -421,7 +421,7 @@ namespace NachoClient.iOS
                     }
                 }
 
-                Owner.UpdateEmailAddress (contact, contact.GetEmailAddress ());
+                Owner.UpdateEmailAddress (contact, Owner.searchResults [indexPath.Row].Value);
             }
 
         }

--- a/NachoClient.iOS/NachoUI.iOS/EventAttendeeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventAttendeeViewController.cs
@@ -524,7 +524,7 @@ namespace NachoClient.iOS
         {
             NcAssert.True (null != address);
 
-            var mailboxAddress = address.ToMailboxAddress ();
+            var mailboxAddress = address.ToMailboxAddress (mustUseAddress: true);
 
             // FIXME: Deal with bad email address
             if (null == mailboxAddress) {


### PR DESCRIPTION
- To fix contact choosing in message compose view, just pass in the email address of the contact choooser cell in RowSelected() so it can propagate to attendee list view.
-  For choosing attendees in events, add an option to ToMailboxAddress() to get the address from the address field instead of the first email address of the contact.
