### PR TITLE
Don't process meeting cancelation notices that are owned by the user

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -1426,7 +1426,7 @@ namespace NachoClient.iOS
             var iCalCancelPart = CalendarHelper.MimeCancelFromCalendar (c);
             var mimeBody = CalendarHelper.CreateMime ("", iCalCancelPart, new List<McAttachment> ());
 
-            CalendarHelper.SendMeetingCancelations (account, c, mimeBody);
+            CalendarHelper.SendMeetingCancelations (account, c, null, mimeBody);
         }
 
         /// <summary>

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -1441,10 +1441,10 @@ namespace NachoClient.iOS
                     } else {
                         occurrenceStartTime = e.StartTime;
                     }
-                    var iCalCancelPart = CalendarHelper.MimeCancelFromOccurrence(root, c, e, occurrenceStartTime);
+                    var iCalCancelPart = CalendarHelper.MimeCancelFromOccurrence (root, c, e, occurrenceStartTime);
                     var mimeBody = CalendarHelper.CreateMime ("", iCalCancelPart, new List<McAttachment> ());
 
-                    CalendarHelper.SendMeetingCancelations (account, root, mimeBody);
+                    CalendarHelper.SendMeetingCancelations (account, root, "Canceled: " + c.GetSubject (), mimeBody);
 
                     NavigationController.PopViewController (true);
                 }),


### PR DESCRIPTION
To work around a server bug, ignore meeting cancelation messages where
the current user is the organizer of the meeting.  (See the big
comment in the code for more details.)

Get the subject of outgoing meeting cancelation messages correct when
canceling a single occurrence of a recurring meeting where the
occurrence is an exception with a different title.
