### PR TITLE
Fix an intermittent alpha / beta build failures

### DIFF
--- a/Test.iOS/Test.iOS.csproj
+++ b/Test.iOS/Test.iOS.csproj
@@ -91,8 +91,8 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <BuildIpa>true</BuildIpa>
-    <CodesignProvision>7ed5936a-a594-4a8f-aebf-6aba9546cfc4</CodesignProvision>
-    <CodesignKey>iPhone Developer: Henry Kwok (E5VR34U847)</CodesignKey>
+    <CodesignProvision>Automatic:AppStore</CodesignProvision>
+    <CodesignKey>iPhone Distribution</CodesignKey>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchExtraArgs>-gcc_flags "-L${ProjectDir}/../native.iOS -framework SystemConfiguration -framework StoreKit -framework AudioToolbox -framework CFNetwork -framework CoreGraphics -framework CoreLocation -framework MobileCoreServices -framework QuartzCore -framework Security -framework Social -framework Accounts -lNachoPlatformSDK -lresolv -lcrypto"</MtouchExtraArgs>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>


### PR DESCRIPTION
Test.iOS is disabled for AdHoc build (and will be for AppStore build as well). But from the build log, it seems to try to build it sometimes and it fails because it is missing the -L flag to native.iOS where our libcrypto.a. So, instead it uses an old libcrypto from the system and it is missing a few functions. The fix is to add the -L flag to all targets.
