### PR TITLE
Fix nachocove/qa#305.  Tell people to use their hotmail or outlook email addresses.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/LaunchViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/LaunchViewController.cs
@@ -385,8 +385,12 @@ namespace NachoClient.iOS
 
             string serviceName;
             if (EmailHelper.IsServiceUnsupported (emailAddress, out serviceName)) {
-                var nuance = String.Format ("Nacho Mail does not support {0} yet.", serviceName);
-                Complain ("Nacho Mail", nuance);
+                if (emailServices.IsHotmailServiceSelected ()) {
+                    Complain ("Nacho Mail", "Please use your Hotmail or Outlook email address instead.");
+                } else {
+                    var nuance = String.Format ("Nacho Mail does not support {0} yet.", serviceName);
+                    Complain ("Nacho Mail", nuance);
+                }
                 return;
             }
 
@@ -415,7 +419,7 @@ namespace NachoClient.iOS
                 }
             } else {
                 if (emailServices.IsHotmailServiceSelected ()) {
-                    ConfirmBeforeStarting ("Confirm Email", "Your email address does not match the selected service.\nUse it anyway?");
+                    ConfirmBeforeStarting ("Confirm Email", "Your email address does not match the selected service.\nUse your Hotmail or Outlook email address?");
                     return;
                 }
             }


### PR DESCRIPTION
Fix nachocove/qa#305.  If a user selects hotmail or outlook, let
them know to user their hotmail or outlook email address instead
of a non-matching email address. (Microsoft allows people to use
any email address to log in.)
