### PR TITLE
Fix nachocove/qa#329.  Plain old email addresses didn't get initials.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
@@ -622,7 +622,16 @@ namespace NachoCore.Utils
             }
             McContact contact = new McContact ();
             NcEmailAddress.ParseName (mailboxAddress, ref contact);
-            return ContactsHelper.GetInitials (contact);
+            var initials = ContactsHelper.GetInitials (contact);
+            if (String.IsNullOrEmpty (initials)) {
+                foreach (char c in fromAddressString) {
+                    if (Char.IsLetterOrDigit (c)) {
+                        initials += Char.ToUpper (c);
+                        break;
+                    }
+                }
+            }
+            return initials;
         }
 
         public static MimeMessage CreateMessage (McAccount account, List<NcEmailAddress> toList, List<NcEmailAddress> ccList, List<NcEmailAddress> bccList)

--- a/NachoClient.Android/NachoCore/Utils/NcEmailAddress.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcEmailAddress.cs
@@ -309,10 +309,12 @@ namespace NachoCore.Utils
             } else if (!String.IsNullOrEmpty (parsedName.MiddleInitials)) { //use middle name if first name is missing
                 contact.FirstName = parsedName.MiddleInitials;
             }
-            if (!String.IsNullOrEmpty (parsedName.LastName))
+            if (!String.IsNullOrEmpty (parsedName.LastName)) {
                 contact.LastName = parsedName.LastName;
-            if (!String.IsNullOrEmpty (parsedName.Suffix))
+            }
+            if (!String.IsNullOrEmpty (parsedName.Suffix)) {
                 contact.Suffix = parsedName.Suffix;
+            }
         }
 
         public static InternetAddressList ToInternetAddressList (List<NcEmailAddress> addressList, Kind kind)

--- a/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
@@ -471,30 +471,7 @@ namespace NachoClient
             }
             // Cache the color
             ColorIndex = emailAddress.ColorIndex;
-            // Let create the initials
-            McContact contact = new McContact ();
-            NcEmailAddress.ParseName (mailboxAddress, ref contact);
-            // Using the name
-            string initials = "";
-            if (!String.IsNullOrEmpty (contact.FirstName)) {
-                initials += Char.ToUpper (contact.FirstName [0]);
-            }
-            if (!String.IsNullOrEmpty (contact.LastName)) {
-                initials += Char.ToUpper (contact.LastName [0]);
-            }
-            // Or, failing that, the first char
-            if (String.IsNullOrEmpty (initials)) {
-                if (!String.IsNullOrEmpty (from)) {
-                    foreach (char c in from) {
-                        if (Char.IsLetterOrDigit (c)) {
-                            initials += Char.ToUpper (c);
-                            break;
-                        }
-                    }
-                }
-            }
-            // Save it to the db
-            Initials = initials;
+            Initials = EmailHelper.Initials (from);
         }
 
         public static UIImage ContactToPortraitImage (McContact contact)

--- a/Test.Android/EmailHelperTest.cs
+++ b/Test.Android/EmailHelperTest.cs
@@ -314,6 +314,9 @@ namespace Test.Android
             initials = EmailHelper.Initials (emailAddress);
             Assert.AreEqual ("BJ", initials);
 
+            emailAddress = "wmonline@wm.com";
+            initials = EmailHelper.Initials (emailAddress);
+            Assert.AreEqual ("W", initials);
         }
     }
 }


### PR DESCRIPTION
Fix nachocove/qa#329.  Need to get initials from addresses that do
not have any real name associated with it. Removed dup code, added
a unit test, and fixed up some braces.
