### PR TITLE
"Remove from calendar" removes single occurrence when appropriate

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -207,10 +207,6 @@ namespace NachoCore.ActiveSync
             if (cal.MeetingStatusIsSet) {
                 xmlAppData.Add (new XElement (CalendarNs + Xml.Calendar.MeetingStatus, (uint)cal.MeetingStatus));
             }
-            if (DateTime.MinValue != cal.AppointmentReplyTime) {
-                xmlAppData.Add (new XElement (CalendarNs + Xml.Calendar.AppointmentReplyTime,
-                    cal.AppointmentReplyTime.ToString (DateTimeFmt1)));
-            }
             if (null != cal.OnlineMeetingConfLink) {
                 xmlAppData.Add (new XElement (CalendarNs + Xml.Calendar.OnlineMeetingConfLink, cal.OnlineMeetingConfLink));
             }
@@ -256,6 +252,9 @@ namespace NachoCore.ActiveSync
                     if (recurrence.OccurrencesIsSet) {
                         xmlRecurrence.Add (new XElement (CalendarNs + Xml.Calendar.Recurrence.Occurrences, recurrence.Occurrences));
                     }
+                    if (DateTime.MinValue != recurrence.Until) {
+                        xmlRecurrence.Add (new XElement (CalendarNs + Xml.Calendar.Recurrence.Until, recurrence.Until.ToString (CompactDateTimeFmt1)));
+                    }
                     if (NcRecurrenceType.Monthly == recurrence.Type || NcRecurrenceType.Yearly == recurrence.Type) {
                         xmlRecurrence.Add (new XElement (CalendarNs + Xml.Calendar.Recurrence.DayOfMonth, recurrence.DayOfMonth));
                     }
@@ -278,67 +277,73 @@ namespace NachoCore.ActiveSync
                 var xmlExceptions = new XElement (CalendarNs + Xml.Calendar.Calendar_Exceptions);
                 foreach (var exception in cal.exceptions) {
                     var xmlException = new XElement (CalendarNs + Xml.Calendar.Exceptions.Exception);
-                    if (0 != exception.attendees.Count) {
-                        var xmlAttendees = new XElement (CalendarNs + Xml.Calendar.Exception.Attendees);
-                        foreach (var attendee in exception.attendees) {
-                            var xmlAttendee = new XElement (CalendarNs + Xml.Calendar.Attendees.Attendee);
-                            xmlAttendee.Add (new XElement (CalendarNs + Xml.Calendar.Email, attendee.Email));
-                            xmlAttendee.Add (new XElement (CalendarNs + Xml.Calendar.Name, attendee.Name));
-                            if (attendee.AttendeeTypeIsSet) {
-                                xmlAttendee.Add (new XElement (CalendarNs + Xml.Calendar.AttendeeType, (uint)attendee.AttendeeType));
-                            }
-                            xmlAttendees.Add (xmlAttendee);
-                        }
-                        xmlException.Add (xmlAttendees);
-                    }
-                    if (0 != exception.categories.Count) {
-                        var xmlCategories = new XElement (CalendarNs + Xml.Calendar.Exception.Categories);
-                        foreach (var category in exception.categories) {
-                            xmlCategories.Add (new XElement (CalendarNs + Xml.Calendar.Category, category.Name));
-                        }
-                        xmlException.Add (xmlCategories);
-                    }
-                    if (exception.AllDayEventIsSet) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.AllDayEvent, exception.AllDayEvent ? "1" : "0"));
-                    }
-                    if (exception.BusyStatusIsSet) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.BusyStatus, (int)exception.BusyStatus));
-                    }
                     if (0 != exception.Deleted) {
+                        // The exception for a deleted occurrence must contain only the Deleted and
+                        // ExceptionStartTime elements.
                         xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.Deleted, "1"));
+                        if (DateTime.MinValue != exception.ExceptionStartTime) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.ExceptionStartTime, exception.ExceptionStartTime.ToString (CompactDateTimeFmt1)));
+                        }
+                    } else {
+                        if (0 != exception.attendees.Count) {
+                            var xmlAttendees = new XElement (CalendarNs + Xml.Calendar.Exception.Attendees);
+                            foreach (var attendee in exception.attendees) {
+                                var xmlAttendee = new XElement (CalendarNs + Xml.Calendar.Attendees.Attendee);
+                                xmlAttendee.Add (new XElement (CalendarNs + Xml.Calendar.Email, attendee.Email));
+                                xmlAttendee.Add (new XElement (CalendarNs + Xml.Calendar.Name, attendee.Name));
+                                if (attendee.AttendeeTypeIsSet) {
+                                    xmlAttendee.Add (new XElement (CalendarNs + Xml.Calendar.AttendeeType, (uint)attendee.AttendeeType));
+                                }
+                                xmlAttendees.Add (xmlAttendee);
+                            }
+                            xmlException.Add (xmlAttendees);
+                        }
+                        if (0 != exception.categories.Count) {
+                            var xmlCategories = new XElement (CalendarNs + Xml.Calendar.Exception.Categories);
+                            foreach (var category in exception.categories) {
+                                xmlCategories.Add (new XElement (CalendarNs + Xml.Calendar.Category, category.Name));
+                            }
+                            xmlException.Add (xmlCategories);
+                        }
+                        if (exception.AllDayEventIsSet) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.AllDayEvent, exception.AllDayEvent ? "1" : "0"));
+                        }
+                        if (exception.BusyStatusIsSet) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.BusyStatus, (int)exception.BusyStatus));
+                        }
+                        if (0 != exception.Deleted) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.Deleted, "1"));
+                        }
+                        if (exception.MeetingStatusIsSet) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.MeetingStatus, (int)exception.MeetingStatus));
+                        }
+                        if (exception.ReminderIsSet) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.Reminder, exception.Reminder));
+                        }
+                        if (exception.SensitivityIsSet) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.Sensitivity, (int)exception.Sensitivity));
+                        }
+                        if (DateTime.MinValue != exception.DtStamp) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.DtStamp, exception.DtStamp.ToString (CompactDateTimeFmt1)));
+                        }
+                        if (DateTime.MinValue != exception.StartTime) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.StartTime, exception.StartTime.ToString (CompactDateTimeFmt1)));
+                        }
+                        if (DateTime.MinValue != exception.EndTime) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.EndTime, exception.EndTime.ToString (CompactDateTimeFmt1)));
+                        }
+                        if (DateTime.MinValue != exception.ExceptionStartTime) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.ExceptionStartTime, exception.ExceptionStartTime.ToString (CompactDateTimeFmt1)));
+                        }
+                        if (null != exception.Subject) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.Subject, exception.Subject));
+                        }
+                        if (null != exception.Location) {
+                            xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.Location, exception.Location));
+                        }
+                        // TODO Body.  Sending a body for an exception is complicated.  Just leave the body out for now,
+                        // which means the exception will inherit its body from the main calendar event.
                     }
-                    if (exception.MeetingStatusIsSet) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.MeetingStatus, (int)exception.MeetingStatus));
-                    }
-                    if (exception.ReminderIsSet) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.Reminder, exception.Reminder));
-                    }
-                    if (exception.SensitivityIsSet) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.Sensitivity, (int)exception.Sensitivity));
-                    }
-                    if (DateTime.MinValue != exception.AppointmentReplyTime) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.AppointmentReplyTime, exception.AppointmentReplyTime.ToString (CompactDateTimeFmt1)));
-                    }
-                    if (DateTime.MinValue != exception.DtStamp) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.DtStamp, exception.DtStamp.ToString (CompactDateTimeFmt1)));
-                    }
-                    if (DateTime.MinValue != exception.StartTime) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.StartTime, exception.StartTime.ToString (CompactDateTimeFmt1)));
-                    }
-                    if (DateTime.MinValue != exception.EndTime) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.EndTime, exception.EndTime.ToString (CompactDateTimeFmt1)));
-                    }
-                    if (DateTime.MinValue != exception.ExceptionStartTime) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.ExceptionStartTime, exception.ExceptionStartTime.ToString (CompactDateTimeFmt1)));
-                    }
-                    if (null != exception.Subject) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.Subject, exception.Subject));
-                    }
-                    if (null != exception.Location) {
-                        xmlException.Add (new XElement (CalendarNs + Xml.Calendar.Exception.Location, exception.Location));
-                    }
-                    // TODO Body.  Sending a body for an exception is complicated.  Just leave the body out for now,
-                    // which means the exception will inherit its body from the main calendar event.
                     xmlExceptions.Add (xmlException);
                 }
                 xmlAppData.Add (xmlExceptions);

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsMeetingResponseCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsMeetingResponseCommand.cs
@@ -67,7 +67,7 @@ namespace NachoCore.ActiveSync
 
             default:
                 PendingResolveApply ((pending) => {
-                    PendingSingle.ResolveAsHardFail (BEContext.ProtoControl, NcResult.Error (NcResult.SubKindEnum.Error_MeetingResponseFailed,
+                    pending.ResolveAsHardFail (BEContext.ProtoControl, NcResult.Error (NcResult.SubKindEnum.Error_MeetingResponseFailed,
                         NcResult.WhyEnum.Unknown));
                 });
                 return Event.Create ((uint)SmEvt.E.HardFail, "FUPFAIL2");


### PR DESCRIPTION
When the user receives a meeting cancelation message for a single
occurrence of a recurring meeting and taps the "Remove from calendar"
button in the message detail view, remove only that occurrence of the
meeting.  Previously, the entire series was being removed.

Fix the code for the "Remove from Calendar" button in the event detail
view to correctly figure out whether to remove the individual
occurrence or the entire series.

When the user receives a meeting request for a singel occurrence of a
recurring meeting, don't try to figure out whether or not the user has
already responded to the request.  Always show the
Attend/Maybe/Decline buttons unselected in this case.

When creating the ActiveSync XML for a calendar item exception,
include only the Deleted and ExceptionStartTime fields for exceptions
that represent deleted occurrences.  In this situation, all the other
fields are meaningless.

When creating the ActiveSync XML for a calendar item, ignore the
AppointmentReplyTime field.  That field is for sync responses only and
should never be in sync requests.

Fix a typo in AsMeetingResponseCommand.ProcessResponse that could
result in a NullReferenceException.

Fix nachocove/qa#307
