### PR TITLE
Fix nachocove/qa#335

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -420,6 +420,9 @@ namespace NachoClient.iOS
             Log.Info (Log.LOG_LIFECYCLE, "OnActivated: Called");
             NcApplication.Instance.PlatformIndication = NcApplication.ExecutionContextEnum.Foreground;
             BadgeNotifClear ();
+            if (doingPerformFetch) {
+                CompletePerformFetchWithoutShutdown ();
+            }
 
             NcApplication.Instance.StatusIndEvent -= BgStatusIndReceiver;
 
@@ -530,9 +533,6 @@ namespace NachoClient.iOS
         {
             Log.Info (Log.LOG_LIFECYCLE, "WillEnterForeground: Called");
             DidEnterBackgroundCalled = false;
-            if (doingPerformFetch) {
-                CompletePerformFetchWithoutShutdown ();
-            }
             Interlocked.Increment (ref ShutdownCounter);
             if (null != ShutdownTimer) {
                 ShutdownTimer.Dispose ();


### PR DESCRIPTION
- It is possible to go to foreground right after a perform fetch is started. In that case, we need to clear the fetch.
- We already have code to do that but it is in the wrong place. A quick sync was started between WillEnterForeground() and OnActivated(). The old check (and clear) is in WIllEnterForeground() so the perform fetch was not cleared and FinalShutdown() was called.
- The fix is to move it to OnActivated() immediately after we set exec. context to foreground.
