### PR TITLE
Fix nachocove/qa#334. Don't delete a null view.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/SwipeActionView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/SwipeActionView.cs
@@ -664,6 +664,10 @@ namespace NachoClient.iOS
 
         protected bool MayRemoveSwipingView ()
         {
+            if (null == swipingView) {
+                // Disabled before view created
+                return false;
+            }
             if (SnapAllShownThreshold > NMath.Abs (swipingView.LastMovePercentage)) {
                 swipingView.SnapToAllButtonsHidden (() => {
                     RemoveSwipingView ();


### PR DESCRIPTION
Fix nachocove/qa#334. The swipeview was being disabled beofre the view
is created which caused a cancel event on the tap handler which cleans
up the view.
