### PR TITLE
Fix nachocove/qa#343.  Fix already in CSharp-Name_Parser project.

### DIFF
--- a/Test.Android/EmailHelperTest.cs
+++ b/Test.Android/EmailHelperTest.cs
@@ -317,6 +317,10 @@ namespace Test.Android
             emailAddress = "wmonline@wm.com";
             initials = EmailHelper.Initials (emailAddress);
             Assert.AreEqual ("W", initials);
+
+            emailAddress = "\"rascal2210@hotmail.com\" <rascal2210@hotmail.com>";
+            initials = EmailHelper.Initials (emailAddress);
+            Assert.AreEqual("R", initials);
         }
     }
 }

--- a/Test.Android/NcEmailAddressTest.cs
+++ b/Test.Android/NcEmailAddressTest.cs
@@ -11,8 +11,17 @@ namespace Test.Common
     public class NcEmailAddressTest
     {
         string[][] names = { 
+            new string [] { "J.", null, "J.", null, null, null },
+            new string [] { "Mr. Jones", "Mr", "Jones", null,  null, null }, // we don't want this one, do we?
             new string [] { "John (The Guy) Smith (via Google Docs)", null, "John", null, "Smith", null },
-            new string [] { "John (The Guy) Larry (Cable) Smith (via Google Docs)", null, "John", "Larry", "Smith", null },
+            new string [] {
+                "John (The Guy) Larry (Cable) Smith (via Google Docs)",
+                null,
+                "John",
+                "Larry",
+                "Smith",
+                null
+            },
             new string [] { "John Smith (via Google Docs)", null, "John", null, "Smith", null },
             new string [] {
                 "Mr O'Malley y Muñoz, C. Björn Roger III",
@@ -43,6 +52,7 @@ namespace Test.Common
             new string [] { "O'Malley, Björn", null, "Björn", null, "O'Malley", null },
             new string [] { "Björn O'Malley", null, "Björn", null, "O'Malley", null },
             new string [] { "Bin Lin", null, "Bin", null, "Lin", null },
+            new string [] { "Linda", null, "Linda", null, null, null },
             new string [] { "Linda Jones", null, "Linda", null, "Jones", null },
             new string [] { "Jason H. Priem", null, "Jason", "H.", "Priem", null },
             new string [] { "Björn O'Malley-Muñoz", null, "Björn", null, "O'Malley-Muñoz", null },


### PR DESCRIPTION
Fix nachocove/qa#343.  Fix already in CSharp-Name_Parser project.
The "J." example caught the problem.  Added some other cases too.
