### PR TITLE
Must set platform indication back to background before perform fetch is finished.

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -648,6 +648,7 @@ namespace NachoClient.iOS
             CleanupPerformFetchStates ();
             FinalShutdown (null);
             FinalizePerformFetch (fetchResult);
+            NcApplication.Instance.PlatformIndication = NcApplication.ExecutionContextEnum.Background;
         }
 
         public override void PerformFetch (UIApplication application, Action<UIBackgroundFetchResult> completionHandler)


### PR DESCRIPTION
- For nachocove/qa#338.
- From one of the log, I see that a remote notification sets the platform indication to quick sync and then it finishes. Then, the app is foreground. So, instead of going from initializing -> background -> foreground, it went initializing -> quick sync -> foreground.
- I cannot say it causes one of the crashes but for sure that is wrong.
