### PR TITLE
Fix #892.  Reflect the state of McCred in the UI.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/LoginHelpers.cs
+++ b/NachoClient.Android/NachoCore/Utils/LoginHelpers.cs
@@ -118,5 +118,26 @@ namespace NachoCore.Utils
         {
             return (null != NcApplication.Instance.Account);
         }
+
+        // Return true if a password associated with the account id will expire
+        // soon and return information about the password that expires soonest.
+        static public bool PasswordWillExpire(int accountId, out DateTime expiry, out string rectificationUrl)
+        {
+            expiry = DateTime.MaxValue;
+            rectificationUrl = String.Empty;
+            var creds = McCred.QueryByAccountId<McCred> (accountId);
+            if (null == creds) {
+                return false;
+            }
+            var gonnaExpireOn = DateTime.MaxValue;
+            foreach (var cred in creds) {
+                if (cred.Expiry < gonnaExpireOn) {
+                    expiry = cred.Expiry;
+                    gonnaExpireOn = cred.Expiry;
+                    rectificationUrl = cred.RectificationUrl;
+                }
+            }
+            return (DateTime.MaxValue != gonnaExpireOn);
+        }
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/NachoTabBarController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoTabBarController.cs
@@ -78,7 +78,7 @@ namespace NachoClient.iOS
 
             FinishedCustomizingViewControllers += (object sender, UITabBarCustomizeChangeEventArgs e) => {
                 SaveCustomTabBarOrder (e);
-                UpdateNotificationBadge();
+                UpdateNotificationBadge (NcApplication.Instance.Account.Id);
             };
 
             ViewControllerSelected += (object sender, UITabBarSelectionEventArgs e) => {
@@ -93,7 +93,7 @@ namespace NachoClient.iOS
         {
             base.ViewWillAppear (animated);
 
-            UpdateNotificationBadge ();
+            UpdateNotificationBadge (NcApplication.Instance.Account.Id);
 
             var accountId = NcApplication.Instance.Account.Id;
 
@@ -138,7 +138,13 @@ namespace NachoClient.iOS
                 LayoutMoreTable ();
             }
             if (NcResult.SubKindEnum.Info_UserInterventionFlagChanged == s.Status.SubKind) {
-                UpdateNotificationBadge ();
+                UpdateNotificationBadge (s.Account.Id);
+            }
+            if (NcResult.SubKindEnum.Error_PasswordWillExpire == s.Status.SubKind) {
+                UpdateNotificationBadge (s.Account.Id);
+            }
+            if (NcResult.SubKindEnum.Info_McCredPasswordChanged == s.Status.SubKind) {
+                UpdateNotificationBadge (s.Account.Id);
             }
         }
 
@@ -244,9 +250,12 @@ namespace NachoClient.iOS
             return false;
         }
 
-        protected void UpdateNotificationBadge ()
+        protected void UpdateNotificationBadge (int accountId)
         {
-            var showNotificationBadge = LoginHelpers.DoesBackEndHaveIssues (NcApplication.Instance.Account.Id);
+            DateTime expiry;
+            string rectificationUrl;
+            var showNotificationBadge = LoginHelpers.PasswordWillExpire (accountId, out expiry, out rectificationUrl);
+            showNotificationBadge |= LoginHelpers.DoesBackEndHaveIssues (accountId);
 
             settingsItem.BadgeValue = (showNotificationBadge ? @"!" : null);
 


### PR DESCRIPTION
Fix #892.  Reflect the state of McCred in the UI.  Respond to status
inds to redraw the notification beacon. Assume URL might not be set.
Picks the next-to-expire cred; it doesn't show them all at once.
