### PR TITLE
Fix nachocove/qa#317

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -798,8 +798,15 @@ namespace NachoCore.Model
         private void EvaluateEmailAddressEclipsing (List<McContactEmailAddressAttribute> addressList, McContactOpEnum op)
         {
             foreach (var address in addressList) {
-                var contactList = QueryByEmailAddress (AccountId, address.Value).Where (x => x.Id != Id);
+                var contactList =
+                    QueryByEmailAddress (AccountId, address.Value)
+                        .Where (x => (x.Id != Id) && (HasSameName (x) || x.IsAnonymous ()));
+                var count = contactList.Count ();
+                if (6 < count) {
+                    Log.Warn (Log.LOG_DB, "EvaluateEmailAddressEclipsing: {0} contacts", count);
+                }
                 foreach (var contact in contactList) {
+                    count++;
                     if (contact.EmailAddressesEclipsed && (McContactOpEnum.Insert == op)) {
                         continue; // insertion can never cause an eclipsed contact to become uneclipsed
                     }
@@ -821,7 +828,13 @@ namespace NachoCore.Model
                 if (McContactStringType.PhoneNumber != phone.Type) {
                     continue;
                 }
-                var contactList = QueryByPhoneNumber (AccountId, phone.Value).Where (x => x.Id != Id);
+                var contactList =
+                    QueryByPhoneNumber (AccountId, phone.Value)
+                        .Where (x => (x.Id != Id) && (HasSameName (x) || x.IsAnonymous ()));
+                var count = contactList.Count ();
+                if (6 < count) {
+                    Log.Warn (Log.LOG_DB, "EvaluatePhoneNumberEclipsing: {0} contacts", count);
+                }
                 foreach (var contact in contactList) {
                     if (contact.PhoneNumbersEclipsed && (McContactOpEnum.Insert == op)) {
                         continue; // insertion can never cause an eclipsed contact to become uneclipsed


### PR DESCRIPTION
- There is one common case that slows down contact eclipsing a lot. Suppose we have many email addresses with the format of "X Y Z notification@github.com". They all have the same email address with different names. So, there are many gleaned contacts.
- The algorithm is roughly O(N^2). Increasing N causes more queries to be done.
- A further optimization is to filter down the result of QueryByEmailAddress(). All these contacts have the same email address but different names and their eclipsing status cannot be affected by another contact with different name. So, we only process contacts with the same name or are anonymous.
- Add a warning if the # of loop count is still high after the filtering. This helps us to determine beta users on the field whether this optimization sufficiently solve power users' problems.
- Steve - I tried to incorporate the name check into the SQL query and it turns out to be not easy at all. Fields with nulls need to be "X is null" but with a valid string, they are "X = ?". So, I keep that part in C#. It is walking a list in memory without any DB ops and should run pretty fast.
