### PR TITLE
Fix layout of date pickers in event editor view

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -544,6 +544,7 @@ namespace NachoClient.iOS
 
             startDatePicker.Frame = new CGRect (0, 44, SCREEN_WIDTH, START_PICKER_HEIGHT);
             startDatePicker.Hidden = true;
+            startDatePicker.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleBottomMargin;
             startView.AddSubview (startDatePicker);
 
             startDatePicker.ValueChanged += (object sender, EventArgs e) => {
@@ -616,6 +617,7 @@ namespace NachoClient.iOS
 
             endDatePicker.Frame = new CGRect (0, CELL_HEIGHT, SCREEN_WIDTH, END_PICKER_HEIGHT);
             endDatePicker.Hidden = true;
+            endDatePicker.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleBottomMargin;
             endView.AddSubview (endDatePicker);
 
             endDatePicker.ValueChanged += (object sender, EventArgs e) => {


### PR DESCRIPTION
With the latest Xamarin upgrade, the autoresizingMask fields were
removed from the storyboard.  This affected the behavior of the date
pickers in EditEventViewController.  Fix the problem by setting the
AutoresizingMask field of the date pickers programatically rather than
setting them in the storyboard.

Fix nachocove/qa#353
