### PR TITLE
Remove database activity inside of transactions

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncEmailCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncEmailCommand.cs
@@ -54,11 +54,9 @@ namespace NachoCore.ActiveSync
             }
 
             emailMessage.SenderEmailAddressId = McEmailAddress.Get (folder.AccountId, emailMessage.Sender);
-            emailMessage.ToEmailAddressId = McEmailAddress.GetList (folder.AccountId, emailMessage.To);
-            emailMessage.CcEmailAddressId = McEmailAddress.GetList (folder.AccountId, emailMessage.Cc);
 
             NcModel.Instance.RunInTransaction (() => {
-                if ((0 != emailMessage.FromEmailAddressId) || (0 < emailMessage.ToEmailAddressId.Count)) {
+                if ((0 != emailMessage.FromEmailAddressId) || !String.IsNullOrEmpty(emailMessage.To))) {
                     if (!folder.IsJunkFolder ()) {
                         NcContactGleaner.GleanContactsHeaderPart1 (emailMessage);
                     }


### PR DESCRIPTION
As part of the plan to minimize database activity inside of transactions, the
code to convert To and Cc strings to lists of indexes has been removed and it
will be implemented later as an on-demand conversion.
