### PR TITLE
Popups stopped working on the ipad.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/NcActionSheet.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/NcActionSheet.cs
@@ -32,7 +32,6 @@ namespace NachoClient.iOS
                 var ppc = alertController.PopoverPresentationController;
                 if (null != ppc) {
                     ppc.SourceView = parentView;
-                    ppc.SourceRect = parentView.Bounds;
                     ppc.PermittedArrowDirections = UIPopoverArrowDirection.Any;
                 }
                 parentViewController.PresentViewController (alertController, true, null);


### PR DESCRIPTION
Popups stopped working on the ipad, probably because of the removal
of sizing info for Xamarin 8.10. Using the view only is working.
