### PR TITLE
Fix nachocove/qa#365. 

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -1034,10 +1034,11 @@ namespace NachoCore
                         DisposeRetryTimer ();
                         result.Exception = e;
                         Log.Warn (Log.LOG_PUSH, "DoHttpRequest: canceled");
-                    }
-                    if (Cts.Token.IsCancellationRequested) {
+                    } else if (Cts.Token.IsCancellationRequested) {
                         result.Exception = new TimeoutException ("HTTP operation timed out");
                         Log.Warn (Log.LOG_PUSH, "DoHttpRequest: timed out");
+                    } else {
+                        result.Exception = e;
                     }
                 } catch (WebException e) {
                     result.Exception = e;


### PR DESCRIPTION
There is a path where an exception is thrown and caught but not saved. So, when return from DoHttpRequest(), it sees no exception, thinks it has a response but doesn't.

The fix is to save the exception.
