### PR TITLE
Fix the default event start/end times for events late in the day

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -170,9 +170,9 @@ namespace NachoClient.iOS
             case CalendarItemEditorAction.create:
                 if (null == item) {
                     if (0001 != startingDate.Year) {
-                        c = CalendarHelper.DefaultMeeting (startingDate, startingDate);
+                        c = CalendarHelper.DefaultMeeting (startingDate);
                     } else {
-                        c = CalendarHelper.DefaultMeeting (DateTime.UtcNow, DateTime.UtcNow);
+                        c = CalendarHelper.DefaultMeeting ();
                     }
                 } else {
                     c = item;
@@ -184,7 +184,7 @@ namespace NachoClient.iOS
                     calendarItemIsMissing = true;
                     // Create a dummy item so the UI elements can be created and the view can finish
                     // loading before we can throw up the dialog to tell the user about the problem.
-                    c = CalendarHelper.DefaultMeeting (DateTime.UtcNow, DateTime.UtcNow);
+                    c = CalendarHelper.DefaultMeeting ();
                 } else {
                     c = item;
                 }

--- a/Test.Android/McCalendarTest.cs
+++ b/Test.Android/McCalendarTest.cs
@@ -17,25 +17,25 @@ namespace Test.Android
         [Test]
         public void TestQueryByUID ()
         {
-            var c1 = CalendarHelper.DefaultMeeting (DateTime.UtcNow, DateTime.UtcNow);
+            var c1 = CalendarHelper.DefaultMeeting ();
             c1.AccountId = 1;
             c1.UID = "aaa";
             c1.Subject = "c1";
             c1.Insert ();
 
-            var c2 = CalendarHelper.DefaultMeeting (DateTime.UtcNow, DateTime.UtcNow);
+            var c2 = CalendarHelper.DefaultMeeting ();
             c2.AccountId = 1;
             c2.UID = "bbb";
             c2.Subject = "c2";
             c2.Insert ();
 
-            var c3 = CalendarHelper.DefaultMeeting (DateTime.UtcNow, DateTime.UtcNow);
+            var c3 = CalendarHelper.DefaultMeeting ();
             c3.AccountId = 2;
             c3.UID = "aaa";
             c3.Subject = "c3";
             c3.Insert ();
 
-            var c4 = CalendarHelper.DefaultMeeting (DateTime.UtcNow, DateTime.UtcNow);
+            var c4 = CalendarHelper.DefaultMeeting ();
             c4.AccountId = 2;
             c4.UID = "bbb";
             c4.Subject = "c4";
@@ -60,7 +60,7 @@ namespace Test.Android
             Assert.NotNull (r4, "McCalendar.QueryByUID (2, \"bbb\") didn't find any item.");
             Assert.AreEqual ("c4", r4.Subject, "McCalendar.QueryByUID (2, \"bbb\") found the wrong item.");
 
-            var c5 = CalendarHelper.DefaultMeeting (DateTime.UtcNow, DateTime.UtcNow);
+            var c5 = CalendarHelper.DefaultMeeting ();
             c5.AccountId = 1;
             c5.UID = "aaa";
             c5.Subject = "c5";
@@ -70,7 +70,7 @@ namespace Test.Android
             Assert.NotNull (r5, "McCalendar.QueryByUID (1, \"aaa\") didn't find any item when there should have been two matching items.");
             Assert.AreEqual ("c5", r5.Subject, "McCalendar.QueryByUID (1, \"aaa\") picked the wrong item of the two available.");
 
-            var c6 = CalendarHelper.DefaultMeeting (DateTime.UtcNow, DateTime.UtcNow);
+            var c6 = CalendarHelper.DefaultMeeting ();
             c6.AccountId = 1;
             c6.UID = "ccc";
             c6.Subject = "c6";


### PR DESCRIPTION
Rewrite CalendarHelper.DefaultMeeting(), being more careful about the
default start and end times for the event.  This fixes two bugs:

Creating an event when the local time was between 10:30pm and 11:30pm
would result in the default end time being 23 hours earlier than the
start time instead of one hour later.

Creating an event when UTC is a different day than local time (which
is true in the late afternoon and evening for Pacific Time) would
result in the event being a day later than it should be.

Fix nachocove/qa#362
