### PR TITLE
1st part of user id changes required in telemetry 3

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -943,15 +943,6 @@ namespace NachoCore
                     }
                 }, "PushAssistDeviceToken");
                 break;
-            case NcResult.SubKindEnum.Info_PushAssistClientToken:
-                NcTask.Run (() => {
-                    if (null == siea.Status.Value) {
-                        PostEvent (PAEvt.E.CliTokLoss, "CLI_TOK_LOST");
-                    } else {
-                        DoGetCliTok ();
-                    }
-                }, "PushAssistClientToken");
-                break;
             case NcResult.SubKindEnum.Info_FastNotificationChanged:
                 if (Owner.Account.Id == siea.Account.Id) {
                     NcTask.Run (() => {

--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -62,14 +62,11 @@ namespace NachoCore.Model
 
     public sealed class NcModel
     {
-        private string Documents;
-
         // RateLimiter PUBLIC FOR TEST ONLY.
         public NcRateLimter RateLimiter { set; get; }
 
         public bool FreshInstall { private set; get; }
 
-        private const string KDataPathSegment = "Data";
         private const string KTmpPathSegment = "tmp";
         private const string KFilesPathSegment = "files";
         private const string KRemovingAccountLockFile = "removing_account_lockfile";
@@ -141,24 +138,9 @@ namespace NachoCore.Model
             }
         }
 
-        public string GetDocumentsPath ()
-        {
-            if (Documents == null) {
-                Documents = Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments);
-            }
-            return Documents;
-        }
-
         public string GetDataDirPath ()
         {
-            if (Documents == null) {
-                GetDocumentsPath ();
-            }
-            string dataDirPath = Path.Combine (Documents, KDataPathSegment);
-            if (!Directory.Exists (dataDirPath)) {
-                Directory.CreateDirectory (dataDirPath);
-            }
-            return dataDirPath;
+            return NcApplication.GetDataDirPath ();
         }
 
         public string GetFileDirPath (int accountId, string segment)

--- a/NachoClient.Android/NachoCore/Utils/NcResult.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcResult.cs
@@ -167,12 +167,14 @@ namespace NachoCore.Utils
             Info_ServerStatus,
             Info_NetworkStatus,
             Info_PushAssistDeviceToken,
+            // This is now obsolete. ClientToken is the device id which is always available.
             Info_PushAssistClientToken,
             Info_PushAssistArmed,
             Info_UserInterventionFlagChanged,
             Info_SystemTimeZoneChanged,
             Info_FastNotificationChanged,
             Info_McCredPasswordChanged,
+            Info_UserIdChanged,
         };
 
         public enum WhyEnum

--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -929,16 +929,6 @@ namespace NachoCore.Utils
                 Log.Info (Log.LOG_UTILS, "Telemetry task exits");
             }
         }
-
-        public string GetUserName ()
-        {
-            if (BackEnd != null) {
-                return BackEnd.GetUserName ();
-            } else {
-                Log.Info (Log.LOG_LIFECYCLE, "Crash reporting has not been started but user name (clientId) was requested from BackEnd");
-                return null;
-            }
-        }
     }
 
     public interface ITelemetryBE

--- a/NachoClient.iOS/NachoPlatform.iOS/CloudHandlerIOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CloudHandlerIOS.cs
@@ -195,7 +195,7 @@ namespace NachoPlatform
         {
             StatusIndEventArgs siea = (StatusIndEventArgs)ea;
             switch (siea.Status.SubKind) {
-            case NcResult.SubKindEnum.Info_PushAssistClientToken:
+            case NcResult.SubKindEnum.Info_UserIdChanged:
                 if (null == siea.Status.Value) {
                     // do nothing now
                 } else {
@@ -207,7 +207,7 @@ namespace NachoPlatform
                     } else if (newUserId != userId) {
                         if (CloudInstallDateEarlierThanLocal ()) {
                             Log.Info (Log.LOG_SYS, "CloudHandler: Earlier UserId exists in cloud. Replacing local UserId {0} with {1}", NcApplication.Instance.ClientId, userId);
-                            NcApplication.Instance.ClientId = userId;
+                            NcApplication.Instance.UserId = userId;
                         }
                     }
                 }
@@ -239,7 +239,7 @@ namespace NachoPlatform
                         if ((userId != null) && (userId != NcApplication.Instance.ClientId)) {
                             if (CloudInstallDateEarlierThanLocal ()) {
                                 Log.Info (Log.LOG_SYS, "CloudHandler: Replacing localUserId {0} with {1} from Cloud", NcApplication.Instance.ClientId, userId);
-                                NcApplication.Instance.ClientId = userId;
+                                NcApplication.Instance.UserId = userId;
                             }
                         }
                     }

--- a/NachoClient.iOS/NachoPlatform.iOS/StoreHandleriOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/StoreHandleriOS.cs
@@ -484,7 +484,7 @@ namespace NachoPlatform
         {
             StatusIndEventArgs siea = (StatusIndEventArgs)ea;
             switch (siea.Status.SubKind) {
-            case NcResult.SubKindEnum.Info_PushAssistClientToken:
+            case NcResult.SubKindEnum.Info_UserIdChanged:
                 if (null == siea.Status.Value) {
                     // do nothing now
                 } else {

--- a/Test.Android/PushAssistTest.cs
+++ b/Test.Android/PushAssistTest.cs
@@ -182,7 +182,6 @@ namespace Test.Common
             Wpa.Dispose ();
             Wpa = null;
             NcApplication.Instance.TestOnlyInvokeUseCurrentThread = false;
-            NcApplication.Instance.ClientId = null;
             PushAssist.MinDelayMsec = OriginalMinDelayMsec;
             PushAssist.IncrementalDelayMsec = OriginalIncrementalDelayMsec;
             WrapPushAssist.SetDeviceToken (null); // do not use PushAssist.SetDeviceToken() as it creates a new task.
@@ -347,14 +346,10 @@ namespace Test.Common
             Wpa.Execute ();
             WaitForState ((uint)PushAssist.Lst.DevTokW);
 
-            // [got device token] -> CliTokW
-            PushAssist.SetDeviceToken (DeviceToken);
-            WaitForState ((uint)PushAssist.Lst.CliTokW);
-
-            // [got client token] -> SessTokW -> Active
+            // [got device token] -> CliTokW -> SessTokW -> Active
             MockHttpClient.ExamineHttpRequestMessage = CheckStartSessionRequest;
             MockHttpClient.ProvideHttpResponseMessage = StartSessionOkResponse;
-            NcApplication.Instance.ClientId = ClientToken;
+            PushAssist.SetDeviceToken (DeviceToken);
             WaitForState ((uint)PushAssist.Lst.Active);
 
             // [defer] -> Active
@@ -375,7 +370,6 @@ namespace Test.Common
         {
             // Set device and client tokens first
             PushAssist.SetDeviceToken (DeviceToken);
-            NcApplication.Instance.ClientId = ClientToken;
 
             // Start
             WaitForState ((uint)St.Start);
@@ -405,7 +399,6 @@ namespace Test.Common
             MockHttpClient.ExamineHttpRequestMessage = CheckStartSessionRequest;
             MockHttpClient.ProvideHttpResponseMessage = StartSessionWarnResponse;
             PushAssist.SetDeviceToken (DeviceToken);
-            NcApplication.Instance.ClientId = ClientToken;
 
             WaitForState ((uint)St.Start);
             Wpa.Execute ();
@@ -429,7 +422,6 @@ namespace Test.Common
                 return StartSessionOkResponse (request);
             };
             PushAssist.SetDeviceToken (DeviceToken);
-            NcApplication.Instance.ClientId = ClientToken;
 
             WaitForState ((uint)St.Start);
             Wpa.Execute ();
@@ -470,7 +462,6 @@ namespace Test.Common
             MockHttpClient.ExamineHttpRequestMessage = CheckStartSessionRequest;
             MockHttpClient.ProvideHttpResponseMessage = StartSessionOkResponse;
             PushAssist.SetDeviceToken (DeviceToken);
-            NcApplication.Instance.ClientId = ClientToken;
 
             WaitForState ((uint)St.Start);
             Wpa.Execute ();


### PR DESCRIPTION
- The cognito id was previously referred as ClientId. It is now called UserId.
- The new client id is the device id (Device.Instance.Identity()).
- client_id file is renamed to user_id file.
- All user id file accesses are now encapsulated in UserIdFile class and it is moved to NcApplication.
- Telemetry continues to set NcApplication.UserId if it is not available.
- The notification of user id change is sent via Info_UserIdChanged. Info_PushAssistClientToken is now obsoleted.
- iCloud sync now sets UserId. Push assist and telemetry continues to use (new) ClientId.
- Move GetDocumentsPath() and GetDataDirPath(). They are system wide info and it avoids a recursion that blows the stack.
- PushAssistTest is updated as there is no need to set client token since it is always available.
