### PR TITLE
Fix the encoding of WBXML opaque data

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/WBXML.cs
+++ b/NachoClient.Android/NachoCore/Utils/WBXML.cs
@@ -356,13 +356,12 @@ namespace NachoCore.Wbxml
                 var text = (XText)node;
                 if (codePages [currentCodePage].GetIsOpaque (text.Parent.Name.LocalName)) {
                     writer.Write ((byte)GlobalTokens.OPAQUE);
-                    byte[] opaque = EncodeOpaque (text.Value);
+                    byte[] opaque = EncodeOpaqueString (text.Value);
                     writer.Write (opaque);
                     filter.Update (level, node);
                 } else if (codePages [currentCodePage].GetIsOpaqueBase64 (text.Parent.Name.LocalName)) {
                     writer.Write ((byte)GlobalTokens.OPAQUE);
-                    byte[] opaqueB64 = EncodeOpaque (Convert.ToBase64String 
-                        (System.Text.UTF8Encoding.UTF8.GetBytes (text.Value)));
+                    byte[] opaqueB64 = EncodeBase64String (text.Value);
                     writer.Write (opaqueB64);
                     filter.Update (level, node);
                 } else {
@@ -376,8 +375,8 @@ namespace NachoCore.Wbxml
             case XmlNodeType.CDATA:
                 var cdata = (XCData)node;
                 writer.Write ((byte)GlobalTokens.OPAQUE);
-                byte[] opaqueCdata = EncodeOpaque (cdata.Value);
-                writer.Write (opaqueCdata, 0, opaqueCdata.Length);
+                byte[] opaqueCdata = EncodeOpaqueString (cdata.Value);
+                writer.Write (opaqueCdata);
                 filter.Update (level, node);
                 break;
             default:
@@ -416,7 +415,7 @@ namespace NachoCore.Wbxml
 
                 if (null != fileAttr) {
                     byteList.Add ((byte)GlobalTokens.OPAQUE);
-                    byteList.AddRange (EncodeOpaque (File.ReadAllText (fileAttr.Value)));
+                    byteList.AddRange (EncodeOpaqueBytes (File.ReadAllBytes (fileAttr.Value)));
                     byteList.Add ((byte)GlobalTokens.END);
                     fileAttr.Remove ();
                 } else if (element.HasElements || !element.IsEmpty) {
@@ -430,12 +429,11 @@ namespace NachoCore.Wbxml
                 var text = (XText)node;
                 if (codePages [currentCodePage].GetIsOpaque (text.Parent.Name.LocalName)) {
                     byteList.Add ((byte)GlobalTokens.OPAQUE);
-                    byteList.AddRange (EncodeOpaque (text.Value));
+                    byteList.AddRange (EncodeOpaqueString (text.Value));
                     filter.Update (level, node);
                 } else if (codePages [currentCodePage].GetIsOpaqueBase64 (text.Parent.Name.LocalName)) {
                     byteList.Add ((byte)GlobalTokens.OPAQUE);
-                    byteList.AddRange (EncodeOpaque (Convert.ToBase64String 
-                        (System.Text.UTF8Encoding.UTF8.GetBytes (text.Value))));
+                    byteList.AddRange (EncodeBase64String (text.Value));
                     filter.Update (level, node);
                 } else {
                     byteList.Add ((byte)GlobalTokens.STR_I);
@@ -446,7 +444,7 @@ namespace NachoCore.Wbxml
             case XmlNodeType.CDATA:
                 var cdata = (XCData)node;
                 byteList.Add ((byte)GlobalTokens.OPAQUE);
-                byteList.AddRange (EncodeOpaque (cdata.Value));
+                byteList.AddRange (EncodeOpaqueString (cdata.Value));
                 filter.Update (level, node);
                 break;
             default:
@@ -543,19 +541,29 @@ namespace NachoCore.Wbxml
             stream.CopyTo (writer.BaseStream);
         }
 
-        private byte[] EncodeOpaque (string value)
+        private byte[] EncodeOpaqueBytes (byte[] bytes)
         {
             List<byte> byteList = new List<byte> ();
 
-            char[] charArray = value.ToCharArray ();
-
-            byteList.AddRange (EncodeMultiByteInteger (charArray.Length));
-
-            for (int i = 0; i < charArray.Length; i++) {
-                byteList.Add ((byte)charArray [i]);
-            }
+            byteList.AddRange (EncodeMultiByteInteger (bytes.Length));
+            byteList.AddRange (bytes);
 
             return byteList.ToArray ();
+        }
+
+        private byte[] EncodeOpaqueString (string value)
+        {
+            return EncodeOpaqueBytes (System.Text.Encoding.UTF8.GetBytes (value));
+        }
+
+        private byte[] EncodeBase64String (string value)
+        {
+            try {
+                return EncodeOpaqueBytes (Convert.FromBase64String (value));
+            } catch (FormatException e) {
+                Log.Error (Log.LOG_UTILS, "Internal error: The string passed to WBXML.EncodeBase64String is not a valid base-64 string: {0}", value);
+                return EncodeOpaqueString (value);
+            }
         }
 
         private byte[] EncodeMultiByteInteger (int value)


### PR DESCRIPTION
(None of the code being changed is currently used by the app, which is
why the bugs in the code have not been noticed.  These changes do not
fix any current bugs, and they have not been thoroughly tested.  But
the code might be used in the future, for example if the app uses the
ItemOperations/Move command, so it is good to fix the bugs now.)

For WBXML opaque fields where the app doesn't need to interpret the
data (only use it as an identifier), the app uses a base-64 encoded
string of the data internally (because a string is easier to manage
than a sequence of bytes).  Decoding the bytes and creating the
base-64 string was correct.  But the code to encode a base-64 string
into the correct byte sequence was completely broken.  This has been
fixed.

When encoding opaque data that is stored in a file, transfer the bytes
of the file directly into the WBXML data, rather than reading the file
in as a string and then converting the string back to a sequence of
bytes.  (There are two versions of this code.  The version in
EmitNode() is used for the body of an outgoing e-mail message, and
that one was already correct.  This update fixes the version in
EncodeNode(), which is not used.)

When encoding opaque data that is stored in a non-base-64 string, use
UTF-8 encoding (which preserves all of the information in the string)
rather than ASCII encoding (which loses some information).  This code
should never be run, since all opaque fields are stored as base-64
strings or in a file.  But the code needs to be here for
completeness.
