### PR TITLE
Eliminate many references to a global account id.

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -398,6 +398,8 @@
     <Compile Include="NachoCore\Model\Migration\NcMigration22.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration23.cs" />
     <Compile Include="NachoCore\BackEnd\NcProtoControl.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration24.cs" />
+    <Compile Include="NachoCore\Utils\PermissionManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration24.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration24.cs
@@ -1,0 +1,43 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+using PM = NachoCore.Utils.PermissionManager;
+
+namespace NachoCore.Model
+{
+    public class NcMigration24 : NcMigration
+    {
+        public override int GetNumberOfObjects ()
+        {
+            return 1;
+        }
+
+        public override void Run (System.Threading.CancellationToken token)
+        {
+            MigrateToDeviceAccount ();
+        }
+
+        // Permissions are associated with the device.
+        // Migrate from single account to multi-account.
+        public void MigrateToDeviceAccount ()
+        {
+            var account = NcModel.Instance.Db.Table<McAccount> ().Where (x => x.AccountType == McAccount.AccountTypeEnum.Exchange).FirstOrDefault ();
+
+            if (null != account) {
+                foreach (var module in new string[] { PM.Module_Calendar, PM.Module_Contacts, PM.Module_Notifications }) {
+                    if (null != McMutables.Get (account.Id, module, PM.Key_AskedUserForPermission)) {
+                        var askedForPermission = McMutables.GetBool (account.Id, module, PM.Key_AskedUserForPermission);
+                        McMutables.SetBool (McAccount.GetDeviceAccount ().Id, module, PM.Key_AskedUserForPermission, askedForPermission);
+                    }
+                    if (null != McMutables.Get (account.Id, module, PM.Key_UserGrantedUsPermission)) {
+                        var grantedPermission = McMutables.GetBool (account.Id, module, PM.Key_UserGrantedUsPermission);
+                        McMutables.SetBool (McAccount.GetDeviceAccount ().Id, module, PM.Key_UserGrantedUsPermission, grantedPermission);
+                    }
+                }
+                if (NachoCore.Utils.LoginHelpers.HasViewedTutorial (account.Id)) {
+                    NachoCore.Utils.LoginHelpers.SetHasViewedTutorial (true);
+                }
+            }
+        }
+    }
+}

--- a/NachoClient.Android/NachoCore/NcEnforcer.cs
+++ b/NachoClient.Android/NachoCore/NcEnforcer.cs
@@ -40,13 +40,14 @@ namespace NachoCore
 
         private void WipeAccountAndRestart(Object state)
         {
+            var account = (McAccount)state;
             // dont bother checking for ack from the server since as per spec : The client SHOULD NOT wait for or rely on any specific response from the server before proceeding with the remote wipe.
             Log.Info (Log.LOG_AS, "Remote Wipe Initiated");
             DelayTimer.Dispose ();
             DelayTimer = null;
             Action action = () => {
                 InvokeOnUIThread.Instance.Invoke (delegate () {
-                    NcAccountHandler.Instance.RemoveAccount ();
+                    NcAccountHandler.Instance.RemoveAccount (account.Id);
                     NcUIRedirector.Instance.GoBackToMainScreen();                        
                     Log.Info (Log.LOG_AS, "Remote Wipe Completed.");
                 });
@@ -58,8 +59,8 @@ namespace NachoCore
         {
             Log.Info (Log.LOG_AS, "Remote Wipe Marked");
             // mark wipe in progress. This will go thru even if the app is stopped/restarted.
-            NcModel.Instance.WriteRemovingAccountIdToFile (NcApplication.Instance.Account.Id);
-            DelayTimer = new NcTimer ("RemoteWipeTimer", WipeAccountAndRestart, this, 1000, 1000);
+            NcModel.Instance.WriteRemovingAccountIdToFile (account.Id);
+            DelayTimer = new NcTimer ("RemoteWipeTimer", WipeAccountAndRestart, account, 1000, 1000);
             return true;
         }
     }

--- a/NachoClient.Android/NachoCore/Utils/LoginHelpers.cs
+++ b/NachoClient.Android/NachoCore/Utils/LoginHelpers.cs
@@ -19,11 +19,7 @@ namespace NachoCore.Utils
         //Implies that auto-d is complete too.
         static public void SetFirstSyncCompleted (int accountId, bool toWhat)
         {
-            if (toWhat) {
-                LoginHelpers.SetAutoDCompleted (accountId, true);
-            }
             Log.Info (Log.LOG_UI, "SetFirstSyncCompleted: {0}={1}", accountId, toWhat);
-            NcAssert.True (GetCurrentAccountId () == accountId);
             McMutables.SetBool (accountId, MODULE, "hasSyncedFolders", toWhat);
         }
 
@@ -32,14 +28,12 @@ namespace NachoCore.Utils
         //False if not
         static public bool HasFirstSyncCompleted (int accountId)
         {
-            NcAssert.True (GetCurrentAccountId () == accountId);
             return McMutables.GetOrCreateBool (accountId, MODULE, "hasSyncedFolders", false);
         }
 
         static public void SetDoesBackEndHaveIssues (int accountId, bool toWhat)
         {
             Log.Info (Log.LOG_UI, "SetDoesBackEndHaveIssues: {0}={1}", accountId, toWhat);
-            NcAssert.True (GetCurrentAccountId () == accountId);
             McMutables.SetBool (accountId, MODULE, "doesBackEndHaveIssues", toWhat);
             NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () {
                 Status = NcResult.Info (NcResult.SubKindEnum.Info_UserInterventionFlagChanged),
@@ -50,15 +44,14 @@ namespace NachoCore.Utils
 
         static public bool DoesBackEndHaveIssues (int accountId)
         {
-            NcAssert.True (GetCurrentAccountId () == accountId);
             return McMutables.GetOrCreateBool (accountId, MODULE, "doesBackEndHaveIssues", false);
         }
 
         //Sets the status of the tutorial bit for given accountId
-        static public void SetHasViewedTutorial (int accountId, bool toWhat)
+        static public void SetHasViewedTutorial (bool toWhat)
         {
+            var accountId = McAccount.GetDeviceAccount ().Id;
             Log.Info (Log.LOG_UI, "SetHasViewedTutorial: {0}={1}", accountId, toWhat);
-            NcAssert.True (GetCurrentAccountId () == accountId);
             // TODO: should this really be per-account or once for all accounts?
             McMutables.SetBool (accountId, MODULE, "hasViewedTutorial", toWhat);
         }
@@ -66,44 +59,12 @@ namespace NachoCore.Utils
         //Gets the status of the tutorial bit for given accountId
         //True if they have viewed tutorial
         //False if not
-        static public bool HasViewedTutorial (int accountId)
+        static public bool HasViewedTutorial (int accountId = 0)
         {
-            NcAssert.True (GetCurrentAccountId () == accountId);
+            if (0 == accountId) {
+                accountId = McAccount.GetDeviceAccount ().Id;
+            }
             return McMutables.GetOrCreateBool (accountId, MODULE, "hasViewedTutorial", false);
-        }
-
-        //Sets the status of the auto-d success bit for given accountId
-        static public void SetAutoDCompleted (int accountId, bool toWhat)
-        {
-            Log.Info (Log.LOG_UI, "SetAutoDCompleted: {0}={1}", accountId, toWhat);
-            NcAssert.True (GetCurrentAccountId () == accountId);
-            McMutables.SetBool (accountId, MODULE, "hasAutoDCompleted", toWhat);
-        }
-
-        //Gets the status of the auto-d success bit for given accountId
-        //True if they have succesfully sync'd folders
-        //False if not
-        static public bool HasAutoDCompleted (int accountId)
-        {
-            NcAssert.True (GetCurrentAccountId () == accountId);
-            return McMutables.GetOrCreateBool (accountId, MODULE, "hasAutoDCompleted", false);
-        }
-
-        //Sets the status of the creds bit for given accountId
-        static public void SetHasProvidedCreds (int accountId, bool toWhat)
-        {
-            Log.Info (Log.LOG_UI, "SetHasProvidedCreds: {0}={1}", accountId, toWhat);
-            NcAssert.True (GetCurrentAccountId () == accountId);
-            McMutables.SetBool (accountId, MODULE, "hasProvidedCreds", toWhat);
-        }
-
-        //Gets the status of the creds bit for given accountId
-        //True if they have provided creds at least once
-        //False if not
-        static public bool HasProvidedCreds (int accountId)
-        {
-            NcAssert.True (GetCurrentAccountId () == accountId);
-            return McMutables.GetOrCreateBool (accountId, MODULE, "hasProvidedCreds", false);
         }
 
         // We want to fail if someone just plucks a null
@@ -121,7 +82,7 @@ namespace NachoCore.Utils
 
         // Return true if a password associated with the account id will expire
         // soon and return information about the password that expires soonest.
-        static public bool PasswordWillExpire(int accountId, out DateTime expiry, out string rectificationUrl)
+        static public bool PasswordWillExpire (int accountId, out DateTime expiry, out string rectificationUrl)
         {
             expiry = DateTime.MaxValue;
             rectificationUrl = String.Empty;
@@ -138,6 +99,22 @@ namespace NachoCore.Utils
                 }
             }
             return (DateTime.MaxValue != gonnaExpireOn);
+        }
+
+        static public bool ReadyToStart ()
+        {
+            if (!NcApplication.Instance.IsUp ()) {
+                return false;
+            }
+            if (null == NcApplication.Instance.Account) {
+                return false;
+            }
+            var backendState = BackEnd.Instance.BackEndState (NcApplication.Instance.Account.Id);
+            return LoginHelpers.HasViewedTutorial () && (BackEndStateEnum.PostAutoDPostInboxSync == backendState);
+        }
+
+        static public int GlobalAccountId {
+            get { return McAccount.GetDeviceAccount ().Id; }
         }
     }
 }

--- a/NachoClient.Android/NachoCore/Utils/PermissionManager.cs
+++ b/NachoClient.Android/NachoCore/Utils/PermissionManager.cs
@@ -1,0 +1,17 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+
+namespace NachoCore.Utils
+{
+    public class PermissionManager
+    {
+        public const string Module_Calendar = "DeviceCalendar";
+        public const string Module_Contacts = "DeviceContacts";
+        public const string Module_Notifications = "DeviceNotifications";
+
+        public const string Key_AskedUserForPermission = "AskedUserForPermission";
+        public const string Key_UserGrantedUsPermission = "UserGrantedUsPermission";
+    }
+}
+

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -380,7 +380,7 @@ namespace NachoClient.iOS
 
             NcKeyboardSpy.Instance.Init ();
 
-            if (NcApplication.Instance.IsUp () && "SegueToTabController" == StartupViewController.NextSegue ()) {
+            if(LoginHelpers.ReadyToStart()) {
                 var storyboard = UIStoryboard.FromName ("MainStoryboard_iPhone", null);
                 var vc = storyboard.InstantiateViewController ("NachoTabBarController");
                 Log.Info (Log.LOG_UI, "fast path to tab bar controller: {0}", vc);
@@ -803,10 +803,10 @@ namespace NachoClient.iOS
             if (hasFirstSyncCompleted == false) {
                 NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () { 
                     Status = NachoCore.Utils.NcResult.Info (NcResult.SubKindEnum.Info_CredReqCallback),
-                    Account = ConstMcAccount.NotAccountSpecific,
+                    Account = McAccount.QueryById<McAccount>(accountId),
                 });
             } else {
-                DisplayCredentialsFixView ();
+                DisplayCredentialsFixView (accountId);
             }
         }
 
@@ -841,7 +841,7 @@ namespace NachoClient.iOS
                 // called if server name is wrong
                 // cancel should call "exit program, enter new server name should be updated server
 
-                LoginHelpers.SetDoesBackEndHaveIssues (LoginHelpers.GetCurrentAccountId (), true);
+                LoginHelpers.SetDoesBackEndHaveIssues (accountId, true);
 
                 var Mo = NcModel.Instance;
                 var Be = BackEnd.Instance;
@@ -857,7 +857,7 @@ namespace NachoClient.iOS
                     var parent = (UIAlertView)a;
                     if (b.ButtonIndex == 0) {
 
-                        LoginHelpers.SetDoesBackEndHaveIssues (LoginHelpers.GetCurrentAccountId (), false);
+                        LoginHelpers.SetDoesBackEndHaveIssues (accountId, false);
 
                         var txt = parent.GetTextField (0).Text;
                         // FIXME need to scan string to make sure it is of right format (regex).
@@ -911,20 +911,21 @@ namespace NachoClient.iOS
                 Log.Info (Log.LOG_UI, "CertAskReqCallback Called for account: {0}", accountId);
                 NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () { 
                     Status = NachoCore.Utils.NcResult.Info (NcResult.SubKindEnum.Error_CertAskReqCallback),
-                    Account = ConstMcAccount.NotAccountSpecific,
+                    Account = McAccount.QueryById<McAccount>(accountId),
                 });
             } else {
                 // UI FIXME - ask user and call CertAskResp async'ly.
-                DisplayCredentialsFixView ();
+                DisplayCredentialsFixView (accountId);
             }
         }
 
-        protected void DisplayCredentialsFixView ()
+        protected void DisplayCredentialsFixView (int accountId)
         {
-            LoginHelpers.SetDoesBackEndHaveIssues (LoginHelpers.GetCurrentAccountId (), true);
+            LoginHelpers.SetDoesBackEndHaveIssues (accountId, true);
 
             UIStoryboard x = UIStoryboard.FromName ("MainStoryboard_iPhone", null);
-            CredentialsAskViewController cvc = (CredentialsAskViewController)x.InstantiateViewController ("CredentialsAskViewController");
+            var cvc = (CredentialsAskViewController)x.InstantiateViewController ("CredentialsAskViewController");
+            cvc.SetAccountId (accountId);
             cvc.SetTabBarController (Util.GetActiveTabBarOrNull ());
             this.Window.RootViewController.PresentViewController (cvc, true, null);
         }

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1371,6 +1371,12 @@
     <Compile Include="..\NachoClient.Android\NachoCore\BackEnd\NcProtoControl.cs">
       <Link>NachoCore\BackEnd\NcProtoControl.cs</Link>
     </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration24.cs">
+      <Link>NachoCore\Model\Migration\NcMigration24.cs</Link>
+    </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Utils\PermissionManager.cs">
+      <Link>NachoCore\Utils\PermissionManager.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/NachoClient.iOS/NachoUI.iOS/AboutUsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/AboutUsViewController.cs
@@ -5,6 +5,7 @@ using System;
 using Foundation;
 using UIKit;
 using CoreGraphics;
+using NachoCore.Utils;
 
 namespace NachoClient.iOS
 {
@@ -238,6 +239,8 @@ namespace NachoClient.iOS
                 vc.SetProperties (url, title, key, loadFromWeb);
                 return;
             }
+            Log.Info (Log.LOG_UI, "Unhandled segue identifer {0}", segue.Identifier);
+            NcAssert.CaseError ();
         }
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/AddAttachmentViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/AddAttachmentViewController.cs
@@ -58,7 +58,6 @@ namespace NachoClient.iOS
                 dc.SetModal (true);
                 return;
             }
-
             Log.Info (Log.LOG_UI, "Unhandled segue identifer {0}", segue.Identifier);
             NcAssert.CaseError ();
         }

--- a/NachoClient.iOS/NachoUI.iOS/ContactDefaultSelectionViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactDefaultSelectionViewController.cs
@@ -531,9 +531,9 @@ namespace NachoClient.iOS
             UITextField phoneTextField = (UITextField)View.ViewWithTag (PHONE_TEXTFIELD_TAG);
             if (!string.IsNullOrEmpty (phoneTextField.Text)) {
                 if (isDefaultSelected) {
-                    contact.AddDefaultPhoneNumberAttribute (LoginHelpers.GetCurrentAccountId (), phoneLabel.type, phoneLabel.label, phoneTextField.Text);
+                    contact.AddDefaultPhoneNumberAttribute (contact.AccountId, phoneLabel.type, phoneLabel.label, phoneTextField.Text);
                 } else {
-                    contact.AddPhoneNumberAttribute (LoginHelpers.GetCurrentAccountId (), phoneLabel.type, phoneLabel.label, phoneTextField.Text);
+                    contact.AddPhoneNumberAttribute (contact.AccountId, phoneLabel.type, phoneLabel.label, phoneTextField.Text);
                 }
                 contact.Update ();
                 NachoCore.BackEnd.Instance.UpdateContactCmd (contact.AccountId, contact.Id);
@@ -548,9 +548,9 @@ namespace NachoClient.iOS
             UITextField emailTextField = (UITextField)View.ViewWithTag (EMAIL_TEXTFIELD_TAG);
             if (EmailHelper.IsValidEmail (emailTextField.Text)) {
                 if (isDefaultSelected) {
-                    contact.AddDefaultEmailAddressAttribute (LoginHelpers.GetCurrentAccountId (), Xml.Contacts.Email1Address, contactHelper.ExchangeNameToLabel (Xml.Contacts.Email1Address), emailTextField.Text);
+                    contact.AddDefaultEmailAddressAttribute (contact.AccountId, Xml.Contacts.Email1Address, contactHelper.ExchangeNameToLabel (Xml.Contacts.Email1Address), emailTextField.Text);
                 } else {
-                    contact.AddEmailAddressAttribute (LoginHelpers.GetCurrentAccountId (), Xml.Contacts.Email1Address, contactHelper.ExchangeNameToLabel (Xml.Contacts.Email1Address), emailTextField.Text);
+                    contact.AddEmailAddressAttribute (contact.AccountId, Xml.Contacts.Email1Address, contactHelper.ExchangeNameToLabel (Xml.Contacts.Email1Address), emailTextField.Text);
                 }
                 contact.Update ();
                 NachoCore.BackEnd.Instance.UpdateContactCmd (contact.AccountId, contact.Id);
@@ -632,9 +632,11 @@ namespace NachoClient.iOS
                 ContactsHelper c = new ContactsHelper ();
                 destinationController.SetLabelList (c.GetAvailablePhoneNames (contact));
                 destinationController.SetSelectedName (c.GetAvailablePhoneNames (contact).First ());
-                destinationController.SetOwner (this);
+                destinationController.SetOwner (this, contact.AccountId);
                 return;
             }
+            Log.Info (Log.LOG_UI, "Unhandled segue identifer {0}", segue.Identifier);
+            NcAssert.CaseError ();
         }
 
         public void PrepareForDismissal (string selectedName)

--- a/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
@@ -183,26 +183,22 @@ namespace NachoClient.iOS
                 destinationController.owner = this;
                 return;
             }
-
             if (segue.Identifier.Equals ("SegueToMessageCompose")) {
                 var h = sender as SegueHolder;
                 MessageComposeViewController mcvc = (MessageComposeViewController)segue.DestinationViewController;
                 mcvc.SetEmailPresetFields (new NcEmailAddress (NcEmailAddress.Kind.To, (string)h.value));
                 return;
             }
-
             if (segue.Identifier.Equals ("ContactToNotes")) {
                 var dc = (NotesViewController)segue.DestinationViewController;
                 dc.SetOwner (this, false);
                 return;
             }
-
             if (segue.Identifier.Equals ("ContactToContactEdit")) {
                 var destinationViewController = (ContactEditViewController)segue.DestinationViewController;
                 destinationViewController.contact = contact;
                 return;
             }
-
             if (segue.Identifier == "NachoNowToMessagePriority") {
                 var holder = (SegueHolder)sender;
                 var thread = (McEmailMessageThread)holder.value;

--- a/NachoClient.iOS/NachoUI.iOS/ContactEditViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactEditViewController.cs
@@ -770,10 +770,11 @@ namespace NachoClient.iOS
                     destinationController.SetSelectedName (editingMiscCell.Name);
                     break;
                 }
-                destinationController.SetContact (contactCopy);
-                destinationController.SetOwner (this);
+                destinationController.SetOwner (this, contactCopy.AccountId);
                 return;
             }
+            Log.Info (Log.LOG_UI, "Unhandled segue identifer {0}", segue.Identifier);
+            NcAssert.CaseError ();
         }
 
         protected override void OnKeyboardChanged ()
@@ -934,9 +935,7 @@ namespace NachoClient.iOS
             if (null != contactBody) {
                 contactBody.UpdateData (notesTextView.Text);
             } else {
-                contactCopy.BodyId = McBody.InsertFile (LoginHelpers.GetCurrentAccountId ()
-                    , McAbstrFileDesc.BodyTypeEnum.PlainText_1,
-                    notesTextView.Text).Id;
+                contactCopy.BodyId = McBody.InsertFile (contactCopy.AccountId, McAbstrFileDesc.BodyTypeEnum.PlainText_1, notesTextView.Text).Id;
             }
         }
 
@@ -1104,7 +1103,7 @@ namespace NachoClient.iOS
                 return;
             }
 
-            var phoneAttribute = contactCopy.AddOrUpdatePhoneNumberAttribute (LoginHelpers.GetCurrentAccountId (), 
+            var phoneAttribute = contactCopy.AddOrUpdatePhoneNumberAttribute (contactCopy.AccountId, 
                                      contactHelper.GetAvailablePhoneNames (contactCopy).First (),
                                      contactHelper.ExchangeNameToLabel (contactHelper.GetAvailablePhoneNames (contactCopy).First ()),
                                      ""
@@ -1125,7 +1124,7 @@ namespace NachoClient.iOS
                 return;
             }
 
-            var emailAttribute = contactCopy.AddOrUpdateEmailAddressAttribute (LoginHelpers.GetCurrentAccountId (), 
+            var emailAttribute = contactCopy.AddOrUpdateEmailAddressAttribute (contactCopy.AccountId, 
                                      contactHelper.GetAvailableEmailNames (contactCopy).First (),
                                      contactHelper.ExchangeNameToLabel (contactHelper.GetAvailableEmailNames (contactCopy).First ()),
                                      ""

--- a/NachoClient.iOS/NachoUI.iOS/FileListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/FileListViewController.cs
@@ -356,7 +356,6 @@ namespace NachoClient.iOS
                 dc.SetOwner (this);
                 return;
             }
-
             Log.Info (Log.LOG_UI, "Unhandled segue identifer {0}", segue.Identifier);
             NcAssert.CaseError ();
         }

--- a/NachoClient.iOS/NachoUI.iOS/FoldersViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/FoldersViewController.cs
@@ -132,7 +132,6 @@ namespace NachoClient.iOS
                 vc.SetOwner (this);
                 return;
             }
-
             Log.Info (Log.LOG_UI, "Unhandled segue identifer {0}", segue.Identifier);
             NcAssert.CaseError ();
         }

--- a/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
@@ -99,6 +99,10 @@ namespace NachoClient.iOS
         public override void PrepareForSegue (UIStoryboardSegue segue, NSObject sender)
         {
             if (segue.Identifier.Equals ("SegueToAccountSettings")) {
+                var h = (SegueHolder)sender;
+                var account = (McAccount)h.value;
+                var vc = (AccountSettingsViewController)segue.DestinationViewController;
+                vc.SetAccount (account);
                 return;
             }
             Log.Info (Log.LOG_UI, "Unhandled segue identifer {0}", segue.Identifier);

--- a/NachoClient.iOS/NachoUI.iOS/HomeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/HomeViewController.cs
@@ -12,11 +12,10 @@ namespace NachoClient.iOS
 {
     public partial class HomeViewController : NcUIViewController
     {
-        public UIPageViewController pageController;
-        int accountId;
         public UIPageControl pageDots;
-        public bool isFirstLoad = true;
         public UIButton closeTutorial;
+
+        UIPageViewController pageController;
 
         public HomeViewController (IntPtr handle) : base (handle)
         {
@@ -48,11 +47,6 @@ namespace NachoClient.iOS
                 this.NavigationController.ToolbarHidden = true;
                 this.NavigationController.NavigationBar.Hidden = true;
             }
-
-            NcApplication.Instance.StatusIndEvent += StatusIndicatorCallback;
-
-            accountId = LoginHelpers.GetCurrentAccountId ();
-
         }
 
         public override void ViewWillDisappear (bool animated)
@@ -62,31 +56,10 @@ namespace NachoClient.iOS
                 this.NavigationController.ToolbarHidden = true;
                 this.NavigationController.NavigationBar.Hidden = false;
             }
-            NcApplication.Instance.StatusIndEvent -= StatusIndicatorCallback;
-        }
-
-        public void StatusIndicatorCallback (object sender, EventArgs e)
-        {
-            var s = (StatusIndEventArgs)e;
-
-            if (NcResult.SubKindEnum.Info_EmailMessageSetChanged == s.Status.SubKind) {
-                Log.Info (Log.LOG_UI, "Info_EmailMessageSetChanged Status Ind (Tutorial)");
-                LoginHelpers.SetFirstSyncCompleted (accountId, true);
-            }
-            if (NcResult.SubKindEnum.Info_InboxPingStarted == s.Status.SubKind) {
-                Log.Info (Log.LOG_UI, "Info_InboxPingStarted Status Ind (Tutorial)");
-                LoginHelpers.SetFirstSyncCompleted (accountId, true);
-            }
-            if (NcResult.SubKindEnum.Info_AsAutoDComplete == s.Status.SubKind) {
-                Log.Info (Log.LOG_UI, "Info_AsAutoDComplete Status Ind (Tutorial)");
-                LoginHelpers.SetAutoDCompleted (LoginHelpers.GetCurrentAccountId (), true);
-            }
         }
 
         public void InitializePageViewController ()
         {
-
-
             UIView dotsAndDismissContainerView = new UIView (); // contain pageDots and the dismiss button
             dotsAndDismissContainerView.Frame = new CoreGraphics.CGRect (0, this.View.Frame.Bottom - 35, this.View.Frame.Width, 35);
             dotsAndDismissContainerView.BackgroundColor = UIColor.White;
@@ -112,8 +85,8 @@ namespace NachoClient.iOS
             //closeTutorial.BackgroundColor = A.Color_NachoRed; // debug
             closeTutorial.HorizontalAlignment = UIControlContentHorizontalAlignment.Right;
             closeTutorial.TouchUpInside += (object sender, EventArgs e) => {
-                LoginHelpers.SetHasViewedTutorial (accountId, true);
-                PerformSegue (StartupViewController.NextSegue (), this);
+                LoginHelpers.SetHasViewedTutorial (true);
+                NavigationController.PopViewController(true);
             };
             dotsAndDismissContainerView.Add (closeTutorial);
 

--- a/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoCertificateResponder.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoCertificateResponder.cs
@@ -4,15 +4,9 @@ using NachoCore.Model;
 
 namespace NachoClient.iOS
 {
-    public interface INachoCertificateResponder
-    {
-        void SetOwner (INachoCertificateResponderParent o);
-        void SetCertificateInfo ();
-    }
-
     public interface INachoCertificateResponderParent
     {
-        void DontAcceptCertificate();
-        void AcceptCertificate();
+        void DontAcceptCertificate(int accountId);
+        void AcceptCertificate(int accountId);
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoLabelChooser.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoLabelChooser.cs
@@ -13,7 +13,7 @@ namespace NachoClient.iOS
 {
     public interface INachoLabelChooser
     {
-        void SetOwner (INachoLabelChooserParent owner);
+        void SetOwner (INachoLabelChooserParent owner, int accountId);
         void SetLabelList (List<string> labelList);
         void SetSelectedName (string selectedName);
     }

--- a/NachoClient.iOS/NachoUI.iOS/LabelSelectionViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/LabelSelectionViewController.cs
@@ -18,7 +18,6 @@ namespace NachoClient.iOS
         protected const float X_INDENT = 30;
 
         public string selectedName;
-        protected McContact contact;
         protected ContactsHelper contactHelper = new ContactsHelper ();
 
         protected const int SELECTED_BUTTON_IMAGE_TAG = 88;
@@ -42,11 +41,20 @@ namespace NachoClient.iOS
         {
         }
 
+        // INachoLabelChooser
+        public void SetOwner (INachoLabelChooserParent owner, int accountId)
+        {
+            this.owner = owner;
+            // Ignores accountId
+        }
+
+        // INachoLabelChooser
         public void SetLabelList (List<string> labelList)
         {
             this.labelList = labelList;
         }
 
+        // INachoLabelChooser
         public void SetSelectedName (string selectedName)
         {
             this.selectedName = selectedName;
@@ -58,11 +66,6 @@ namespace NachoClient.iOS
                 labelList.Insert (0, selectedName);
             }
             base.ViewDidLoad ();
-        }
-
-        public void SetOwner (INachoLabelChooserParent owner)
-        {
-            this.owner = owner;
         }
 
         protected override void CreateViewHierarchy ()
@@ -207,11 +210,6 @@ namespace NachoClient.iOS
         protected override void ConfigureAndLayout ()
         {
 
-        }
-
-        public void SetContact (McContact contact)
-        {
-            this.contact = contact;
         }
 
         private void DismissViewTouchUpInside (object sender, EventArgs e)

--- a/NachoClient.iOS/NachoUI.iOS/MessagePriorityViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessagePriorityViewController.cs
@@ -203,6 +203,9 @@ namespace NachoClient.iOS
                 var vc = (DatePickerViewController)segue.DestinationViewController;
                 vc.owner = this;
             }
+
+            Log.Info (Log.LOG_UI, "Unhandled segue identifer {0}", segue.Identifier);
+            NcAssert.CaseError ();
         }
 
         public void DismissDatePicker (DatePickerViewController vc, DateTime chosenDateTime)

--- a/NachoClient.iOS/NachoUI.iOS/SettingsLegalViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/SettingsLegalViewController.cs
@@ -103,7 +103,7 @@ namespace NachoClient.iOS
         void CacheUrlHtml (object sender, EventArgs e)
         {
             if (!string.IsNullOrEmpty (urlSourceCode)) {
-                McMutables.Set (LoginHelpers.GetCurrentAccountId (), CACHE_MODULE, key, urlSourceCode);
+                McMutables.Set (LoginHelpers.GlobalAccountId, CACHE_MODULE, key, urlSourceCode);
             }
             LayoutView ();
         }
@@ -111,7 +111,7 @@ namespace NachoClient.iOS
         void HandleLoadError (object sender, UIWebErrorArgs e)
         {
             UIWebView webView = (UIWebView)View.ViewWithTag (WEB_VIEW_TAG);
-            string urlHtml = McMutables.GetOrCreate (LoginHelpers.GetCurrentAccountId (), CACHE_MODULE, key, "");
+            string urlHtml = McMutables.GetOrCreate (LoginHelpers.GlobalAccountId, CACHE_MODULE, key, "");
             if (!string.IsNullOrEmpty (urlHtml)) {
                 webView.LoadHtmlString (urlHtml, new NSUrl ("about:blank"));
             } else if (!NachoCore.Utils.Network_Helpers.HasNetworkConnection ()) {

--- a/NachoClient.iOS/NachoUI.iOS/SignatureEditViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/SignatureEditViewController.cs
@@ -22,8 +22,15 @@ namespace NachoClient.iOS
 
         protected string originalSignature;
 
+        int accountId;
+
         public SignatureEditViewController (IntPtr handle) : base (handle)
         {
+        }
+
+        public void SetAccountId(int accountId)
+        {
+            this.accountId = accountId;
         }
 
         public override void ViewDidAppear (bool animated)
@@ -34,7 +41,7 @@ namespace NachoClient.iOS
 
         protected void CaptureOriginalSignature ()
         {
-            McAccount theAccount = McAccount.QueryById<McAccount> (LoginHelpers.GetCurrentAccountId ());
+            McAccount theAccount = McAccount.QueryById<McAccount> (accountId);
             originalSignature = theAccount.Signature ?? "";
         }
 
@@ -81,7 +88,7 @@ namespace NachoClient.iOS
 
         protected override void ConfigureAndLayout ()
         {
-            McAccount theAccount = McAccount.QueryById<McAccount> (LoginHelpers.GetCurrentAccountId ());
+            McAccount theAccount = McAccount.QueryById<McAccount> (accountId);
             var signatureTextView = (UITextView)View.ViewWithTag (SIGNATURE_TEXT_VIEW_TAG);
             signatureTextView.Text = theAccount.Signature ?? "";
         }
@@ -97,7 +104,7 @@ namespace NachoClient.iOS
 
         protected void SaveButtonClicked (object sender, EventArgs e)
         {
-            McAccount theAccount = McAccount.QueryById <McAccount> (LoginHelpers.GetCurrentAccountId ());
+            McAccount theAccount = McAccount.QueryById <McAccount> (accountId);
             var signatureTextView = (UITextView)View.ViewWithTag (SIGNATURE_TEXT_VIEW_TAG);
 
             theAccount.Signature = signatureTextView.Text.Trim ();

--- a/NachoClient.iOS/NachoUI.iOS/Support/AccountInfoView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/AccountInfoView.cs
@@ -91,7 +91,7 @@ namespace NachoClient.iOS
             var emailAddress = account.EmailAddr;
             emailLabel.Text = emailAddress;
 
-            var userImage = Util.ImageOfSender (LoginHelpers.GetCurrentAccountId (), emailAddress);
+            var userImage = Util.ImageOfSender (account.Id, emailAddress);
 
             if (null != userImage) {
                 userImageView.Image = userImage;
@@ -99,7 +99,7 @@ namespace NachoClient.iOS
             } else {
                 int ColorIndex;
                 string Initials;
-                Util.UserMessageField (emailAddress, LoginHelpers.GetCurrentAccountId (), out ColorIndex, out Initials);
+                Util.UserMessageField (emailAddress, account.Id, out ColorIndex, out Initials);
                 userLabelView.BackgroundColor = Util.ColorForUser (ColorIndex);
                 userLabelView.Text = Initials;
                 userLabelView.Hidden = false;

--- a/NachoClient.iOS/NachoUI.iOS/Support/CertificateView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/CertificateView.cs
@@ -15,16 +15,14 @@ namespace NachoClient.iOS
     public class CertificateView: UIView
     {
         INachoCertificateResponderParent owner;
+
         UIView certificateView;
+
+        int callbackAccountId;
 
         protected string certInfo;
         protected string certCommonName;
         protected string certOrganization;
-
-        public CertificateView ()
-        {
-
-        }
 
         public void SetOwner (INachoCertificateResponderParent owner)
         {
@@ -38,7 +36,6 @@ namespace NachoClient.iOS
 
         public CertificateView (IntPtr handle) : base (handle)
         {
-
         }
 
         const int GRAY_BACKGROUND_TAG = 20;
@@ -109,7 +106,7 @@ namespace NachoClient.iOS
             trustCertificateButton.AccessibilityIdentifier = "Allow";
             trustCertificateButton.TouchUpInside += (object sender, EventArgs e) => {
                 DismissView ();
-                owner.AcceptCertificate ();
+                owner.AcceptCertificate (callbackAccountId);
             };
             certificateView.Add (trustCertificateButton);
 
@@ -125,7 +122,7 @@ namespace NachoClient.iOS
             dontTrustCertificateButton.SetTitleColor (A.Color_SystemBlue, UIControlState.Normal);
             dontTrustCertificateButton.TouchUpInside += (object sender, EventArgs e) => {
                 DismissView ();
-                owner.DontAcceptCertificate ();
+                owner.DontAcceptCertificate (callbackAccountId);
             };
             certificateView.Add (dontTrustCertificateButton);
 
@@ -165,9 +162,10 @@ namespace NachoClient.iOS
             certInfoTextView.Text = certInfo;
         }
 
-        public void SetCertificateInformation ()
+        public void SetCertificateInformation (int accountId)
         {
-            var certToBeExamined = BackEnd.Instance.ServerCertToBeExamined (LoginHelpers.GetCurrentAccountId ());
+            callbackAccountId = accountId;
+            var certToBeExamined = BackEnd.Instance.ServerCertToBeExamined (accountId);
             certInfo = CertificateHelper.FormatCertificateData (certToBeExamined);
             certCommonName = CertificateHelper.GetCommonName (certToBeExamined);
             certOrganization = CertificateHelper.GetOrganizationname (certToBeExamined);

--- a/NachoClient.iOS/NachoUI.iOS/Support/PermissionManager.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/PermissionManager.cs
@@ -9,6 +9,7 @@ using UIKit;
 using NachoCore;
 using NachoCore.Model;
 using NachoCore.Utils;
+using PM = NachoCore.Utils.PermissionManager;
 
 namespace NachoClient.iOS
 {
@@ -35,13 +36,6 @@ namespace NachoClient.iOS
 
     public class PermissionManager
     {
-        const string Module_Calendar = "DeviceCalendar";
-        const string Module_Contacts = "DeviceContacts";
-        const string Module_Notifications = "DeviceNotifications";
-
-        const string Key_AskedUserForPermission = "AskedUserForPermission";
-        const string Key_UserGrantedUsPermission = "UserGrantedUsPermission";
-
 
         public PermissionManager ()
         {
@@ -50,13 +44,13 @@ namespace NachoClient.iOS
         // Notifications -- no callback?
         public static void DealWithNotificationPermission ()
         {
-            var module = Module_Notifications;
-            var accountId = LoginHelpers.GetCurrentAccountId ();
+            var module = PM.Module_Notifications;
+            var accountId = McAccount.GetDeviceAccount ().Id;
 
-            if (McMutables.GetOrCreateBool (accountId, module, Key_AskedUserForPermission, false)) {
+            if (McMutables.GetOrCreateBool (accountId, module, PM.Key_AskedUserForPermission, false)) {
                 return;
             }
-            McMutables.SetBool (accountId, module, Key_AskedUserForPermission, true);
+            McMutables.SetBool (accountId, module, PM.Key_AskedUserForPermission, true);
 
             var title = "Nacho Mail would like to send you push notifications.";
             var body = "This allows Nacho Mail to tell you when you have new mail or an upcoming meeting.";
@@ -64,16 +58,16 @@ namespace NachoClient.iOS
             var alert = new UIAlertView (title, body, null, null, new string[] { "Don't Allow", "OK" });
             alert.Clicked += (s, b) => {
                 if ((alert.FirstOtherButtonIndex + 1) == b.ButtonIndex) {
-                    McMutables.SetBool (accountId, module, Key_AskedUserForPermission, true);
-                    Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, Key_AskedUserForPermission, "yes");
+                    McMutables.SetBool (accountId, module, PM.Key_AskedUserForPermission, true);
+                    Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, PM.Key_AskedUserForPermission, "yes");
                     var application = UIApplication.SharedApplication;
                     if (application.RespondsToSelector (new Selector ("registerUserNotificationSettings:"))) {
                         var settings = UIUserNotificationSettings.GetSettingsForTypes (UIUserNotificationType.Alert | UIUserNotificationType.Badge | UIUserNotificationType.Sound, new NSSet ());
                         application.RegisterUserNotificationSettings (settings);
                     }
                 } else {
-                    McMutables.SetBool (accountId, module, Key_AskedUserForPermission, true);
-                    Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, Key_AskedUserForPermission, "no");
+                    McMutables.SetBool (accountId, module, PM.Key_AskedUserForPermission, true);
+                    Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, PM.Key_AskedUserForPermission, "no");
                 }
             };
             alert.Show ();
@@ -85,18 +79,18 @@ namespace NachoClient.iOS
             // FIXME
             return;
 
-//            var module = Module_Calendar;
-//            var accountId = LoginHelpers.GetCurrentAccountId ();
+//            var module = PM.Module_Calendar;
+//            var accountId = McAccount.GetDeviceAccount ().Id;
 //
 //            // If we have already asked, then don't ask again.  TODO:  Setting to enabled access
-//            if (McMutables.GetOrCreateBool (accountId, module, Key_AskedUserForPermission, false)) {
+//            if (McMutables.GetOrCreateBool (accountId, module, PM.Key_AskedUserForPermission, false)) {
 //                return;
 //            }
 //
 //            // Has the system already allowed or denied Nacho Mail?
-//            if(!NachoPlatform.Calendars.Instance.ShouldWeBotherToAsk()) {
-//                McMutables.SetBool (accountId, module, Key_AskedUserForPermission, true);
-//                Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, Key_AskedUserForPermission, "do not bother");
+//            if (!NachoPlatform.Calendars.Instance.ShouldWeBotherToAsk ()) {
+//                McMutables.SetBool (accountId, module, PM.Key_AskedUserForPermission, true);
+//                Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, PM.Key_AskedUserForPermission, "do not bother");
 //                return;
 //            }
 //
@@ -107,17 +101,17 @@ namespace NachoClient.iOS
 //            alert.Clicked += (s, b) => {
 //                if ((alert.FirstOtherButtonIndex + 1) == b.ButtonIndex) {
 //                    NachoPlatform.Calendars.Instance.AskForPermission ((bool granted) => {
-//                        McMutables.SetBool (accountId, module, Key_AskedUserForPermission, true);
-//                        McMutables.SetBool (accountId, module, Key_UserGrantedUsPermission, granted);
-//                        Log.Info(Log.LOG_UI, "{0}: {1} {2}", module, Key_AskedUserForPermission, "yes");
-//                        Log.Info(Log.LOG_UI, "{0}: {1} {2}", module, Key_UserGrantedUsPermission, granted);
+//                        McMutables.SetBool (accountId, module, PM.Key_AskedUserForPermission, true);
+//                        McMutables.SetBool (accountId, module, PM.Key_UserGrantedUsPermission, granted);
+//                        Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, PM.Key_AskedUserForPermission, "yes");
+//                        Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, PM.Key_UserGrantedUsPermission, granted);
 //                        if (granted) {
 //                            NcDeviceCalendars.Run ();
 //                        }
 //                    });
 //                } else {
-//                    McMutables.SetBool (accountId, module, Key_AskedUserForPermission, true);
-//                    Log.Info(Log.LOG_UI, "{0}: {1} {2}", module, Key_AskedUserForPermission, "no");
+//                    McMutables.SetBool (accountId, module, PM.Key_AskedUserForPermission, true);
+//                    Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, PM.Key_AskedUserForPermission, "no");
 //                }
 //            };
 //            alert.Show ();
@@ -126,18 +120,18 @@ namespace NachoClient.iOS
         // Contacts
         public static void DealWithContactsPermission ()
         {
-            var module = Module_Contacts;
-            var accountId = LoginHelpers.GetCurrentAccountId ();
+            var module = PM.Module_Contacts;
+            var accountId = McAccount.GetDeviceAccount ().Id;
 
             // If we have already asked, then don't ask again.  TODO:  Setting to enabled access
-            if (McMutables.GetOrCreateBool (accountId, module, Key_AskedUserForPermission, false)) {
+            if (McMutables.GetOrCreateBool (accountId, module, PM.Key_AskedUserForPermission, false)) {
                 return;
             }
 
             // Has the system already allowed or denied Nacho Mail?
             if (!NachoPlatform.Contacts.Instance.ShouldWeBotherToAsk ()) {
-                McMutables.SetBool (accountId, module, Key_AskedUserForPermission, true);
-                Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, Key_AskedUserForPermission, "do not bother");
+                McMutables.SetBool (accountId, module, PM.Key_AskedUserForPermission, true);
+                Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, PM.Key_AskedUserForPermission, "do not bother");
                 return;
             }
 
@@ -148,20 +142,21 @@ namespace NachoClient.iOS
             alert.Clicked += (s, b) => {
                 if ((alert.FirstOtherButtonIndex + 1) == b.ButtonIndex) {
                     NachoPlatform.Contacts.Instance.AskForPermission ((bool granted) => {
-                        McMutables.SetBool (accountId, module, Key_AskedUserForPermission, true);
-                        McMutables.SetBool (accountId, module, Key_UserGrantedUsPermission, granted);
-                        Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, Key_AskedUserForPermission, "yes");
-                        Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, Key_UserGrantedUsPermission, granted);
+                        McMutables.SetBool (accountId, module, PM.Key_AskedUserForPermission, true);
+                        McMutables.SetBool (accountId, module, PM.Key_UserGrantedUsPermission, granted);
+                        Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, PM.Key_AskedUserForPermission, "yes");
+                        Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, PM.Key_UserGrantedUsPermission, granted);
                         if (granted) {
                             NcDeviceContacts.Run ();
                         }
                     });
                 } else {
-                    McMutables.SetBool (accountId, module, Key_AskedUserForPermission, true);
-                    Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, Key_AskedUserForPermission, "no");
+                    McMutables.SetBool (accountId, module, PM.Key_AskedUserForPermission, true);
+                    Log.Info (Log.LOG_UI, "{0}: {1} {2}", module, PM.Key_AskedUserForPermission, "no");
                 }
             };
             alert.Show ();
         }
+
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/Support/WaitingScreen.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/WaitingScreen.cs
@@ -36,12 +36,8 @@ namespace NachoClient.iOS
         protected const int SPINNER_HEIGHT = 338;
         protected const int MASK_DIAMETER = 80;
         protected nfloat LOWER_SECTION_Y_VAL;
-        protected bool quitLoadingAnimation;
         protected CGPoint topHalfSpinnerCenter;
         protected CGPoint bottomHalfSpinnerCenter;
-
-        protected NSTimer SegueToTutorial;
-        protected const int WAIT_TIME = 12;
 
         public WaitingScreen ()
         {
@@ -202,44 +198,17 @@ namespace NachoClient.iOS
             }));
         }
 
-        public void InitializeAutomaticSegueTimer ()
-        {
-            if (!LoginHelpers.HasViewedTutorial (LoginHelpers.GetCurrentAccountId ())) {
-                SegueToTutorial = NSTimer.CreateScheduledTimer (WAIT_TIME, delegate {
-                    // TODO: Move this logic to advanced view controller
-                    if (LoginHelpers.IsCurrentAccountSet ()) {
-                        if (!LoginHelpers.HasAutoDCompleted (LoginHelpers.GetCurrentAccountId ())) {
-                            owner.PerformSegue ("SegueToHome", this);
-                        }
-                    } else {
-                        Log.Info (Log.LOG_UI, "avl: segue timer account null");
-                    }
-                });
-            }
-        }
-
-        public void InvalidateAutomaticSegueTimer ()
-        {
-            if (null != SegueToTutorial) {
-                SegueToTutorial.Invalidate ();
-            }
-        }
-
         public void ShowView ()
         {
-            InitializeAutomaticSegueTimer ();
             this.Hidden = false;
             owner.NavigationItem.Title = "";
             Util.ConfigureNavBar (true, owner.NavigationController);
-            quitLoadingAnimation = false;
             ResetLoadingItems ();
             StartLoadingAnimation ();
         }
 
         public void DismissView ()
         {
-            InvalidateAutomaticSegueTimer ();
-            quitLoadingAnimation = true;
             bottomHalfSpinner.Layer.RemoveAllAnimations ();
             topHalfSpinner.Layer.RemoveAllAnimations ();
             owner.NavigationItem.Title = "Account Setup";
@@ -286,7 +255,7 @@ namespace NachoClient.iOS
             }));
         }
 
-        public void StartSyncedEmailAnimation ()
+        public void StartSyncedEmailAnimation (int accountId)
         {
             UIView.AnimateKeyframes (4, .1, UIViewKeyframeAnimationOptions.OverrideInheritedDuration, () => {
 
@@ -322,7 +291,7 @@ namespace NachoClient.iOS
                 });
 
             }, ((bool finished) => {
-                owner.PerformSegue (StartupViewController.NextSegue (), this);
+                owner.FinishedSyncedEmailAnimation(accountId);
             }));
         }
     }

--- a/NachoClient.iOS/NachoUI.iOS/SupportViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/SupportViewController.cs
@@ -189,17 +189,6 @@ namespace NachoClient.iOS
             if (null != this.NavigationController) {
                 this.NavigationController.ToolbarHidden = true;
             }
-
-            if (!LoginHelpers.IsCurrentAccountSet ()) {
-                NavigationItem.SetHidesBackButton (false, true);
-                NavigationController.NavigationBar.TintColor = A.Color_NachoBlue;
-            }
-            else if (!LoginHelpers.HasFirstSyncCompleted(LoginHelpers.GetCurrentAccountId())) {
-                NavigationItem.SetHidesBackButton (false, true);
-            } else {
-                // Uncomment to hide <More
-                // NavigationItem.SetHidesBackButton (true, true);
-            }
         }
 
         public override void ViewWillDisappear (bool animated)

--- a/Test.Android/RemoveAccountTest.cs
+++ b/Test.Android/RemoveAccountTest.cs
@@ -64,7 +64,7 @@ namespace Test.iOS
             }
 
             // remove account
-            NcAccountHandler.Instance.RemoveAccount (stopStartServices: false);
+            NcAccountHandler.Instance.RemoveAccount (account.Id, stopStartServices: false);
 
             // assert not founds
             foundAccount = McAccount.QueryById<McAccount> (defaultAccountId);


### PR DESCRIPTION
Eliminate many references to a global account id.  Add
account id as a parameter to many routines. Revamp the
startup and advanced screens to be the normal push and
return flow. Use the backend states instead of a bunch
of mutables. Status inds are used to force re-evaluate
the backend state so we do not have a second source of
truth.
