### PR TITLE
Remove some useless information from message previews

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using NachoCore.Model;
 using NachoCore;
 using NachoCore.Utils;
+using System.Text.RegularExpressions;
 
 namespace NachoClient.iOS
 {
@@ -617,8 +618,7 @@ namespace NachoClient.iOS
             // Preview label view
             var previewLabelView = (UILabel)cell.ContentView.ViewWithTag (PREVIEW_TAG);
             previewLabelView.Hidden = false;
-            var rawPreview = message.GetBodyPreviewOrEmpty ();
-            var cookedPreview = System.Text.RegularExpressions.Regex.Replace (rawPreview, @"\s+", " ");
+            var cookedPreview = AdjustPreviewText (message.GetBodyPreviewOrEmpty ());
             using (var text = new NSAttributedString (cookedPreview)) {
                 previewLabelView.AttributedText = text;
             }
@@ -636,6 +636,20 @@ namespace NachoClient.iOS
                 reminderImageView.Hidden = true;
                 reminderLabelView.Hidden = true;
             }
+        }
+
+        /// <summary>
+        /// Compress the message preview so it is more tightly packed with useful information.
+        /// Remove some pieces that the user is unlikely to find useful.  Collapse adjacent
+        /// white space into a single space character.
+        /// </summary>
+        protected string AdjustPreviewText (string raw)
+        {
+            return Regex.Replace (Regex.Replace (Regex.Replace (Regex.Replace (raw,
+                @"\[(http|image|cid).*\]", ""),
+                @"<http.*>", ""),
+                @"\s+", " "),
+                @"^\s", "");
         }
 
         protected void ConfigureDraftMessageCell (UITableView tableView, UITableViewCell cell, int messageThreadIndex)


### PR DESCRIPTION
Remove the following strings from message previews that appear in
message list views:
    `\[http.*\]`
    `\[cid.*\]`
    `\[image.*\]`
    `<http.*>`
These strings are usually less useful to the user that the other
information around them, so it is best to not display them in the very
small message preview field.

This update improves nachocove/qa#3, but it does not fully resolve the
issue.  More work needs to be done to close the issue.
