### PR TITLE
Add company name to contact index. Fix bug in updating index version by adding a specialized update version.

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -282,7 +282,7 @@ namespace NachoCore.Brain
                 Log.Info (Log.LOG_BRAIN, "{0} contacts indexed", numIndexed);
             }
             if (0 != bytesIndexed) {
-                Log.Info (Log.LOG_BRAIN, "{0:NO} bytes indexed", bytesIndexed);
+                Log.Info (Log.LOG_BRAIN, "{0:N0} bytes indexed", bytesIndexed);
             }
             return numIndexed;
         }

--- a/NachoClient.Android/NachoCore/Brain/NcBrainActions.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainActions.cs
@@ -190,6 +190,7 @@ namespace NachoCore.Brain
                 FirstName = contact.FirstName,
                 MiddleName = contact.MiddleName,
                 LastName = contact.LastName,
+                CompanyName = contact.CompanyName,
             };
 
             // Add all email address, phone numbers and addresses
@@ -237,7 +238,7 @@ namespace NachoCore.Brain
             }
 
             contact.SetIndexVersion ();
-            contact.Update ();
+            contact.UpdateIndexVersion ();
 
             return true;
         }

--- a/NachoClient.Android/NachoCore/Index/Index.cs
+++ b/NachoClient.Android/NachoCore/Index/Index.cs
@@ -205,6 +205,7 @@ namespace NachoCore.Index
                 "first_name",
                 "middle_name",
                 "last_name",
+                "company_name",
                 "email_address",
                 "phone_number",
                 "address",

--- a/NachoClient.Android/NachoCore/Index/IndexDocument.cs
+++ b/NachoClient.Android/NachoCore/Index/IndexDocument.cs
@@ -115,6 +115,7 @@ namespace NachoCore.Index
         public List<string> PhoneNumbers;
         public List<string> Addresses;
         public string Note;
+        public string CompanyName;
 
         public ContactIndexParameters ()
         {
@@ -144,6 +145,7 @@ namespace NachoCore.Index
             AddIndexedField ("first_name", contact.FirstName);
             AddIndexedField ("middle_name", contact.MiddleName);
             AddIndexedField ("last_name", contact.LastName);
+            AddIndexedField ("company_name", contact.CompanyName);
             foreach (var emailAddress in contact.EmailAddresses) {
                 AddIndexedField ("email_address", emailAddress);
             }

--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -808,6 +808,14 @@ namespace NachoCore.Model
             });
         }
 
+        public void UpdateIndexVersion ()
+        {
+            NcModel.Instance.BusyProtect (() => {
+                return NcModel.Instance.Db.Execute ("UPDATE McContact SET IndexVersion = ? WHERE Id = ?",
+                    IndexVersion, Id);
+            });
+        }
+
         public override int Delete ()
         {
             // Force an auxilary read


### PR DESCRIPTION
- Steve asked McContact.CompanyName to be indexed as well.
- During the clean up or PR #1954 , I moved the NcBrain.UnindexContact() call from ContactEditViewController in order to handle the case a contact is updated remotely and needs to be re-indexed. But IndexContact() uses the same Update() and it ends up always unindexing a contact after it index it.
- The fix is to create a McContact.UpdateIndexVersion() which is used by IndexContact().
