### PR TITLE
Correctly handle RTF bodies

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McAbstrCalendarRoot.cs
+++ b/NachoClient.Android/NachoCore/Model/McAbstrCalendarRoot.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using NachoCore.Utils;
 using MimeKit;
 using System.IO;
+using NachoCore.ActiveSync;
 
 namespace NachoCore.Model
 {
@@ -258,19 +259,21 @@ namespace NachoCore.Model
                         cachedDescription = body.GetContentsString ();
                         cachedDescriptionType = McAbstrFileDesc.BodyTypeEnum.HTML_2;
                         break;
+                    case McAbstrFileDesc.BodyTypeEnum.RTF_3:
+                        cachedDescription = AsHelpers.Base64CompressedRtfToNormalRtf (body.GetContentsString ());
+                        cachedDescriptionType = McAbstrFileDesc.BodyTypeEnum.RTF_3;
+                        break;
                     case McAbstrFileDesc.BodyTypeEnum.MIME_4:
                         if (!MimeHelpers.FindTextWithType (
-                            MimeHelpers.LoadMessage (body), out cachedDescription, out cachedDescriptionType,
-                            McAbstrFileDesc.BodyTypeEnum.PlainText_1, McAbstrFileDesc.BodyTypeEnum.HTML_2,
-                            McAbstrFileDesc.BodyTypeEnum.RTF_3))
-                        {
+                                MimeHelpers.LoadMessage (body), out cachedDescription, out cachedDescriptionType,
+                                McAbstrFileDesc.BodyTypeEnum.PlainText_1, McAbstrFileDesc.BodyTypeEnum.HTML_2,
+                                McAbstrFileDesc.BodyTypeEnum.RTF_3)) {
                             // Couldn't find anything in the message.  Set the description to empty plain text.
                             cachedDescription = "";
                             cachedDescriptionType = McAbstrFileDesc.BodyTypeEnum.PlainText_1;
                         }
                         break;
                     default:
-                        // TODO Handle RTF correctly.
                         cachedDescription = body.GetContentsString ();
                         cachedDescriptionType = McAbstrFileDesc.BodyTypeEnum.PlainText_1;
                         break;

--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -918,12 +918,19 @@ namespace NachoClient.iOS
 
         protected string ConvertToPlainText (string formattedText, NSDocumentType type)
         {
-            NSError error = null;
-            var descriptionData = NSData.FromString (formattedText);
-            var descriptionAttributed = new NSAttributedString (descriptionData, new NSAttributedStringDocumentAttributes {
-                DocumentType = type
-            }, ref error);
-            return descriptionAttributed.Value;
+            try {
+                NSError error = null;
+                var descriptionData = NSData.FromString (formattedText);
+                var descriptionAttributed = new NSAttributedString (descriptionData, new NSAttributedStringDocumentAttributes {
+                    DocumentType = type
+                }, ref error);
+                return descriptionAttributed.Value;
+            } catch (Exception e) {
+                // The NSAttributedString init: routine will fail if formattedText is not the specified type.
+                // We don't want to crash the app in this case.
+                Log.Warn (Log.LOG_CALENDAR, "Calendar body has unexpected format and will be treated as plain text: {0}", e.ToString());
+                return formattedText;
+            }
         }
 
         protected McFolder GetCalendarFolder ()

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -170,7 +170,7 @@ namespace NachoClient.iOS
                 RenderHtmlString (body.GetContentsString ());
                 break;
             case McAbstrFileDesc.BodyTypeEnum.RTF_3:
-                RenderRtfString (body.GetContentsString ());
+                RenderRtfString (AsHelpers.Base64CompressedRtfToNormalRtf (body.GetContentsString ()));
                 break;
             case McAbstrFileDesc.BodyTypeEnum.MIME_4:
                 RenderMime (body);


### PR DESCRIPTION
Fix the app to correctly handle RTF item bodies.  (This does not
affect the handling of MIME messages with a "text/rtf" part.  That
code was already correct.  This fixes the case where the ActiveSync
body type is RTF.  The sync options that the app uses means that the
app should never receive an RTF body.  But in case the server ignores
the options and sends an RTF body, the app should do the right thing.)

The server sends RTF bodies in a base-64 compressed format.  The app
was expecting normal RTF.  Fix the app to convert the base-64
compressed RTF into normal RTF before attempting to display the RTF.

Fix nachocove/qa#375
