### PR TITLE
Improve the algorithm for stripping junk from message previews

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -98,11 +98,7 @@ namespace NachoCore.ActiveSync
                     bodyText = xmlData.Value;
                 }
                 if (null == xmlPreview) {
-                    if (255 >= bodyText.Length) {
-                        item.BodyPreview = bodyText;
-                    } else {
-                        item.BodyPreview = bodyText.Substring (0, 255);
-                    }
+                    item.BodyPreview = bodyText;
                 }
             }
         }

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
@@ -215,20 +215,13 @@ namespace NachoCore.ActiveSync
                     switch (classCodeEnum) {
                     case McAbstrFolderEntry.ClassCodeEnum.Email:
                         options.Add (new XElement (m_ns + Xml.AirSync.FilterType, (uint)perFolder.FilterCode));
-                        // If the server supports previews, then ask for 0-sized MIME with a preview.
-                        // Otherwise, ask for 255 bytes of plain text.
-                        if (BEContext.Server.HostIsGMail () || 14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion)) {
-                            options.Add (MimeSupportElement (Xml.AirSync.MimeSupportCode.NoMime_0));
-                            options.Add (new XElement (m_baseNs + Xml.AirSync.BodyPreference,
-                                new XElement (m_baseNs + Xml.AirSyncBase.Type, (uint)Xml.AirSync.TypeCode.PlainText_1),
-                                new XElement (m_baseNs + Xml.AirSyncBase.TruncationSize, "255")));
-                        } else {
-                            options.Add (MimeSupportElement (Xml.AirSync.MimeSupportCode.AllMime_2));
-                            options.Add (new XElement (m_baseNs + Xml.AirSync.BodyPreference,
-                                new XElement (m_baseNs + Xml.AirSyncBase.Type, (uint)Xml.AirSync.TypeCode.Mime_4),
-                                new XElement (m_baseNs + Xml.AirSyncBase.TruncationSize, "0"),
-                                new XElement (m_baseNs + Xml.AirSyncBase.Preview, "255")));
-                        }
+                        options.Add (MimeSupportElement (Xml.AirSync.MimeSupportCode.NoMime_0));
+                        // Some servers support a preview option, but that is limited by the spec to 255 bytes.
+                        // The app wants more than that, so it can have some useful text left after stripping
+                        // away all the junk.  For all servers, ask for a plain text body truncated to 500 bytes.
+                        options.Add (new XElement (m_baseNs + Xml.AirSync.BodyPreference,
+                            new XElement (m_baseNs + Xml.AirSyncBase.Type, (uint)Xml.AirSync.TypeCode.PlainText_1),
+                            new XElement (m_baseNs + Xml.AirSyncBase.TruncationSize, "500")));
                         break;
 
                     case McAbstrFolderEntry.ClassCodeEnum.Calendar:

--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -10,6 +10,7 @@ using NachoCore.Model;
 using NachoCore;
 using NachoCore.Utils;
 using System.Text.RegularExpressions;
+using HtmlAgilityPack;
 
 namespace NachoClient.iOS
 {
@@ -645,11 +646,40 @@ namespace NachoClient.iOS
         /// </summary>
         protected string AdjustPreviewText (string raw)
         {
-            return Regex.Replace (Regex.Replace (Regex.Replace (Regex.Replace (raw,
-                @"\[(http|image|cid).*\]", ""),
-                @"<http.*>", ""),
-                @"\s+", " "),
-                @"^\s", "");
+            Log.Info (Log.LOG_UI, "AdjustPreviewText:\n{0}", raw);
+            string adjusted = null;
+            if (raw.StartsWith ("<") && (raw.Contains ("<body") || raw.Contains ("<BODY"))) {
+                // It looks like it might be HTML.  Parse it as such and see if a <body> tag can be found.
+                HtmlDocument html = new HtmlDocument ();
+                // Some tags, such as <p> and <br>, become white space when rendered.  Since we are just
+                // pulling out the text, not rendering it, we want to convert those tags to white space
+                // right now.  If this is not done, then "<p>Call me Ishmael.</p><p>Some years ago" will
+                // display as "Call me Ishmael.Some years ago" instead of "Call me Ishmael. Some years ago".
+                html.LoadHtml (Regex.Replace (raw, @"<(/?[Pp]|[Bb][Rr]\s*/?)>", " "));
+                foreach (var bodyNode in html.DocumentNode.Descendants ("body")) {
+                    adjusted = Regex.Replace (Regex.Replace (bodyNode.InnerText, @"\s+", " "), @"^\s", "");
+                    break;
+                }
+            }
+            if (null == adjusted) {
+                adjusted = Regex.Replace (Regex.Replace (Regex.Replace (Regex.Replace (Regex.Replace (raw,
+                    @"\[(http|image|cid|img_).*?\]", " "),
+                    @"<(http|mailto)\S*?>", " "),
+                    @"https?:\S*", " "),
+                    @"\s+", " "),
+                    @"^\s", "");
+                if (adjusted.EndsWith ("< ") && !adjusted.EndsWith ("<< ")) {
+                    // The trailing '<' is probably left over from an incomplete "<http://...".  It is not useful
+                    // by itself, so strip it off.
+                    adjusted = adjusted.Substring (0, adjusted.Length - 2);
+                }
+            }
+            if (10 > adjusted.Length) {
+                // The adjustments stripped out almost everything.  What's left is probably not useful.
+                // Use the raw text, only collapsing the white space.
+                adjusted = Regex.Replace (raw, @"\s+", " ");
+            }
+            return adjusted;
         }
 
         protected void ConfigureDraftMessageCell (UITableView tableView, UITableViewCell cell, int messageThreadIndex)


### PR DESCRIPTION
The algorithm for adjusting message preview text has been improved.
See the code for details.

To have useful text left over after stripping out the junk, the amount
of data initially fetched had to be increased from 255 bytes to 500
bytes (which is the same amount of data that iOS Mail and Outlook
Mobile fetch for their previews).  But the <Preview> element in
ActiveSync is limited to 255 bytes, so the app had to be changed to
not use <Preview> at all instead ask for 500 bytes of the plain text
version of the body.

Fix nachocove/qa#3
