### PR TITLE
Increase preview fetch size from 255 bytes to 500 bytes

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -98,11 +98,7 @@ namespace NachoCore.ActiveSync
                     bodyText = xmlData.Value;
                 }
                 if (null == xmlPreview) {
-                    if (255 >= bodyText.Length) {
-                        item.BodyPreview = bodyText;
-                    } else {
-                        item.BodyPreview = bodyText.Substring (0, 255);
-                    }
+                    item.BodyPreview = bodyText;
                 }
             }
         }

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
@@ -215,20 +215,13 @@ namespace NachoCore.ActiveSync
                     switch (classCodeEnum) {
                     case McAbstrFolderEntry.ClassCodeEnum.Email:
                         options.Add (new XElement (m_ns + Xml.AirSync.FilterType, (uint)perFolder.FilterCode));
-                        // If the server supports previews, then ask for 0-sized MIME with a preview.
-                        // Otherwise, ask for 255 bytes of plain text.
-                        if (BEContext.Server.HostIsGMail () || 14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion)) {
-                            options.Add (MimeSupportElement (Xml.AirSync.MimeSupportCode.NoMime_0));
-                            options.Add (new XElement (m_baseNs + Xml.AirSync.BodyPreference,
-                                new XElement (m_baseNs + Xml.AirSyncBase.Type, (uint)Xml.AirSync.TypeCode.PlainText_1),
-                                new XElement (m_baseNs + Xml.AirSyncBase.TruncationSize, "255")));
-                        } else {
-                            options.Add (MimeSupportElement (Xml.AirSync.MimeSupportCode.AllMime_2));
-                            options.Add (new XElement (m_baseNs + Xml.AirSync.BodyPreference,
-                                new XElement (m_baseNs + Xml.AirSyncBase.Type, (uint)Xml.AirSync.TypeCode.Mime_4),
-                                new XElement (m_baseNs + Xml.AirSyncBase.TruncationSize, "0"),
-                                new XElement (m_baseNs + Xml.AirSyncBase.Preview, "255")));
-                        }
+                        options.Add (MimeSupportElement (Xml.AirSync.MimeSupportCode.NoMime_0));
+                        // Some servers support a preview option, but that is limited by the spec to 255 bytes.
+                        // The app wants more than that, so it can have some useful text left after stripping
+                        // away all the junk.  For all servers, ask for a plain text body truncated to 500 bytes.
+                        options.Add (new XElement (m_baseNs + Xml.AirSync.BodyPreference,
+                            new XElement (m_baseNs + Xml.AirSyncBase.Type, (uint)Xml.AirSync.TypeCode.PlainText_1),
+                            new XElement (m_baseNs + Xml.AirSyncBase.TruncationSize, "500")));
                         break;
 
                     case McAbstrFolderEntry.ClassCodeEnum.Calendar:


### PR DESCRIPTION
Now that the app strips junk from the message preview text, 255 bytes
is not big enough to consistently have enough useful text left over
after stripping away the junk.  So increase the preview fetch size to
500 bytes.  (That is still not big enough for all messages, but it is
big enough for most, and it is the size used by iOS Mail and Outlook
Mobile.)  Unfortunately the `<Preview>` sync option is limited by the
spec to 255 bytes.  So the app has to stop using `<Preview>` and instead
ask for a plain text body truncated to 500 bytes.
