### PR TITLE
Device calendar items should always have a body

### DIFF
--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -118,10 +118,8 @@ namespace NachoPlatform
                     cal.OrganizerEmail = TryExtractEmailAddress (Event.Organizer);
                 }
 
-                if (null != Event.Notes) {
-                    var body = McBody.InsertFile (accountId, McAbstrFileDesc.BodyTypeEnum.PlainText_1, Event.Notes);
-                    cal.BodyId = body.Id;
-                }
+                var body = McBody.InsertFile (accountId, McAbstrFileDesc.BodyTypeEnum.PlainText_1, Event.Notes ?? "");
+                cal.BodyId = body.Id;
 
                 cal.ResponseTypeIsSet = true;
                 switch (Event.Status) {


### PR DESCRIPTION
It is assumed that a McCalendar item always has an associated McBody
item, even if the body is empty.  When creating McCalendar items from
the device calendar, always give the item a McBody.
