### PR TITLE
Notify the app when changes are copied from the device calendar

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NcDeviceCalendars.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcDeviceCalendars.cs
@@ -86,6 +86,7 @@ namespace NachoCore
                             });
                         }
                     }
+                    NcApplication.Instance.InvokeStatusIndEventInfo (McAccount.GetDeviceAccount (), NcResult.SubKindEnum.Info_CalendarSetChanged);
                 }, "NcDeviceCalendars:Process", true);
                 task.Wait (NcTask.Cts.Token);
                 NcTask.Cts.Token.ThrowIfCancellationRequested ();
@@ -98,6 +99,7 @@ namespace NachoCore
                         folder.Unlink (map.FolderEntryId, McAbstrFolderEntry.ClassCodeEnum.Calendar);
                         McCalendar.DeleteById<McCalendar> (map.FolderEntryId);
                     });
+                    NcApplication.Instance.InvokeStatusIndEventInfo (McAccount.GetDeviceAccount (), NcResult.SubKindEnum.Info_CalendarSetChanged);
                 }, "NcDeviceCalendars:Delete", true);
                 task.Wait (NcTask.Cts.Token);
                 NcTask.Cts.Token.ThrowIfCancellationRequested ();


### PR DESCRIPTION
When changes are copied from the device calendar to Nacho Mail's
calendar, the Info_CalendarSetChanged status indicator needs to be
fired so that the various parts of the app can react to the changes,
the most important being generating McEvents and updating the calendar
view.
