### PR TITLE
Use default(DateTime) instead of nullable DateTime for missing value

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NcDeviceCalendars.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcDeviceCalendars.cs
@@ -77,9 +77,10 @@ namespace NachoCore
                             Log.Error (Log.LOG_SYS, "RemoveAll found {0} for {1}/{2}", count, deviceCalendar.UniqueId, existing.Id);
                         }
                         // If present and stale, update it.
-                        if (null == deviceCalendar.LastUpdate || 
-                            null == existing.DeviceLastUpdate ||
-                            deviceCalendar.LastUpdate > existing.DeviceLastUpdate) {
+                        if (default(DateTime) == deviceCalendar.LastUpdate ||
+                            default(DateTime) == existing.DeviceLastUpdate ||
+                            deviceCalendar.LastUpdate > existing.DeviceLastUpdate)
+                        {
                             NcModel.Instance.RunInTransaction (() => {
                                 if (null != inserter.Invoke (deviceCalendar)) {
                                     folder.Unlink (existing);

--- a/NachoClient.Android/NachoCore/Model/McCalendar.cs
+++ b/NachoClient.Android/NachoCore/Model/McCalendar.cs
@@ -17,10 +17,10 @@ namespace NachoCore.Model
         public string DeviceUniqueId { get; set; }
 
         /// Set only for Device calendars.
-        public DateTime? DeviceCreation { get; set; }
+        public DateTime DeviceCreation { get; set; }
 
         /// Set only for Device calendars.
-        public DateTime? DeviceLastUpdate { get; set; }
+        public DateTime DeviceLastUpdate { get; set; }
 
         /// Name of the creator of the calendar item (optional). Calendar only.
         [MaxLength (256)]

--- a/NachoClient.Android/NachoPlatform/IPlatform.cs
+++ b/NachoClient.Android/NachoPlatform/IPlatform.cs
@@ -180,7 +180,7 @@ namespace NachoPlatform
     {
         public abstract string UniqueId { get; }
 
-        public abstract DateTime? LastUpdate { get; }
+        public abstract DateTime LastUpdate { get; }
 
         public abstract NcResult ToMcCalendar ();
     }

--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -42,7 +42,11 @@ namespace NachoPlatform
 
             public override string UniqueId { get { return Event.EventIdentifier + Event.StartDate.ToString (); } }
 
-            public override DateTime? LastUpdate { get { return (null == Event.LastModifiedDate) ? null : (DateTime?)Event.LastModifiedDate.ToDateTime (); } }
+            public override DateTime LastUpdate {
+                get {
+                    return (null == Event.LastModifiedDate) ? default(DateTime) : Event.LastModifiedDate.ToDateTime ();
+                }
+            }
 
             private string TryExtractEmailAddress (EKParticipant who)
             {
@@ -84,7 +88,7 @@ namespace NachoPlatform
                 };
 
                 cal.AllDayEvent = Event.AllDay;
-                cal.DeviceLastUpdate = (null == Event.LastModifiedDate) ? null : (DateTime?)Event.LastModifiedDate.ToDateTime ();
+                cal.DeviceLastUpdate = (null == Event.LastModifiedDate) ? default(DateTime) : Event.LastModifiedDate.ToDateTime ();
                 cal.DeviceCreation = (null == Event.CreationDate) ? cal.DeviceLastUpdate : Event.CreationDate.ToDateTime ();
                 cal.DeviceUniqueId = UniqueId;
 


### PR DESCRIPTION
Use `default(DateTime)` (a.k.a. `DateTime.MinValue`) as an indication
that the field does not have a value, rather than using a nullable
DateTime (`DateTime?`).  This is the convention we have used so far,
and I don't see a compelling reason to change it.
