### PR TITLE
Don't check MIME content type when resolving a cid: URL

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/PlatformHelpers.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/PlatformHelpers.cs
@@ -92,58 +92,23 @@ namespace NachoClient
         }
 
         /// <summary>
-        /// Renders the image from a MIME part.
-        /// Supported Image Formats & Filename extensions
-        /// Tagged Image File Format (TIFF) .tiff, .tif
-        /// Joint Photographic Experts Group (JPEG) .jpg, .jpeg
-        /// Graphic Interchange Format (GIF) .gif
-        /// Portable Network Graphic (PNG) .png
-        /// Windows Bitmap Format (DIB) .bmp, .BMPf
-        /// Windows Icon Format .ico
-        /// Windows Cursor .cur
-        /// X Window System bitmap .xbm
+        /// Renders the image from a MIME part.  Just pass the data to UIImage.LoadFromData() and
+        /// see if that routine can parse the data as an image.  Don't check the MIME content type
+        /// or try to figure what kind of image it is.  (Not checking the content type is because
+        /// we have seen a real message where the sender put the image in an application/octet-stream
+        /// section instead of an image/jpeg section.)
         /// </summary>
         /// <returns>The image as a UIImage or null if the image type isn't supported.</returns>
         /// <param name="part">The MIME part.</param>
         static public UIImage RenderImage (MimePart part)
         {
-            if (!part.ContentType.Matches ("image", "*")) {
-                return null;
-            }
-            if (!RendersToUIImage (part)) {
-                return null;
-            }
-
             using (var content = new MemoryStream ()) {
-                // If the content is base64 encoded (which it probably is), decode it.
                 part.ContentObject.DecodeTo (content);
                 content.Seek (0, SeekOrigin.Begin);
                 var data = NSData.FromStream (content);
                 var image = UIImage.LoadFromData (data);
                 return image;
             }
-        }
-
-        static public bool RendersToUIImage (MimePart part)
-        {
-            string[] subtype = {
-                "tiff",
-                "jpeg",
-                "jpg",
-                "gif",
-                "png",
-                "x-icon",
-                " vnd.microsoft.ico",
-                "x-win-bitmap",
-                "x-xbitmap",
-            };
-
-            foreach (var s in subtype) {
-                if (part.ContentType.Matches ("image", s)) {
-                    return true;
-                }
-            }
-            return false;
         }
 
         static public UIImage RenderStringToImage (string value)


### PR DESCRIPTION
When resolving a cid: URL (which is used to reference an image that is
in another MIME entity in the same message body), don't check the
content type of the MIME entity with the image.  We have seen a
message where the content type for the image was wrong.  The app
should be permissive when parsing inputs and should be able to display
the image anyway.

Fix https://support.nachocove.com/helpdesk/tickets/99
