### PR TITLE
Generalize WBXML JSON files to support IMAP requests and responses. Fix a bug in enforcing the max duration of a JSON file.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -154,23 +154,29 @@ namespace NachoCore.Utils
             RecordJsonEvent (type, jsonEvent);
         }
 
-        public static void RecordWbxmlEvent (bool isRequest, byte[] wbxml)
+        protected static void RecordProtocolEvent (TelemetryEventType type, byte[] payload)
         {
             if (!ENABLED) {
                 return;
             }
 
-            TelemetryEventType type;
-            if (isRequest) {
-                type = TelemetryEventType.WBXML_REQUEST;
-            } else {
-                type = TelemetryEventType.WBXML_RESPONSE;
-            }
             // TODO - Add check for the limit of wbxml. But we need to limit the base64 encode no the binary bytes.
-            var jsonEvent = new TelemetryWbxmlEvent (type) {
-                wbxml = wbxml
+            var jsonEvent = new TelemetryProtocolEvent (type) {
+                payload = payload,
             };
             RecordJsonEvent (type, jsonEvent);
+        }
+
+        public static void RecordWbxmlEvent (bool isRequest, byte[] wbxml)
+        {
+            var type = isRequest ? TelemetryEventType.WBXML_REQUEST : TelemetryEventType.WBXML_RESPONSE;
+            RecordProtocolEvent (type, wbxml);
+        }
+
+        public static void RecordImapEvent (bool isRequest, byte[] payload)
+        {
+            var type = isRequest ? TelemetryEventType.IMAP_REQUEST : TelemetryEventType.IMAP_RESPONSE;
+            RecordProtocolEvent (type, payload);
         }
 
         public static void RecordCounter (string name, Int64 count, DateTime start, DateTime end)

--- a/NachoClient.Android/NachoCore/Utils/TelemetryEvent.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryEvent.cs
@@ -26,6 +26,8 @@ namespace NachoCore.Utils
         SAMPLES,
         DISTRIBUTION,
         STATISTICS2,
+        IMAP_REQUEST,
+        IMAP_RESPONSE,
         MAX_TELEMETRY_EVENT_TYPE,
     };
 

--- a/NachoClient.Android/NachoCore/Utils/TelemetryJsonEvent.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryJsonEvent.cs
@@ -67,28 +67,37 @@ namespace NachoCore.Utils
         }
     }
 
-    public class TelemetryWbxmlEvent : TelemetryJsonEvent
+    public class TelemetryProtocolEvent : TelemetryJsonEvent
     {
-        public const string REQUEST = "WBXML_REQUEST";
-        public const string RESPONSE = "WBXML_RESPONSE";
+        public const string WBXML_REQUEST = "WBXML_REQUEST";
+        public const string WBXML_RESPONSE = "WBXML_RESPONSE";
+        public const string IMAP_REQUEST = "IMAP_REQUEST";
+        public const string IMAP_RESPONSE = "IMAP_RESPONSE";
 
-        public byte[] wbxml;
+        public byte[] payload;
 
-        public TelemetryWbxmlEvent () : this (TelemetryEventType.WBXML_REQUEST)
+        public TelemetryProtocolEvent () : this (TelemetryEventType.WBXML_REQUEST)
         {
         }
 
-        public TelemetryWbxmlEvent (TelemetryEventType type)
+        public TelemetryProtocolEvent (TelemetryEventType type)
         {
             switch (type) {
             case TelemetryEventType.WBXML_REQUEST:
-                event_type = REQUEST;
+                event_type = WBXML_REQUEST;
                 break;
             case TelemetryEventType.WBXML_RESPONSE:
-                event_type = RESPONSE;
+                event_type = WBXML_RESPONSE;
+                break;
+            case TelemetryEventType.IMAP_REQUEST:
+                event_type = IMAP_REQUEST;
+                break;
+            case TelemetryEventType.IMAP_RESPONSE:
+                event_type = IMAP_RESPONSE;
                 break;
             default:
-                throw new NcAssert.NachoDefaultCaseFailure (String.Format ("RecordWbxmlEvent: unexpected type {0}", type));
+                var msg = String.Format ("TelemetryProtocolEvent: unexpected type {0}", type);
+                throw new NcAssert.NachoDefaultCaseFailure (msg);
             }
         }
     }

--- a/Test.Android/TelemetryJsonEventTest.cs
+++ b/Test.Android/TelemetryJsonEventTest.cs
@@ -75,22 +75,22 @@ namespace Test.Common
         public void TelemetryWbxmlEvent ()
         {
             var now = DateTime.UtcNow;
-            var jsonEvent1 = new TelemetryWbxmlEvent (TelemetryEventType.WBXML_REQUEST) {
-                wbxml = new byte[3] { 0x1, 0x2, 0x3 },
+            var jsonEvent1 = new TelemetryProtocolEvent (TelemetryEventType.WBXML_REQUEST) {
+                payload = new byte[3] { 0x1, 0x2, 0x3 },
             };
             var json1 = jsonEvent1.ToJson ();
-            var decode1 = JsonConvert.DeserializeObject<TelemetryWbxmlEvent> (json1);
+            var decode1 = JsonConvert.DeserializeObject<TelemetryProtocolEvent> (json1);
             CheckCommonHeader (now, decode1);
-            Assert.AreEqual (jsonEvent1.wbxml, decode1.wbxml);
+            Assert.AreEqual (jsonEvent1.payload, decode1.payload);
 
             now = DateTime.UtcNow;
-            var jsonEvent2 = new TelemetryWbxmlEvent (TelemetryEventType.WBXML_RESPONSE) {
-                wbxml = new byte[4] { 0x9, 0x8, 0x7, 0x6 },
+            var jsonEvent2 = new TelemetryProtocolEvent (TelemetryEventType.WBXML_RESPONSE) {
+                payload = new byte[4] { 0x9, 0x8, 0x7, 0x6 },
             };
             var json2 = jsonEvent2.ToJson ();
-            var decode2 = JsonConvert.DeserializeObject<TelemetryWbxmlEvent> (json2);
+            var decode2 = JsonConvert.DeserializeObject<TelemetryProtocolEvent> (json2);
             CheckCommonHeader (now, decode2);
-            Assert.AreEqual (jsonEvent2.wbxml, decode2.wbxml);
+            Assert.AreEqual (jsonEvent2.payload, decode2.payload);
         }
 
         [Test]


### PR DESCRIPTION
- TelemetryWbxmlEvent are renamed TelemetryProtocolEvent.
- 'wbxml' field is renamed to 'payload'.
- Add unit tests.
