### PR TITLE
Fix nachocove/qa#409

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
@@ -774,26 +774,10 @@ namespace NachoClient
 
         public static string GetVersionNumber ()
         {
-            var devBundleId = NSBundle.FromIdentifier ("com.nachocove.nachomail");
-            var betaBundleId = NSBundle.FromIdentifier ("com.nachocove.nachomail.beta");
-            var alphaBundleId = NSBundle.FromIdentifier ("com.nachocove.nachomail.alpha");
-
-            if (devBundleId != null) {
-                var build = devBundleId.InfoDictionary ["CFBundleVersion"];
-                var version = devBundleId.InfoDictionary ["CFBundleShortVersionString"].ToString ();
-                return String.Format ("{0} ({1})", version, build);
-            } 
-            if (betaBundleId != null) {
-                var build = betaBundleId.InfoDictionary ["CFBundleVersion"];
-                var version = betaBundleId.InfoDictionary ["CFBundleShortVersionString"].ToString ();
-                return String.Format ("{0} ({1})", version, build);
-            } 
-            if (alphaBundleId != null) {
-                var build = alphaBundleId.InfoDictionary ["CFBundleVersion"];
-                var version = alphaBundleId.InfoDictionary ["CFBundleShortVersionString"].ToString ();
-                return String.Format ("{0} ({1})", version, build);
-            } 
-            return "Unknown version";
+            var bundle = NSBundle.MainBundle;
+            var build = bundle.InfoDictionary ["CFBundleVersion"].ToString ();
+            var version = bundle.InfoDictionary ["CFBundleShortVersionString"].ToString ();
+            return String.Format ("{0} ({1})", version, build);
         }
 
         public static UITableView FindEnclosingTableView (UIView view)


### PR DESCRIPTION
The existing code have some hard coded bundle IDs but did not have the one for the App Store release. We can just get the main bundle instead of getting bundle by a set of identifiers.
