### PR TITLE
Manually delete existing .gz JSON files before creating (or recreating) it.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -377,6 +377,9 @@ namespace NachoCore.Utils
             }
 
             var gzJsonFilePath = jsonFilePath + ".gz";
+            if (File.Exists (gzJsonFilePath)) {
+                File.Delete (gzJsonFilePath); // last upload could be aborted.
+            }
             using (var jsonStream = File.Open (jsonFilePath, FileMode.Open, FileAccess.Read))
             using (var gzJsonStream = File.Open (gzJsonFilePath, FileMode.CreateNew, FileAccess.Write))
             using (var gzipStream = new GZipStream (gzJsonStream, CompressionMode.Compress)) {


### PR DESCRIPTION
- If the gz JSON file exists, delete it before recreating it.
- The reason for not using the existing file is that it could be incomplete. (E.g. crash during writing gzip.)
