### PR TITLE
Use the invariant locale when parsing ASProtocolVersion

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -349,7 +349,7 @@ namespace NachoCore.ActiveSync
                 xmlAppData.Add (xmlExceptions);
             }
 
-            if (cal.ResponseRequestedIsSet && 14.0 <= Convert.ToDouble (beContext.ProtocolState.AsProtocolVersion)) {
+            if (cal.ResponseRequestedIsSet && 14.0 <= Convert.ToDouble (beContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 xmlAppData.Add (new XElement (CalendarNs + Xml.Calendar.ResponseRequested, XmlFromBool (cal.ResponseRequested)));
             }
             if (cal.DisallowNewTimeProposalIsSet) {

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
@@ -242,7 +242,7 @@ namespace NachoCore.ActiveSync
         {
             NcResult result = NcResult.Error (NcResult.SubKindEnum.Error_UnknownCommandFailure);
             Log.Info (Log.LOG_AS, "SmartEmailCmd({0},{1},{2},{3},{4})", Op, newEmailMessageId, refdEmailMessageId, folderId, originalEmailIsEmbedded);
-            if (originalEmailIsEmbedded && 14.0 > Convert.ToDouble (ProtocolState.AsProtocolVersion)) {
+            if (originalEmailIsEmbedded && 14.0 > Convert.ToDouble (ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 return SendEmailCmd (newEmailMessageId);
             }
             McFolder folder;
@@ -1162,7 +1162,7 @@ namespace NachoCore.ActiveSync
                 // In this (these?) scenarios, update the Cal item in the DB, and Sync the change to the server.
                 //
                 if (Xml.FolderHierarchy.TypeCode.DefaultInbox_2 != folder.Type &&
-                14.1 > Convert.ToDouble (ProtocolState.AsProtocolVersion)) {
+                    14.1 > Convert.ToDouble (ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                     var cal = item as McCalendar;
                     if (null == cal) {
                         result = NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsOptionsCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsOptionsCommand.cs
@@ -64,10 +64,19 @@ namespace NachoCore.ActiveSync
                 }
                 var value = values.First ();
                 Log.Info (Log.LOG_AS, "AsOptionsCommand: MS-ASProtocolVersions: {0}", value);
-                float[] float_versions = Array.ConvertAll (value.Split (','), x => float.Parse (x));
+                float[] float_versions;
+                try {
+                    float_versions = Array.ConvertAll (value.Split (','), x => float.Parse (x, System.Globalization.CultureInfo.InvariantCulture));
+                } catch (FormatException e) {
+                    Log.Error (Log.LOG_AS, "FormatException \"{0}\" while parsing MS-ASProtocolVersions. Defaulting to version 12.1", e.Message);
+                    float_versions = new float[] { 12.1f };
+                } catch (OverflowException e) {
+                    Log.Error (Log.LOG_AS, "OverflowException \"{0}\" while parsing MS-ASProtocolVersions. Defaulting to version 12.1", e.Message);
+                    float_versions = new float[] { 12.1f };
+                }
                 Array.Sort (float_versions);
                 Array.Reverse (float_versions);
-                string[] versions = Array.ConvertAll (float_versions, x => x.ToString ("0.0"));
+                string[] versions = Array.ConvertAll (float_versions, x => x.ToString ("0.0", System.Globalization.CultureInfo.InvariantCulture));
                 protocolState.AsProtocolVersion = versions [0];
             } else {
                 Log.Error (Log.LOG_AS, "AsOptionsCommand: Could not retrieve MS-ASProtocolVersions. Defaulting to 12.0");

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSendMailCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSendMailCommand.cs
@@ -26,7 +26,7 @@ namespace NachoCore.ActiveSync
 
         public override Dictionary<string,string> ExtraQueryStringParams (AsHttpOperation Sender)
         {
-            if (14.0 <= Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion)) {
+            if (14.0 <= Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 return null;
             }
             return new Dictionary<string, string> () {
@@ -41,7 +41,7 @@ namespace NachoCore.ActiveSync
 
         protected override XDocument ToXDocument (AsHttpOperation Sender)
         {
-            if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion)) {
+            if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 return null;
             }
             var mimePath = EmailMessage.MimePath ();
@@ -59,7 +59,7 @@ namespace NachoCore.ActiveSync
 
         protected override Stream ToMime (AsHttpOperation Sender)
         {
-            if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion)) {
+            if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 long length;
                 var stream = EmailMessage.ToMime (out length);
                 Timeout = new TimeSpan (0, 0, BEContext.ProtoControl.SyncStrategy.UploadTimeoutSecs (length));

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSmartCommand/AsSmartCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSmartCommand/AsSmartCommand.cs
@@ -24,7 +24,7 @@ namespace NachoCore.ActiveSync
 
         public override Dictionary<string,string> ExtraQueryStringParams (AsHttpOperation Sender)
         {
-            if (14.0 <= Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion)) {
+            if (14.0 <= Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 return null;
             }
 
@@ -37,7 +37,7 @@ namespace NachoCore.ActiveSync
 
         protected override XDocument ToXDocument (AsHttpOperation Sender)
         {
-            if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion)) {
+            if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 return null;
             }
             var mimePath = EmailMessage.MimePath ();
@@ -61,7 +61,7 @@ namespace NachoCore.ActiveSync
 
         protected override Stream ToMime (AsHttpOperation Sender)
         {
-            if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion)) {
+            if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 long length;
                 var stream = EmailMessage.ToMime (out length);
                 Timeout = new TimeSpan (0, 0, BEContext.ProtoControl.SyncStrategy.UploadTimeoutSecs (length));

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
@@ -217,7 +217,7 @@ namespace NachoCore.ActiveSync
                         options.Add (new XElement (m_ns + Xml.AirSync.FilterType, (uint)perFolder.FilterCode));
                         // If the server supports previews, then ask for 0-sized MIME with a preview.
                         // Otherwise, ask for 255 bytes of plain text.
-                        if (BEContext.Server.HostIsGMail () || 14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion)) {
+                        if (BEContext.Server.HostIsGMail () || 14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                             options.Add (MimeSupportElement (Xml.AirSync.MimeSupportCode.NoMime_0));
                             options.Add (new XElement (m_baseNs + Xml.AirSync.BodyPreference,
                                 new XElement (m_baseNs + Xml.AirSyncBase.Type, (uint)Xml.AirSync.TypeCode.PlainText_1),
@@ -239,7 +239,7 @@ namespace NachoCore.ActiveSync
                             // will be unformatted.  So we may as well just ask for plain text.
                             options.Add (MimeSupportElement (Xml.AirSync.MimeSupportCode.NoMime_0));
                             options.Add (BodyPreferenceElement (Xml.AirSync.TypeCode.PlainText_1));
-                        } else if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion)) {
+                        } else if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                             // Exchange 2007 will fail if we ask for MIME.  But it can handle
                             // any other format.  So ask for either HTML or plain text, with a
                             // preference for HTML
@@ -257,7 +257,7 @@ namespace NachoCore.ActiveSync
                     case McAbstrFolderEntry.ClassCodeEnum.Contact:
                         if (Xml.FolderHierarchy.TypeCode.Ric_19 == folder.Type) {
                             // Expressing BodyPreference for RIC gets Protocol Error.
-                            if (14.0 <= Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion)) {
+                            if (14.0 <= Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                                 options.Add (new XElement (m_ns + Xml.AirSync.MaxItems, "200"));
                             }
                         } else {


### PR DESCRIPTION
The app was using the current locale when parsing the
ASProtocolVersion string.  This was causing problems when the current
locale used something other than a period for the decimal separator
character.

Fix the app to always use CultureInfo.InvariantCulture when parsing
the ASProtocolVersion string.

Fix nachocove/qa#412
