### PR TITLE
Fix nachocove/qa#417

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -541,9 +541,7 @@ namespace NachoCore
             }
             // Cancel any HTTP request to pinger. Otherwise, the task that makes the HTTP request
             // may delay the PA SM from going to Park state immediately.
-            if (null != Cts) {
-                Cts.Cancel ();
-            }
+            MayCancelHttpRequest ();
             PostEvent (PAEvt.E.Park, "PAPARK");
         }
 
@@ -1097,9 +1095,11 @@ namespace NachoCore
 
         private void DisposeCts ()
         {
-            if (null != Cts) {
-                Cts.Dispose ();
-                Cts = null;
+            lock (LockObj) {
+                if (null != Cts) {
+                    Cts.Dispose ();
+                    Cts = null;
+                }
             }
         }
 
@@ -1109,7 +1109,7 @@ namespace NachoCore
             DisposeCts ();
             Cts = new CancellationTokenSource ();
             TimeoutTimer = new NcTimer ("PATimeout", (state) => {
-                Cts.Cancel ();
+                MayCancelHttpRequest ();
             }, null, new TimeSpan (0, 0, 0, 0, MaxTimeoutMsec), TimeSpan.Zero);
         }
 
@@ -1119,6 +1119,15 @@ namespace NachoCore
             DeferTimer = new NcTimer ("PADefer", (state) => {
                 Defer ();
             }, null, DeferPeriodMsec, Timeout.Infinite);
+        }
+
+        private void MayCancelHttpRequest ()
+        {
+            lock (LockObj) {
+                if (null != Cts) {
+                    Cts.Cancel ();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- The crash happens because one thread is disposing the token when another thread is signaling cancellation. And the race happens when the null check happens just before the disposal and cancellation happens right after.
- The fix is use lock to protect the HTTP timeout cancellation token.
