### PR TITLE
Change the way that the MS-ASProtocolVersions header is processed

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsOptionsCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsOptionsCommand.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Headers;
 using System.Threading;
 using NachoCore.Model;
 using NachoCore.Utils;
+using System.Text.RegularExpressions;
 
 namespace NachoCore.ActiveSync
 {
@@ -66,15 +67,12 @@ namespace NachoCore.ActiveSync
                     Log.Warn (Log.LOG_AS, "AsOptionsCommand: more than one MS-ASProtocolVersions header.");
                 }
                 var value = values.First ();
-                Log.Info (Log.LOG_AS, "AsOptionsCommand: MS-ASProtocolVersions: {0}", value);
-                // Loop through the protocol versions that the app understands, in the preferred order.
+                string[] serverVersions = Regex.Split (value, @"\s*,\s*");
+                // Loop through the protocol versions that the app understands, in the preferred order, until
+                // we find one that the server also supports.
                 bool foundMatch = false;
                 foreach (var supportedVersion in SupportedVersions) {
-                    if (value == supportedVersion ||
-                        value.StartsWith (supportedVersion + ",") ||
-                        value.EndsWith ("," + supportedVersion) ||
-                        value.Contains ("," + supportedVersion + ","))
-                    {
+                    if (serverVersions.Contains (supportedVersion)) {
                         foundMatch = true;
                         protocolState.AsProtocolVersion = supportedVersion;
                         break;
@@ -84,6 +82,7 @@ namespace NachoCore.ActiveSync
                     Log.Error (Log.LOG_AS, "AsOptionsCommand: MS-ASProtocolVersions does not contain a version supported by this client. Defaulting to version 12.0.");
                     protocolState.AsProtocolVersion = "12.0";
                 }
+                Log.Info (Log.LOG_AS, "AsOptionsCommand: Selected version {0} from MS-ASProtocolVersions: {1}", protocolState.AsProtocolVersion, value);
             } else {
                 Log.Error (Log.LOG_AS, "AsOptionsCommand: Could not retrieve MS-ASProtocolVersions. Defaulting to 12.0");
                 protocolState.AsProtocolVersion = "12.0";


### PR DESCRIPTION
When processing the MS-ASProtocolVersions header in the Options
command response, look for the protocol versions that the app
supports, rather than using whatever version has the highest numerical
value.  This change prevents the app from accidentally using a newer
version of the protocol that it doesn't understand.

Conflicts:
    NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsOptionsCommand.cs
