### PR TITLE
Get attachment content from MIME message bodies

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -343,9 +343,8 @@ namespace NachoClient.iOS
             yOffset += 1;
 
             // Message body, which is added to the scroll view, not the header view.
-            bodyView = BodyView.VariableHeightBodyView (new CGPoint (VIEW_INSET, yOffset), scrollView.Frame.Width - 2 * VIEW_INSET, scrollView.Frame.Size, LayoutView, onLinkSelected);
+            bodyView = BodyView.VariableHeightBodyView (new CGPoint (VIEW_INSET, yOffset), scrollView.Frame.Width - 2 * VIEW_INSET, scrollView.Frame.Size, BodyViewLayoutCallback, onLinkSelected);
             scrollView.AddSubview (bodyView);
-
 
             blockMenu = new UIBlockMenu (this, new List<UIBlockMenu.Block> () {
                 new UIBlockMenu.Block ("contact-quickemail", "Quick Reply", () => {
@@ -565,6 +564,15 @@ namespace NachoClient.iOS
             #if (DEBUG_UI)
             ViewHelper.DumpViews<TagType> (scrollView);
             #endif
+        }
+
+        protected void BodyViewLayoutCallback ()
+        {
+            // BodyView calls its layout delegate after the download of the body has finished.
+            // Downloading the body can result in a status change for attachments.  So we refresh
+            // the attachments in addition to laying out the view.
+            attachmentListView.Refresh ();
+            LayoutView ();
         }
 
         protected void LayoutBody ()

--- a/NachoClient.iOS/NachoUI.iOS/Support/AttachmentListView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/AttachmentListView.cs
@@ -116,6 +116,13 @@ namespace NachoClient.iOS
             ExpandedHeight += AttachmentView.VIEW_HEIGHT;
         }
 
+        public void Refresh ()
+        {
+            foreach (var attachmentView in attachmentViews) {
+                attachmentView.RefreshStatus ();
+            }
+        }
+
         protected new void Cleanup ()
         {
             base.Cleanup ();

--- a/NachoClient.iOS/NachoUI.iOS/Support/AttachmentView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/AttachmentView.cs
@@ -257,7 +257,7 @@ namespace NachoClient.iOS
             }
         }
 
-        protected void RefreshStatus ()
+        public void RefreshStatus ()
         {
             if (null == attachment) {
                 return;


### PR DESCRIPTION
When e-mail message bodies are downloaded as MIME, the message's
attachments are included in the MIME body.  Take advantage of this and
extract the attachments from the MIME body when it is first
downloaded.  (As opposed to downloading the attachments separately,
which the app was doing.)
