### PR TITLE
Extract the content of inline attachments from message bodies

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -68,7 +68,7 @@ namespace NachoCore.ActiveSync
 
                 // Now that we have a body, see if it is possible to fill in the contents of any attachments.
                 if (McBody.BodyTypeEnum.MIME_4 == body.BodyType && McBody.FilePresenceEnum.Complete == body.FilePresence && !body.Truncated) {
-                    var bodyAttachments = MimeHelpers.AllAttachments (MimeHelpers.LoadMessage (body));
+                    var bodyAttachments = MimeHelpers.AllAttachmentsIncludingInline (MimeHelpers.LoadMessage (body));
                     if (0 < bodyAttachments.Count) {
 
                         foreach (var ba in bodyAttachments) {


### PR DESCRIPTION
An earlier update enhanced the app to extract attachment contents from
downloaded message bodies.  But an oversight in that update resulted
in this working only for non-inline attachments.  This update fixes
that to also include inline attachments.
