### PR TITLE
Move strategy code for body and attachment download to AsStrategy

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/IAsStrategy.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/IAsStrategy.cs
@@ -34,10 +34,16 @@ namespace NachoCore.ActiveSync
         {
             public string ParentId { get; set; }
             public string ServerId { get; set; }
+            public Xml.AirSync.TypeCode BodyPref { get; set; }
+        }
+        public class FetchPending
+        {
+            public McPending Pending { get; set; }
+            public Xml.AirSync.TypeCode BodyPref { get; set; }
         }
         public List<FetchBody> FetchBodies { get; set; }
         public List<McAttachment> FetchAttachments { get; set; }
-        public List<McPending> Pendings { get; set; }
+        public List<FetchPending> Pendings { get; set; }
     }
 
     public class MoveKit


### PR DESCRIPTION
The code that decided whether or not to download attachments when
downloading a message body was in AsItemOperations.  That code has
been moved to AsStrategy and improved.

Improve the code in AsStrategy that figures out speculative downloads
of message bodies and attachments.  The code now takes into account
the quality of the network connection when deciding how much to
download.
