### PR TITLE
Fix several minor issues with the attendee list view

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -296,7 +296,8 @@ namespace NachoClient.iOS
             if (segue.Identifier.Equals ("EditEventToEventAttendees")) {
                 var dc = (EventAttendeeViewController)segue.DestinationViewController;
                 ExtractValues ();
-                dc.Setup (this, account, c.attendees, c, true, CalendarHelper.IsOrganizer (c.OrganizerEmail, account.EmailAddr));
+                dc.Setup (this, account, c.attendees, c, editing: true,
+                    organizer: CalendarHelper.IsOrganizer (c.OrganizerEmail, account.EmailAddr), recurring: false);
                 return;
             }
 

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -840,7 +840,7 @@ namespace NachoClient.iOS
         {
             if (segue.Identifier.Equals ("EventToEventAttendees")) {
                 var dc = (EventAttendeeViewController)segue.DestinationViewController;
-                dc.Setup (null, account, c.attendees, c, false, CalendarHelper.IsOrganizer (root.OrganizerEmail, account.EmailAddr));
+                dc.Setup (null, account, c.attendees, c, false, CalendarHelper.IsOrganizer (root.OrganizerEmail, account.EmailAddr), 0 != root.recurrences.Count);
                 return;
             }
 

--- a/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoAttendeeListChooser.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoAttendeeListChooser.cs
@@ -10,7 +10,8 @@ namespace NachoClient.iOS
 {
     public interface INachoAttendeeListChooser
     {
-        void Setup (INachoAttendeeListChooserDelegate owner, McAccount account, IList<McAttendee> attendees, McAbstrCalendarRoot c, bool editing, bool organizer);
+        void Setup (INachoAttendeeListChooserDelegate owner, McAccount account, IList<McAttendee> attendees,
+            McAbstrCalendarRoot c, bool editing, bool organizer, bool recurring);
         void DismissViewController (bool animated, Action action);
     }
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/AttendeeTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/AttendeeTableViewSource.cs
@@ -19,6 +19,7 @@ namespace NachoClient.iOS
         protected McAccount Account;
         protected bool editing = false;
         protected bool organizer = false;
+        protected bool recurring = false;
         public IAttendeeTableViewSourceDelegate owner;
         protected bool isMultiSelecting;
         protected Dictionary<NSIndexPath,McAttendee> multiSelect = null;
@@ -82,27 +83,18 @@ namespace NachoClient.iOS
             this.owner = owner;
         }
 
-        public void SetAttendeeList (List<McAttendee> attendees)
+        public void Setup (IList<McAttendee> attendees, McAccount account, bool editing, bool organizer, bool recurring)
         {
-            this.AttendeeList = new List<McAttendee> ();
-            foreach (var attendee in attendees) {
-                this.AttendeeList.Add (attendee);
-            }
-        }
-
-        public void SetEditing (bool editing)
-        {
-            this.editing = editing;
-        }
-
-        public void SetOrganizer (bool organizer)
-        {
-            this.organizer = organizer;
-        }
-
-        public void SetAccount (McAccount account)
-        {
+            SetAttendeeList (attendees);
             this.Account = account;
+            this.editing = editing;
+            this.organizer = organizer;
+            this.recurring = recurring;
+        }
+
+        public void SetAttendeeList (IList<McAttendee> attendees)
+        {
+            this.AttendeeList = new List<McAttendee> (attendees);
         }
 
         public List<McAttendee> GetAttendeeList ()
@@ -298,13 +290,15 @@ namespace NachoClient.iOS
                     view.SetAction (EMAIL_BUTTON, SwipeSide.RIGHT);
                     view.SetAction (CALL_BUTTON, SwipeSide.LEFT);
                 }
-                if (NcAttendeeType.Required == attendee.AttendeeType) {
-                    view.SetAction (MAKE_OPTIONAL_BUTTON, SwipeSide.RIGHT);
-                } else {
-                    view.SetAction (MAKE_REQUIRED_BUTTON, SwipeSide.RIGHT);
-                }
-                if (editing) {
-                    view.SetAction (DELETE_BUTTON, SwipeSide.RIGHT);
+                if (!recurring) {
+                    if (NcAttendeeType.Required == attendee.AttendeeType) {
+                        view.SetAction (MAKE_OPTIONAL_BUTTON, SwipeSide.RIGHT);
+                    } else {
+                        view.SetAction (MAKE_REQUIRED_BUTTON, SwipeSide.RIGHT);
+                    }
+                    if (editing) {
+                        view.SetAction (DELETE_BUTTON, SwipeSide.RIGHT);
+                    }
                 }
                 view.SetAction (RESEND_INVITE_BUTTON, SwipeSide.LEFT);
 
@@ -551,10 +545,10 @@ namespace NachoClient.iOS
 
         public void ChangeAttendeeType (UITableViewCell cell, McAttendee attendee)
         {
-            if (NcAttendeeType.Optional == attendee.AttendeeType) {
-                attendee.AttendeeType = NcAttendeeType.Required;
-            } else {
+            if (NcAttendeeType.Required == attendee.AttendeeType) {
                 attendee.AttendeeType = NcAttendeeType.Optional;
+            } else {
+                attendee.AttendeeType = NcAttendeeType.Required;
             }
             owner.UpdateLists ();
             owner.ConfigureAttendeeTable ();


### PR DESCRIPTION
The user is allowed to toggle the type of an attendee between required
and optional without having to edit the meeting first.  But doing this
had no effect; the change was lost.  Fix the app so this gesture does
what it is supposed to do.

Don't crash when the user taps "Send Invite" when viewing an exception
of a recurring meeting.

Don't crash when the user changes the attendee type twice in a row
when viewing an exception of a recurring meeting.  This was fixed by
disabling the "Required"/"Optional" button when viewing a recurring
meeting.  Users are currently not allowed to edit a recurring meeting,
so they shouldn't be allowed to indirectly edit it by changing the
attendee type.

Don't crash when the user deletes a meeting from another client while
the attendee list view is visible, and the proceeds to change the
attendee type twice in a row.

Fix the behavior when a meeting has an attendee with the type
"Resource".  (Such an attendee can't be created in the app, but it can
be created in some other clients.)  Previously, the app was showing
the Required button for a Resource attendee, but was changing the type
to Optional when the button was pressed.

Fix nachocove/qa#408
