### PR TITLE
Ignore status inds that are directed to an account that's not active.

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/StatusIndEventArgs.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/StatusIndEventArgs.cs
@@ -11,5 +11,16 @@ namespace NachoCore
         public McAccount Account;
         public NcResult Status;
         public string[] Tokens;
+
+        public bool AppliesToAccount (McAccount account)
+        {
+            if (null == Account) {
+                return true; // applies to all accounts
+            }
+            if (null == account) {
+                return false;
+            }
+            return (account.Id == Account.Id);
+        }
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -286,7 +286,7 @@ namespace NachoClient.iOS
             return false;
         }
 
-        public virtual bool HasAccountSwitcher()
+        public virtual bool HasAccountSwitcher ()
         {
             return false;
         }
@@ -356,15 +356,20 @@ namespace NachoClient.iOS
         public void StatusIndicatorCallback (object sender, EventArgs e)
         {
             var s = (StatusIndEventArgs)e;
-            switch (s.Status.SubKind) {
 
+            if (null != s.Account) {
+                var m = messageSource.GetNachoEmailMessages ();
+                if ((null == m) || !m.IsCompatibleWithAccount (s.Account)) {
+                    return;
+                }
+            }
+            switch (s.Status.SubKind) {
             case NcResult.SubKindEnum.Info_EmailMessageSetChanged:
             case NcResult.SubKindEnum.Info_EmailMessageSetFlagSucceeded:
             case NcResult.SubKindEnum.Info_EmailMessageClearFlagSucceeded:
             case NcResult.SubKindEnum.Info_SystemTimeZoneChanged:
                 RefreshThreadsIfVisible ();
                 break;
-
             case NcResult.SubKindEnum.Info_EmailSearchCommandSucceeded:
                 Log.Debug (Log.LOG_UI, "StatusIndicatorCallback: Info_EmailSearchCommandSucceeded");
                 UpdateSearchResultsFromServer (s.Status.GetValue<List<NcEmailMessageIndex>> ());

--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -291,8 +291,11 @@ namespace NachoClient.iOS
 
         public void StatusIndicatorCallback (object sender, EventArgs e)
         {
-            switch (((StatusIndEventArgs)e).Status.SubKind) {
-
+            var s = (StatusIndEventArgs)e;
+            if (!s.AppliesToAccount (currentAccount)) {
+                return;
+            }
+            switch (s.Status.SubKind) {
             case NcResult.SubKindEnum.Info_EmailMessageSetChanged:
             case NcResult.SubKindEnum.Info_EmailMessageScoreUpdated:
             case NcResult.SubKindEnum.Info_EmailMessageSetFlagSucceeded:


### PR DESCRIPTION
Ignore status inds that are directed to an account that's not on
the screen. This applies to email views only for now because the
Calendar and contacts views show all accounts
