### PR TITLE
Fix bug of sending meeting requests with RTF code in description

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EventAttendeeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventAttendeeViewController.cs
@@ -614,8 +614,20 @@ namespace NachoClient.iOS
                 Log.Error (Log.LOG_UI, "EventAttendeeViewController.SendAttendeeInvite(): Calendar item is a {0} instead of a McCalendar.", c.GetType ().Name);
                 return;
             }
+            string plainTextDescription;
+            switch (item.DescriptionType) {
+            case McAbstrFileDesc.BodyTypeEnum.HTML_2:
+                plainTextDescription = Util.ConvertToPlainText (item.Description, NSDocumentType.HTML);
+                break;
+            case McAbstrFileDesc.BodyTypeEnum.RTF_3:
+                plainTextDescription = Util.ConvertToPlainText (item.Description, NSDocumentType.RTF);
+                break;
+            default:
+                plainTextDescription = item.Description;
+                break;
+            }
             var iCalPart = CalendarHelper.MimeRequestFromCalendar (item);
-            var mimeBody = CalendarHelper.CreateMime (item.Description, iCalPart, item.attachments);
+            var mimeBody = CalendarHelper.CreateMime (plainTextDescription, iCalPart, item.attachments);
 
             CalendarHelper.SendInvite (account, item, attendee, mimeBody);
         }

--- a/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
@@ -1203,6 +1203,31 @@ namespace NachoClient
             return new CGRect (A.Card_Horizontal_Indent, A.Card_Vertical_Indent, width - (2 * A.Card_Horizontal_Indent), height);
         }
 
+        /// <summary>
+        /// Convert formatted text to plain text.
+        /// </summary>
+        /// <remarks>
+        /// This really should be in a platform-generic location.  But the simplest code for doing the conversion
+        /// is iOS-specific.  So this will sit in an iOS-specific class for now.
+        /// </remarks>
+        public static string ConvertToPlainText (string formattedText, NSDocumentType type)
+        {
+            try {
+                NSError error = null;
+                var descriptionData = NSData.FromString (formattedText);
+                var descriptionAttributed = new NSAttributedString (descriptionData, new NSAttributedStringDocumentAttributes {
+                    DocumentType = type
+                }, ref error);
+                return descriptionAttributed.Value;
+            } catch (Exception e) {
+                // The NSAttributedString init: routine will fail if formattedText is not the specified type.
+                // We don't want to crash the app in this case.
+                NachoCore.Utils.Log.Warn (NachoCore.Utils.Log.LOG_CALENDAR,
+                    "Calendar body has unexpected format and will be treated as plain text: {0}", e.ToString());
+                return formattedText;
+            }
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
When a meeting was initially created on a different client with a
formatted body, then editing the meeting in the app would result in
the meeting request message being sent out with the raw RTF as the
meeting's description.  This would also happen when choosing "Send
Invite" from the attendee view to resend an invitation.

Fix the problem by converting a formated meeting description into
plain text before sending out a meeting request.

Fix nachocove/qa#406
