### PR TITLE
Download bodies of messages that are visible in a message list view

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -637,6 +637,13 @@ namespace NachoClient.iOS
                 reminderImageView.Hidden = true;
                 reminderLabelView.Hidden = true;
             }
+
+            // Since there is a decent chance that the user will open this message, go ahead and
+            // download its body.
+            var body = message.GetBody ();
+            if (null == body || McBody.FilePresenceEnum.None == body.FilePresence) {
+                BackEnd.Instance.DnldEmailBodyCmd (message.AccountId, message.Id, doNotDelay: true);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Whenever a message becomes visible in a message list view, go ahead
and download its body.  Don't wait for the user to open the message
detail.  This avoids many of the situations where the user sees a
spinner for a second or two in the message detail view.

Fix nachocove/qa#420
