### PR TITLE
Imap fetch error

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapSyncCommand.cs
@@ -127,6 +127,7 @@ namespace NachoCore.IMAP
                                     Log.Error (Log.LOG_IMAP, "Got {0} summaries but was expecting 1", s.Count);
                                 }
                             } catch (ImapProtocolException ex1) {
+                                // FIXME In our current scheme we can not handle a 'lost' message like this, as we only know Min and Max UID. Need a better Sync scheme.
                                 Log.Error (Log.LOG_IMAP, "Could not fetch item uid {0}\n{1}", uid, ex1);
                                 if (!Client.IsConnected || !Client.IsAuthenticated) {
                                     var authy = new ImapAuthenticateCommand (BEContext, Client);


### PR DESCRIPTION
I encountered an error where MailKit failed to parse a reply from the server. This causes us to loop endlessly trying to fetch this one group of Uids. As a comment notes, we have a problem handling non-contiguous messages in our sync scheme. Skipping this message causes us to lose this message. We know we need a better sync scheme, which should then address this issue.
