### PR TITLE
Minor telemetry event format changes

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -188,8 +188,8 @@ namespace NachoCore.Utils
             var jsonEvent = new TelemetryCounterEvent () {
                 counter_name = name,
                 count = count,
-                counter_start = start.Ticks,
-                counter_end = end.Ticks
+                counter_start = TelemetryJsonEvent.AwsDateTime (start),
+                counter_end = TelemetryJsonEvent.AwsDateTime (end)
             };
             RecordJsonEvent (TelemetryEventType.COUNTER, jsonEvent);
         }

--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -413,7 +413,7 @@ namespace NachoCore.Utils
                            new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
 
             // Create the temporary JSON .gz file
-            var timestamp = new DateTime (jsonEvent.timestamp, DateTimeKind.Utc);
+            var timestamp = jsonEvent.Timestamp ();
             var readFilePath = TelemetryJsonFileTable.GetReadFilePath (
                                    Path.Combine (NcApplication.GetDataDirPath (), "device_info"),
                                    timestamp, timestamp);

--- a/NachoClient.Android/NachoCore/Utils/TelemetryJsonEvent.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryJsonEvent.cs
@@ -16,19 +16,40 @@ namespace NachoCore.Utils
     {
         public string id;
         public string client;
-        public long timestamp;
+        public string user;
+        public string timestamp;
         public string event_type;
 
         public TelemetryJsonEvent ()
         {
             id = Guid.NewGuid ().ToString ().Replace ("-", "");
             client = NcApplication.Instance.ClientId;
-            timestamp = DateTime.UtcNow.Ticks;
+            user = NcApplication.Instance.UserId;
+            timestamp = AwsDateTime (DateTime.UtcNow);
         }
 
         public string ToJson ()
         {
-            return JsonConvert.SerializeObject (this);
+            return JsonConvert.SerializeObject (this, Newtonsoft.Json.Formatting.None,
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+        }
+
+        public static string AwsDateTime (DateTime timestamp)
+        {
+            return String.Format ("{0:yyyy-MM-dd HH:mm:ss.fff}", timestamp);
+        }
+
+        public DateTime Timestamp ()
+        {
+            NcAssert.True (23 == timestamp.Length);
+            int year = int.Parse (timestamp.Substring (0, 4));
+            int month = int.Parse (timestamp.Substring (5, 2));
+            int day = int.Parse (timestamp.Substring (8, 2));
+            int hour = int.Parse (timestamp.Substring (11, 2));
+            int minute = int.Parse (timestamp.Substring (14, 2));
+            int second = int.Parse (timestamp.Substring (17, 2));
+            int millisecond = int.Parse (timestamp.Substring (20, 3));
+            return new DateTime (year, month, day, hour, minute, second, millisecond, DateTimeKind.Utc);
         }
     }
 
@@ -108,8 +129,8 @@ namespace NachoCore.Utils
 
         public string counter_name;
         public long count;
-        public long counter_start;
-        public long counter_end;
+        public string counter_start;
+        public string counter_end;
 
         public TelemetryCounterEvent ()
         {
@@ -135,7 +156,7 @@ namespace NachoCore.Utils
         public const string TIME_SERIES = "TIME_SERIES";
 
         public string time_series_name;
-        public List<long> time_series_timestamp;
+        public List<string> time_series_timestamp;
         public List<int> time_series_samples;
 
         public TelemetryTimeSeriesSamplesEvent ()

--- a/NachoClient.Android/NachoCore/Utils/TelemetryJsonFile.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryJsonFile.cs
@@ -74,7 +74,7 @@ namespace NachoCore.Utils
             if (null == jsonEvent) {
                 return false;
             }
-            var timestamp = new DateTime (jsonEvent.timestamp, DateTimeKind.Utc);
+            var timestamp = jsonEvent.Timestamp ();
             if (0 == NumberOfEntries) {
                 FirstTimestamp = timestamp;
             }
@@ -277,7 +277,7 @@ namespace NachoCore.Utils
                     if (writeFile.LatestTimestamp.Day != now.Day) {
                         doFinalize = true; // do not allow JSON file to span more than one day
                     }
-                    if ((jsonEvent.timestamp - writeFile.FirstTimestamp.Ticks) > MAX_DURATION) {
+                    if ((jsonEvent.Timestamp () - writeFile.FirstTimestamp).Ticks > MAX_DURATION) {
                         doFinalize = true; // larger than max duration
                     }
                 }

--- a/Test.Android/TelemetryJsonFileTest.cs
+++ b/Test.Android/TelemetryJsonFileTest.cs
@@ -228,7 +228,7 @@ namespace Test.Common
             // Add a log event. This should create the log file
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 1, 2, 3, 456);
             var event1 = new TelemetryLogEvent (TelemetryEventType.INFO) {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 thread_id = 2,
                 message = "This is an info",
             };
@@ -239,7 +239,7 @@ namespace Test.Common
             // Add a UI event, This should create the UI JSON file
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 2, 2, 3, 456);
             var event2 = new TelemetryUiEvent () {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 ui_type = "UIButton",
                 ui_object = "OK",
             };
@@ -250,7 +250,7 @@ namespace Test.Common
             // Add a WBXML event. This should create the WBXML JSON file
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 3, 0, 0, 001);
             var event3 = new TelemetryProtocolEvent () {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 payload = new byte[3] { 0x11, 0x22, 0x33 },
             };
             AddEventAndCheck (event3);
@@ -260,7 +260,7 @@ namespace Test.Common
             // Add a samples event. This should create the samples JSON file
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 4, 0, 0, 000);
             var event4 = new TelemetrySamplesEvent () {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 samples_name = "Process_memory",
                 samples = new List<int> () { 90, 110, 70, 130 },
             };
@@ -271,7 +271,7 @@ namespace Test.Common
             // Add a statistics2 event. This should create the statistics2 file
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 11, 0, 0, 22);
             var event5 = new TelemetryStatistics2Event () {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 stat2_name = "McEmailAddress_Insert",
                 count = 100,
                 min = 10,
@@ -286,7 +286,7 @@ namespace Test.Common
             // Add a support event. This should cause the support file to finalize immediately
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 12, 50, 47, 000);
             var event6 = new TelemetrySupportEvent () {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 support = "Help!",
             };
             AddEventAndCheck (event6, shouldAdd: false);
@@ -300,7 +300,7 @@ namespace Test.Common
             // and it is being filled in correctly.
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 12, 55, 0, 101);
             var event7 = new TelemetryLogEvent (TelemetryEventType.INFO) {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 thread_id = 10,
                 message = "Another info log",
             };
@@ -355,7 +355,7 @@ namespace Test.Common
 
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 13, 1, 0, 0, DateTimeKind.Utc);
             bool added = FileTable.Add (new TelemetryLogEvent (TelemetryEventType.INFO) {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 thread_id = 10,
                 message = "This message should not generate a read file",
             });
@@ -366,7 +366,7 @@ namespace Test.Common
 
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 13, 2, 0, 0, DateTimeKind.Utc);
             added = FileTable.Add (new TelemetryLogEvent (TelemetryEventType.INFO) {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 thread_id = 11,
                 message = "This message should not generate a read file",
             });
@@ -377,7 +377,7 @@ namespace Test.Common
 
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 13, 3, 0, 0);
             added = FileTable.Add (new TelemetryLogEvent (TelemetryEventType.INFO) {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 thread_id = 12,
                 message = "This message should not generate a read file",
             });
@@ -388,7 +388,7 @@ namespace Test.Common
 
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 13, 4, 0, 0);
             added = FileTable.Add (new TelemetryLogEvent (TelemetryEventType.INFO) {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 thread_id = 13,
                 message = "This message should generate a read file",
             });
@@ -406,7 +406,7 @@ namespace Test.Common
             TelemetryJsonFileTable.MAX_DURATION = 5 * TimeSpan.TicksPerMinute;
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 13, 5, 0, 0);
             added = FileTable.Add (new TelemetryLogEvent (TelemetryEventType.INFO) {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 thread_id = 14,
                 message = "This message should not generate a read file",
             });
@@ -417,7 +417,7 @@ namespace Test.Common
 
             WrappedTelemetryJsonFileTable.UtcNow = new DateTime (2015, 5, 26, 13, 10, 0, 1);
             added = FileTable.Add (new TelemetryLogEvent (TelemetryEventType.INFO) {
-                timestamp = WrappedTelemetryJsonFileTable.UtcNow.Ticks,
+                timestamp = TelemetryJsonEvent.AwsDateTime (WrappedTelemetryJsonFileTable.UtcNow),
                 thread_id = 15,
                 message = "This message should generate a read file",
             });


### PR DESCRIPTION
- Add user id to telemetry event.
- Change datetime format so that it will remain a datetime (instead of long) in RedShift.
