### PR TITLE
Don't crash on a server with a valid scheme but invalid host name

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
@@ -261,6 +261,13 @@ namespace NachoCore.Utils
             try {
                 // User may have entered a scheme - let's try it.
                 serverURI = new Uri (serverName);
+            } catch (UriFormatException e) {
+                if (serverName.StartsWith ("http://") || serverName.StartsWith ("https://")) {
+                    // The massaging of the URL that happens later, namely prepending "https://",
+                    // won't do any good.  In fact it will make things worse.  So give up now.
+                    // Since the scheme looks valid, the problem is most likely the host name.
+                    return ParseServerWhyEnum.FailBadHost;
+                }
             } catch {
             }
             if (null != serverURI) {


### PR DESCRIPTION
Don't crash when the user enters a server name on the advanced login
page with a valid scheme (http or https) but an invalid host name
(such as one with a space in it).

Fix nachocove/qa#439
