### PR TITLE
Fix nachocove/qa#444

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -325,7 +325,8 @@ namespace NachoCore.Utils
             }
 
             var jsonEvent = new TelemetrySupportEvent () {
-                support = JsonConvert.SerializeObject (info)
+                support = JsonConvert.SerializeObject (info),
+                callback = callback
             };
             RecordJsonEvent (TelemetryEventType.SUPPORT, jsonEvent);
         }
@@ -491,7 +492,11 @@ namespace NachoCore.Utils
                             // New log file-based telemetry
                             succeed = BackEnd.UploadEvents (readFile);
                             if (succeed) {
-                                JsonFileTable.Remove (readFile);
+                                Action supportCallback;
+                                JsonFileTable.Remove (readFile, out supportCallback);
+                                if (null != supportCallback) {
+                                    InvokeOnUIThread.Instance.Invoke (supportCallback);
+                                }
                             } else {
                                 FailToSend.Click ();
                                 if (FailToSendLogLimiter.TakeToken ()) {

--- a/NachoClient.Android/NachoCore/Utils/TelemetryJsonEvent.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryJsonEvent.cs
@@ -19,6 +19,8 @@ namespace NachoCore.Utils
         public string user;
         public string timestamp;
         public string event_type;
+        [JsonIgnore]
+        public Action callback;
 
         public TelemetryJsonEvent ()
         {

--- a/Test.Android/TelemetryJsonFileTest.cs
+++ b/Test.Android/TelemetryJsonFileTest.cs
@@ -111,6 +111,11 @@ namespace Test.Common
             Assert.AreEqual (a.message, b.message);
         }
 
+        protected long TimestampTicks (string timestamp)
+        {
+            return TelemetryJsonEvent.Timestamp (timestamp).Ticks;
+        }
+
         [Test]
         public void TestTelemetryJsonFile ()
         {
@@ -130,8 +135,8 @@ namespace Test.Common
             };
             bool added = jsonFile.Add (event1);
             Assert.True (added);
-            Assert.AreEqual (event1.timestamp, jsonFile.FirstTimestamp.Ticks);
-            Assert.AreEqual (event1.timestamp, jsonFile.LatestTimestamp.Ticks);
+            Assert.AreEqual (TimestampTicks (event1.timestamp), jsonFile.FirstTimestamp.Ticks);
+            Assert.AreEqual (TimestampTicks (event1.timestamp), jsonFile.LatestTimestamp.Ticks);
             Assert.AreEqual (1, jsonFile.NumberOfEntries);
 
             // Write a warning log
@@ -141,8 +146,8 @@ namespace Test.Common
             };
             added = jsonFile.Add (event2);
             Assert.True (added);
-            Assert.AreEqual (event1.timestamp, jsonFile.FirstTimestamp.Ticks);
-            Assert.AreEqual (event2.timestamp, jsonFile.LatestTimestamp.Ticks);
+            Assert.AreEqual (TimestampTicks (event1.timestamp), jsonFile.FirstTimestamp.Ticks);
+            Assert.AreEqual (TimestampTicks (event2.timestamp), jsonFile.LatestTimestamp.Ticks);
             Assert.AreEqual (2, jsonFile.NumberOfEntries);
 
             // Write an info log
@@ -152,15 +157,15 @@ namespace Test.Common
             };
             added = jsonFile.Add (event3);
             Assert.True (added);
-            Assert.AreEqual (event1.timestamp, jsonFile.FirstTimestamp.Ticks);
-            Assert.AreEqual (event3.timestamp, jsonFile.LatestTimestamp.Ticks);
+            Assert.AreEqual (TimestampTicks (event1.timestamp), jsonFile.FirstTimestamp.Ticks);
+            Assert.AreEqual (TimestampTicks (event3.timestamp), jsonFile.LatestTimestamp.Ticks);
             Assert.AreEqual (3, jsonFile.NumberOfEntries);
 
             // Close the file and re-open it. Make sure the timestamp and # entries are correct
             jsonFile.Close ();
             jsonFile = new TelemetryJsonFile (filePath);
-            Assert.AreEqual (event1.timestamp, jsonFile.FirstTimestamp.Ticks);
-            Assert.AreEqual (event3.timestamp, jsonFile.LatestTimestamp.Ticks);
+            Assert.AreEqual (TimestampTicks (event1.timestamp), jsonFile.FirstTimestamp.Ticks);
+            Assert.AreEqual (TimestampTicks (event3.timestamp), jsonFile.LatestTimestamp.Ticks);
             Assert.AreEqual (3, jsonFile.NumberOfEntries);
 
             // Close it again. Read it line-by-line and make sure the content is correct
@@ -200,11 +205,11 @@ namespace Test.Common
         {
             Assert.AreEqual (numEntries, jsonFile.NumberOfEntries);
             if (1 == numEntries) {
-                Assert.AreEqual (jsonEvent.timestamp, jsonFile.FirstTimestamp.Ticks);
+                Assert.AreEqual (TimestampTicks (jsonEvent.timestamp), jsonFile.FirstTimestamp.Ticks);
             } else {
-                Assert.AreNotEqual (jsonEvent.timestamp, jsonFile.FirstTimestamp.Ticks);
+                Assert.AreNotEqual (TimestampTicks (jsonEvent.timestamp), jsonFile.FirstTimestamp.Ticks);
             }
-            Assert.AreEqual (jsonEvent.timestamp, jsonFile.LatestTimestamp.Ticks);
+            Assert.AreEqual (TimestampTicks (jsonEvent.timestamp), jsonFile.LatestTimestamp.Ticks);
         }
 
         protected void CheckWriteFilesCount (int expected)
@@ -340,11 +345,12 @@ namespace Test.Common
             }
 
             // Read each read file.
+            Action dummyCallback;
             foreach (var expected in expectedReadFiles) {
                 readFile = FileTable.GetNextReadFile ();
                 Assert.AreEqual (expected, Path.GetFileName (readFile));
                 Assert.True (File.Exists (readFile));
-                FileTable.Remove (readFile);
+                FileTable.Remove (readFile, out dummyCallback);
                 Assert.False (File.Exists (readFile));
             }
 
@@ -397,7 +403,7 @@ namespace Test.Common
             CheckWriteFilesCount (0);
             readFile = FileTable.GetNextReadFile ();
             Assert.AreEqual ("20150526130100000.20150526130400000.log", Path.GetFileName (readFile));
-            FileTable.Remove (readFile);
+            FileTable.Remove (readFile, out dummyCallback);
 
             // Set the max duration to 5 mins. Write 2 entries 5m0.001s apart and expect a new read file
             CheckReadFilesCount (0);


### PR DESCRIPTION
- This is a regression due to T3. There used to be a callback field in the old event objects so that when the event is uploaded to telemetry server, the callback is invoked. But the new TelemetryJsonEvent does not record the callback.
- Record a callback for support JSON event. When the support JSON file is uploaded and removed, the callback is returned and invoked.
- Update the unit test due to the time stamp format change in previous commit.
