### PR TITLE
Fix a couple of crashes in the device contact and calendar code

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NcDeviceCalendars.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcDeviceCalendars.cs
@@ -94,10 +94,10 @@ namespace NachoCore
 
         public bool RemoveNextStale ()
         {
-            // TODO This doesn't work yet. Disable it until I have time to fix it.
-            return true;
-            #if false
             if (null == Stale) {
+                if (null == Present) {
+                    return true;
+                }
                 Stale = Present.GetEnumerator ();
                 PresentCount = Present.Count;
             }
@@ -118,7 +118,6 @@ namespace NachoCore
                 McCalendar.DeleteById<McCalendar> (map.FolderEntryId);
             });
             return false;
-            #endif
         }
 
         public void Report ()

--- a/NachoClient.Android/NachoCore/Adapters/NcDeviceContacts.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcDeviceContacts.cs
@@ -87,10 +87,10 @@ namespace NachoCore
 
         public bool RemoveNextStale ()
         {
-            // TODO This doesn't work yet.  Avoid it until I have time to fix it.
-            return true;
-            #if false
             if (null == Stale) {
+                if (null == Present) {
+                    return true;
+                }
                 Stale = Present.GetEnumerator ();
                 PresentCount = Present.Count;
             }
@@ -111,7 +111,6 @@ namespace NachoCore
                 McContact.DeleteById<McContact> (map.FolderEntryId);
             });
             return false;
-            #endif
         }
 
         public void Report ()


### PR DESCRIPTION
The code that cleans up deleted device contacts and device calendar
items was not protecting against the case where the device contacts or
device calendars could not be accessed, which could result in a
NullReferenceException.

When a pair of tasks for synching device contacts and device calendar
items overlapped, a NullReferenceException could result.  Add checks
and locking to prevent this from happening.
