### PR TITLE
Get UID from device calendar items

### DIFF
--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -106,6 +106,7 @@ namespace NachoPlatform
                 cal.DeviceCreation = (null == Event.CreationDate) ? cal.DeviceLastUpdate : Event.CreationDate.ToDateTime ();
                 cal.Subject = Event.Title;
                 cal.Location = Event.Location;
+                cal.UID = Event.CalendarItemExternalIdentifier;
 
                 cal.BusyStatusIsSet = true;
                 switch (Event.Availability) {
@@ -135,8 +136,7 @@ namespace NachoPlatform
                     cal.OrganizerEmail = TryExtractEmailAddress (Event.Organizer);
                 }
 
-                var body = McBody.InsertFile (accountId, McAbstrFileDesc.BodyTypeEnum.PlainText_1, Event.Notes ?? "");
-                cal.BodyId = body.Id;
+                cal.SetDescription (Event.Notes ?? "", McBody.BodyTypeEnum.PlainText_1);
 
                 cal.ResponseTypeIsSet = true;
                 switch (Event.Status) {


### PR DESCRIPTION
When copying an event from the device calendar into the app, include
the UID.  (I verified that Event.CalendarItemExternalIdentifier
corresponds to the event's UID.)

Change the code that copies the description from a device calendar
event.  Use the Description field rather than writing to the McBody
directly.
