### PR TITLE
Rename the enum constants within NcMeetingStatus

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McAbstrCalendarRoot.cs
+++ b/NachoClient.Android/NachoCore/Model/McAbstrCalendarRoot.cs
@@ -476,16 +476,16 @@ namespace NachoCore.Model
 
     public enum NcMeetingStatus
     {
-        /// No attendees
+        /// An appointment.  Not a meeting.  No attendees.
         Appointment = 0,
-        /// The user is the meeting organizer
-        Meeting = 1,
-        /// The meeting was recieved from someone else
-        ForwardedMeeting = 3,
-        /// The user is the cancelled meeting's organizer
-        MeetingCancelled = 5,
-        /// The cancelled meeting was recieved from someone else
-        ForwardedMeetingCancelled = 7,
+        /// The event is a meeting and the user is the meeting organizer.
+        MeetingOrganizer = 1,
+        /// The event is a meeting and the user was invited to attend the meeting.
+        MeetingAttendee = 3,
+        /// The user is the organizer but the meeting has been cancelled.
+        MeetingOrganizerCancelled = 5,
+        /// The user was invited to attend the meeting but the meeting has been cancelled.
+        MeetingAttendeeCancelled = 7,
     }
     // Similar to NcResponseType
     public enum NcAttendeeStatus

--- a/NachoClient.Android/NachoCore/Model/McEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McEvent.cs
@@ -134,7 +134,7 @@ namespace NachoCore.Model
             McEvent result = null;
             foreach (var evt in NcModel.Instance.Db.Table<McEvent> ().Where (x => x.EndTime >= now && x.StartTime < weekInFuture).OrderBy (x => x.StartTime)) {
                 var cal = evt.GetCalendarItemforEvent ();
-                if (null != cal && (NcMeetingStatus.MeetingCancelled == cal.MeetingStatus || NcMeetingStatus.ForwardedMeetingCancelled == cal.MeetingStatus)) {
+                if (null != cal && (NcMeetingStatus.MeetingOrganizerCancelled == cal.MeetingStatus || NcMeetingStatus.MeetingAttendeeCancelled == cal.MeetingStatus)) {
                     // A meeting that has been canceled.  Ignore it.
                     continue;
                 }

--- a/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
@@ -139,13 +139,13 @@ namespace NachoCore.Utils
             }
             if (DateTime.MinValue == eventInfo.RecurrenceId) {
                 // Cancel the entire meeting, not just one occurrence.  This is the easy case.
-                if (cal.MeetingStatusIsSet && (NcMeetingStatus.MeetingCancelled == cal.MeetingStatus || NcMeetingStatus.ForwardedMeetingCancelled == cal.MeetingStatus)) {
+                if (cal.MeetingStatusIsSet && (NcMeetingStatus.MeetingOrganizerCancelled == cal.MeetingStatus || NcMeetingStatus.MeetingAttendeeCancelled == cal.MeetingStatus)) {
                     // Someone, most likely the server, has already marked the meeting as cancelled.
                     // No need to update the item again.
                     return;
                 }
                 cal.MeetingStatusIsSet = true;
-                cal.MeetingStatus = NcMeetingStatus.ForwardedMeetingCancelled;
+                cal.MeetingStatus = NcMeetingStatus.MeetingAttendeeCancelled;
                 cal.Subject = "Canceled: " + cal.Subject;
             } else {
                 // Only one occurrence of a recurring meeting has been cancelled.
@@ -159,7 +159,7 @@ namespace NachoCore.Utils
                         EndTime = eventInfo.EndTime,
                         Subject = "Canceled: " + cal.Subject,
                         MeetingStatusIsSet = true,
-                        MeetingStatus = NcMeetingStatus.ForwardedMeetingCancelled,
+                        MeetingStatus = NcMeetingStatus.MeetingAttendeeCancelled,
                     };
                     allExceptions.Add (exception);
                 } else {
@@ -171,10 +171,10 @@ namespace NachoCore.Utils
                     foreach (var exception in exceptions) {
                         if (0 == exception.Deleted &&
                             (!exception.MeetingStatusIsSet ||
-                                (NcMeetingStatus.MeetingCancelled != exception.MeetingStatus && NcMeetingStatus.ForwardedMeetingCancelled != exception.MeetingStatus)))
+                                (NcMeetingStatus.MeetingOrganizerCancelled != exception.MeetingStatus && NcMeetingStatus.MeetingAttendeeCancelled != exception.MeetingStatus)))
                         {
                             exception.MeetingStatusIsSet = true;
-                            exception.MeetingStatus = NcMeetingStatus.ForwardedMeetingCancelled;
+                            exception.MeetingStatus = NcMeetingStatus.MeetingAttendeeCancelled;
                             exception.Subject = "Canceled: " + exception.GetSubject ();
                         }
                     }

--- a/NachoClient.Android/NachoCore/Utils/ManageItems.cs
+++ b/NachoClient.Android/NachoCore/Utils/ManageItems.cs
@@ -134,7 +134,7 @@ namespace NachoCore.Utils
         {
             var item = CreateEvent (account);
             item.MeetingStatusIsSet = true;
-            item.MeetingStatus = NcMeetingStatus.Meeting;
+            item.MeetingStatus = NcMeetingStatus.MeetingOrganizer;
             item.ResponseRequestedIsSet = true;
             item.ResponseRequested = true;
             var attendees = new List<McAttendee> ();
@@ -230,7 +230,7 @@ namespace NachoCore.Utils
             item.TimeZone = new AsTimeZone (CalendarHelper.SimplifiedLocalTimeZone (), DateTime.UtcNow).toEncodedTimeZone ();
             item.UID = System.Guid.NewGuid ().ToString ().Replace ("-", null).ToUpper ();
             item.MeetingStatusIsSet = true;
-            item.MeetingStatus = NcMeetingStatus.Meeting;
+            item.MeetingStatus = NcMeetingStatus.MeetingOrganizer;
             item.ResponseRequestedIsSet = true;
             item.ResponseRequested = true;
 

--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -1119,7 +1119,7 @@ namespace NachoClient.iOS
                 c.ResponseRequestedIsSet = true;
             } else {
                 c.MeetingStatusIsSet = true;
-                c.MeetingStatus = NcMeetingStatus.Meeting;
+                c.MeetingStatus = NcMeetingStatus.MeetingOrganizer;
                 c.ResponseRequested = true;
                 c.ResponseRequestedIsSet = true;
             }

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -491,7 +491,7 @@ namespace NachoClient.iOS
             /// If any of these are true the user is the organizer of the event.
             isOrganizer = (account.EmailAddr == root.OrganizerEmail && account.Id == c.AccountId) ||
             (c.HasResponseType () && NcResponseType.Organizer == c.GetResponseType ()) ||
-            (NcMeetingStatus.Meeting == c.MeetingStatus);
+            (NcMeetingStatus.MeetingOrganizer == c.MeetingStatus);
 
             if (isOrganizer && !isRecurring) {
                 NavigationItem.RightBarButtonItem = editEventButton;
@@ -1100,7 +1100,7 @@ namespace NachoClient.iOS
 
         public void ConfigureRsvpBar (bool isOrganizer)
         {
-            if (c.MeetingStatus == NcMeetingStatus.ForwardedMeetingCancelled) {
+            if (c.MeetingStatus == NcMeetingStatus.MeetingAttendeeCancelled) {
                 messageLabel.Hidden = true;
                 acceptButton.Hidden = true;
                 organizerIcon.Hidden = true;
@@ -1367,7 +1367,7 @@ namespace NachoClient.iOS
             NavigationController.PopViewController (true);
 
             // Remove the item from the calendar.
-            if (c is McException && NcMeetingStatus.ForwardedMeetingCancelled != root.MeetingStatus) {
+            if (c is McException && NcMeetingStatus.MeetingAttendeeCancelled != root.MeetingStatus) {
                 // The user is viewing an occurrence of a recurring meeting, and it appears that the
                 // entire series has not been canceled.  So delete just this one occurrence.
                 CalendarHelper.CancelOccurrence (root, ((McException)c).ExceptionStartTime);

--- a/Test.Android/McEventTest.cs
+++ b/Test.Android/McEventTest.cs
@@ -147,12 +147,12 @@ namespace Test.Common
             var goodCal = new McCalendar () {
                 AccountId = 1,
                 MeetingStatusIsSet = true,
-                MeetingStatus = NcMeetingStatus.Meeting,
+                MeetingStatus = NcMeetingStatus.MeetingOrganizer,
             };
             var canceledCal = new McCalendar () {
                 AccountId = 1,
                 MeetingStatusIsSet = true,
-                MeetingStatus = NcMeetingStatus.MeetingCancelled,
+                MeetingStatus = NcMeetingStatus.MeetingOrganizerCancelled,
             };
             goodCal.Insert ();
             canceledCal.Insert ();

--- a/Test.Android/NcCalendarTest.cs
+++ b/Test.Android/NcCalendarTest.cs
@@ -375,7 +375,7 @@ namespace Test.Common
             Assert.AreNotEqual (NcRecurrenceType.YearlyOnDay, "0".ParseInteger<NcRecurrenceType> ());
             Assert.AreNotEqual (NcResponseType.Tentative, "3".ParseInteger<NcResponseType> ());
             Assert.AreNotEqual (NcSensitivity.Private, "3".ParseInteger<NcSensitivity> ());
-            Assert.AreNotEqual (NcMeetingStatus.MeetingCancelled, "0".ParseInteger<NcMeetingStatus> ());
+            Assert.AreNotEqual (NcMeetingStatus.MeetingOrganizerCancelled, "0".ParseInteger<NcMeetingStatus> ());
             Assert.AreNotEqual (NcDayOfWeek.Tuesday, "32".ParseInteger<NcDayOfWeek> ());
             Assert.AreNotEqual (NcCalendarType.UmalQuraReservedMustNotBeUsed, "15".ParseInteger<NcCalendarType> ());
             Assert.AreNotEqual (NcBusyStatus.Tentative, "2".ParseInteger<NcBusyStatus> ());


### PR DESCRIPTION
The old names were confusing, and have caused me to write buggy code
in the past.  The new names for the enumeration constants better
describe what the values really mean.
