### PR TITLE
DeviceProtoControl: Don't crash on AbateOn/AbateOff/AbateOn

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/Device/DeviceProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/Device/DeviceProtoControl.cs
@@ -347,8 +347,13 @@ namespace NachoCore
 
         private void DoAbate ()
         {
-            Cts.Cancel ();
-            Cts = null;
+            // If the state machine in state SyncW gets AbateOn, AbateOff, AbateOn events before it gets
+            // the SyncCancelled event, then Cts will be null.  This is not an error, since the in-progress
+            // sync has already been notified and there is nothing else that needs ot be cancelled.
+            if (null != Cts) {
+                Cts.Cancel ();
+                Cts = null;
+            }
         }
 
         private void DoPark ()


### PR DESCRIPTION
If the DeviceProtoControl state machine was in state SyncW and then
received AbateOn, AbateOff, and AbateOn events without seeing a
SyncCancelled event, the app would crash because the cancellation
token would be unexpectedly null when processing the second AbateOn.
Fix the code to not crash when the cancellation token is null, since
this situation is normal.
