### PR TITLE
Fix nachocove/qa#449

### DIFF
--- a/NachoClient.Android/NachoCore/Model/EmailAddressScore.cs
+++ b/NachoClient.Android/NachoCore/Model/EmailAddressScore.cs
@@ -302,11 +302,13 @@ namespace NachoCore.Model
 
         protected void ReadScoreStates ()
         {
-            DbScoreStates = McEmailAddressScore.QueryByParentId (Id);
-            if (null == DbScoreStates) {
-                Log.Error (Log.LOG_BRAIN, "fail to find score states for email address {0}. Create one", Id);
-                InsertScoreStates ();
-            }
+            NcModel.Instance.RunInTransaction (() => {
+                DbScoreStates = McEmailAddressScore.QueryByParentId (Id);
+                if (null == DbScoreStates) {
+                    Log.Error (Log.LOG_BRAIN, "fail to find score states for email address {0}. Create one", Id);
+                    InsertScoreStates ();
+                }
+            });
         }
 
         protected void DeleteScoreStates ()


### PR DESCRIPTION
- Wrap the read-conditional-write sequence in a transaction so another thread (e.g. BE) cannot insert a duplicate McEmailAddressScore in that window.
- David: Your client's db mostly likely has a duplicate entry that will keep crashing. If you think re-installing is not good, let me know. I will add a migration to clean it up.
