### PR TITLE
Multi-account support for background fetch

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -460,7 +460,11 @@ namespace NachoCore
                                 Act = DoGetCliTok,
                                 State = (uint)St.Start
                             },
-                            new Trans { Event = (uint)SmEvt.E.Launch, Act = DoActive, State = (uint)Lst.Active },
+                            new Trans {
+                                Event = (uint)SmEvt.E.Launch,
+                                Act = DoStartSession,
+                                State = (uint)Lst.SessTokW
+                            },
                             new Trans { Event = (uint)PAEvt.E.Stop, Act = DoStopSession, State = (uint)St.Start },
                         }
                     }


### PR DESCRIPTION
- Track both the list of all accounts that will fetch and will arm push assist SM.
- For remote notification, will only track fetch status of the account in the notification payload. But will try to fetch all.
- Will track PA arming for all accounts to make sure that will get notifications for all accounts before going to sleep.
- Fix a regression introduced when switching client id. When launching a PA SM from parked state, go to SessTokW instead of Active so that it starts a session.
