### PR TITLE
IMAP support for push assist

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IPushAssistOwner.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IPushAssistOwner.cs
@@ -10,7 +10,7 @@ namespace NachoCore
     {
         UNKNOWN = 0,
         ACTIVE_SYNC = 1,
-        IMAP_SMTP = 2,
+        IMAP = 2,
     };
 
     public class PushAssistParameters

--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -968,7 +968,7 @@ namespace NachoCore
                 return "unknown";
             case PushAssistProtocol.ACTIVE_SYNC:
                 return "ActiveSync";
-            case PushAssistProtocol.IMAP_SMTP:
+            case PushAssistProtocol.IMAP:
                 return "IMAP";
             default:
                 Log.Error (Log.LOG_PUSH, "Unexpected push assist protocol {0}", (uint)protocol);


### PR DESCRIPTION
- Rename PushAssistProtocol.IMAP to IMAP_SMTP to match account type.
- Add missing switch case for encoding context.
- IMAP proto control is not instantiating PushAssist object yet. And according Azim, pinger is not fully supporting IMAP yet. So, still more work to do. With this, PushAssist is expected to work integrating with others.
