### PR TITLE
Support recurring events that come from the device calendar

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NcDeviceCalendars.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcDeviceCalendars.cs
@@ -41,6 +41,7 @@ namespace NachoCore
             if (null == deviceCalendar) {
                 return true;
             }
+
             Func<PlatformCalendarRecord, McCalendar> inserter = (record) => {
                 NcResult result;
                 try {
@@ -58,7 +59,7 @@ namespace NachoCore
                     });
                     return calendar;
                 } else {
-                    Log.Error (Log.LOG_SYS, "Failed to create McCalendar from device calendar {0}", deviceCalendar.ServerId);
+                    Log.Error (Log.LOG_SYS, "Failed to create McCalendar from device calendar {0}", record.ServerId);
                     return null;
                 }
             };

--- a/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
@@ -906,7 +906,7 @@ namespace NachoCore.Utils
         /// <summary>
         /// Convert from a C# DayOfWeek value to the DayOfWeek field within a recurrence.
         /// </summary>
-        protected static NcDayOfWeek ToNcDayOfWeek (DayOfWeek day)
+        public static NcDayOfWeek ToNcDayOfWeek (DayOfWeek day)
         {
             switch (day) {
             case DayOfWeek.Sunday:


### PR DESCRIPTION
When copying a recurring event from the device calendar to the app,
convert the recurrence rule, so the calendar item shows up as a series
of events instead of a one-time event.

Exceptions to recurring meetings are currently ignored.  They will be
handled in a later update.
