### PR TITLE
Xamarin goes nuts loading and unloading a library when tele is enabled.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/Telemetry.cs
+++ b/NachoClient.Android/NachoCore/Utils/Telemetry.cs
@@ -17,7 +17,11 @@ namespace NachoCore.Utils
 {
     public class Telemetry
     {
+        #if __IOS__
         public static bool ENABLED = true;
+        #else
+        public static bool ENABLED = false;
+        #endif
 
         // AWS Redshift has a limit of 65,535 for varchar.
         private const int MAX_AWS_LEN = 65535;


### PR DESCRIPTION
We'll debug it later; for now, let's turn it off.
