### PR TITLE
Avoid duplicate events in the calendar view

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McEvent.cs
@@ -41,13 +41,22 @@ namespace NachoCore.Model
         [Indexed]
         public int ExceptionId { get; set; }
 
-        static public McEvent Create (int accountId, DateTime startTime, DateTime endTime, bool allDayEvent, int calendarId, int exceptionId)
+        /// <summary>
+        /// The UID of the root calendar item.  It is stored in the McEvent to avoid database lookups when
+        /// eliminating duplicates from the calendar view.  The UID is not unique to this McEvent when
+        /// (1) this is one occurrence in a recurring meeting, or (2) the same event is on multiple calendars
+        /// that are being tracked by the app.
+        /// </summary>
+        public string UID { get; set; }
+
+        static public McEvent Create (int accountId, DateTime startTime, DateTime endTime, string UID, bool allDayEvent, int calendarId, int exceptionId)
         {
             // Save the event
             var e = new McEvent ();
             e.AccountId = accountId;
             e.StartTime = startTime;
             e.EndTime = endTime;
+            e.UID = UID;
             e.AllDayEvent = allDayEvent;
             e.CalendarId = calendarId;
             e.ExceptionId = exceptionId;

--- a/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
@@ -1119,7 +1119,7 @@ namespace NachoCore.Utils
             int exceptionId = null == exception ? 0 : exception.Id;
             do {
                 DateTime nextDay = dayStart.AddDays (1.0);
-                var ev = McEvent.Create (c.AccountId, dayStart, nextDay, true, c.Id, exceptionId);
+                var ev = McEvent.Create (c.AccountId, dayStart, nextDay, c.UID, true, c.Id, exceptionId);
                 if (needsReminder) {
                     ev.SetReminder (reminderItem.GetReminder ());
                     needsReminder = false; // Only the first day should have a reminder.
@@ -1208,7 +1208,7 @@ namespace NachoCore.Utils
             var exceptions = McException.QueryForExceptionId (c.Id, startTime);
 
             if ((null == exceptions) || (0 == exceptions.Count)) {
-                var e = McEvent.Create (c.AccountId, startTime, endTime, false, c.Id, 0);
+                var e = McEvent.Create (c.AccountId, startTime, endTime, c.UID, false, c.Id, 0);
                 if (c.ReminderIsSet) {
                     e.SetReminder (c.Reminder);
                 }
@@ -1223,7 +1223,7 @@ namespace NachoCore.Utils
                         if (DateTime.MinValue == exceptionEnd) {
                             exceptionEnd = endTime;
                         }
-                        var e = McEvent.Create (c.AccountId, exceptionStart, exceptionEnd, false, c.Id, exception.Id);
+                        var e = McEvent.Create (c.AccountId, exceptionStart, exceptionEnd, c.UID, false, c.Id, exception.Id);
                         if (exception.HasReminder ()) {
                             e.SetReminder (exception.GetReminder ());
                         }

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1523,6 +1523,7 @@
     <Compile Include="..\NachoClient.Android\NachoCore\Utils\NcMailKitProtocolLogger.cs">
       <Link>NachoCore\Utils\NcMailKitProtocolLogger.cs</Link>
     </Compile>
+    <Compile Include="NachoCore\Model\Migration\NcMigration31.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/NachoClient.iOS/NachoCore/Model/Migration/NcMigration31.cs
+++ b/NachoClient.iOS/NachoCore/Model/Migration/NcMigration31.cs
@@ -1,0 +1,24 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+
+namespace NachoCore.Model
+{
+    public class NcMigration31 : NcMigration
+    {
+        public override int GetNumberOfObjects ()
+        {
+            return Db.Table<McCalendar> ().Count ();
+        }
+
+        public override void Run (System.Threading.CancellationToken token)
+        {
+            foreach (var cal in Db.Table<McCalendar> ()) {
+                token.ThrowIfCancellationRequested ();
+                Db.Execute ("UPDATE McEvent SET UID = ? WHERE CalendarId = ?", cal.UID, cal.Id);
+                UpdateProgress (1);
+            }
+        }
+    }
+}
+

--- a/Test.Android/NcEventsCommonTest.cs
+++ b/Test.Android/NcEventsCommonTest.cs
@@ -40,11 +40,11 @@ namespace Test.Common
                 cg.Insert ();
 
                 var list = new System.Collections.Generic.List<NachoCore.Model.McEvent> ();
-                list.Add (McEvent.Create (id, DateTime.Now.AddDays (-60), DateTime.Now.AddDays (-60).AddHours (1), false, cg.Id, 0));
-                list.Add (McEvent.Create (id, DateTime.Now.AddDays (-30), DateTime.Now.AddDays (-30).AddHours (1), false, cg.Id, 0));
-                list.Add (McEvent.Create (id, DateTime.Now.AddDays (0), DateTime.Now.AddDays (0).AddHours (1), false, cg.Id, 0));
-                list.Add (McEvent.Create (id, DateTime.Now.AddDays (30), DateTime.Now.AddDays (30).AddHours (1), false, cg.Id, 0));
-                list.Add (McEvent.Create (id, DateTime.Now.AddDays (60), DateTime.Now.AddDays (60).AddHours (1), false, cg.Id, 0));
+                list.Add (McEvent.Create (id, DateTime.Now.AddDays (-60), DateTime.Now.AddDays (-60).AddHours (1), "a", false, cg.Id, 0));
+                list.Add (McEvent.Create (id, DateTime.Now.AddDays (-30), DateTime.Now.AddDays (-30).AddHours (1), "a", false, cg.Id, 0));
+                list.Add (McEvent.Create (id, DateTime.Now.AddDays (0), DateTime.Now.AddDays (0).AddHours (1), "a", false, cg.Id, 0));
+                list.Add (McEvent.Create (id, DateTime.Now.AddDays (30), DateTime.Now.AddDays (30).AddHours (1), "a", false, cg.Id, 0));
+                list.Add (McEvent.Create (id, DateTime.Now.AddDays (60), DateTime.Now.AddDays (60).AddHours (1), "a", false, cg.Id, 0));
                 return list;
             }
                  


### PR DESCRIPTION
When identifying events to show in the calendar view, eliminate
duplicates that can arise when the same event is in several different
calendars that are tracked by the app.  The calendar item's UID is
used to identify duplicates.  When choosing the event to show, choose
the current account over other accounts, and any account over the
device account.
