### PR TITLE
Dots in calendar view rows are colored to show the containing folder

### DIFF
--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1524,6 +1524,7 @@
       <Link>NachoCore\Utils\NcMailKitProtocolLogger.cs</Link>
     </Compile>
     <Compile Include="NachoCore\Model\Migration\NcMigration31.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration32.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/NachoClient.iOS/NachoCore/Model/Migration/NcMigration32.cs
+++ b/NachoClient.iOS/NachoCore/Model/Migration/NcMigration32.cs
@@ -1,0 +1,51 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+using NachoCore.ActiveSync;
+using NachoCore.Utils;
+using System.Linq;
+
+namespace NachoCore.Model
+{
+    // Set the DisplayColor field for existing calendar folders.  Each calendar folder needs to have a unique
+    // value, and the values should be continuous.
+    public class NcMigration32 : NcMigration
+    {
+        public override int GetNumberOfObjects ()
+        {
+            // The number of calendar folders whose DisplayColor field is not set.
+            return Db.Table<McFolder> ()
+                .Where (x => (x.Type == Xml.FolderHierarchy.TypeCode.DefaultCal_8 ||
+                    x.Type == Xml.FolderHierarchy.TypeCode.UserCreatedCal_13) &&
+                    x.DisplayColor != 0)
+                .Count ();
+        }
+
+        public override void Run (System.Threading.CancellationToken token)
+        {
+            // Handle the case where this migration was interrupted during a previous run.  Look for any
+            // existing folders where DisplayColor is set, and then make sure any newly set folders have
+            // a value greater than that.
+            var maxIndexFolder = Db.Query<McFolder> (
+                "SELECT f.* FROM McFolder AS f " +
+                " WHERE f.Type IN " + Folder_Helpers.TypesToCommaDelimitedString (NachoFolders.FilterForCalendars) +
+                " AND f.DisplayColor <> 0 " +
+                " ORDER BY f.DisplayColor DESC").FirstOrDefault ();
+            int colorIndex = (null == maxIndexFolder) ? 1 : maxIndexFolder.DisplayColor + 1;
+
+            var calFoldersNeedingUpdate = Db.Query<McFolder> (
+                "SELECT f.* FROM McFolder AS f " +
+                " WHERE f.Type IN " + Folder_Helpers.TypesToCommaDelimitedString (NachoFolders.FilterForCalendars) +
+                " AND f.DisplayColor = 0");
+            foreach (var folder in calFoldersNeedingUpdate) {
+                token.ThrowIfCancellationRequested ();
+                folder.UpdateWithOCApply<McFolder> ((record) => {
+                    ((McFolder)record).DisplayColor = colorIndex++;
+                    return true;
+                });
+                UpdateProgress (1);
+            }
+        }
+    }
+}
+

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -721,12 +721,9 @@ namespace NachoClient.iOS
             var calendarName = (UILabel)View.ViewWithTag ((int)TagType.EVENT_CALENDAR_DETAIL_TAG);
             string accountName = account.DisplayName;
             string folderName = "(Unknown)";
-            var folderMapEntry = McMapFolderFolderEntry.QueryByFolderEntryIdClassCode (root.AccountId, root.Id, root.GetClassCode ()).FirstOrDefault ();
-            if (null != folderMapEntry) {
-                var folder = McFolder.QueryById<McFolder> (folderMapEntry.FolderId);
-                if (null != folder) {
-                    folderName = folder.DisplayName;
-                }
+            var folder = McFolder.QueryByFolderEntryId<McCalendar> (root.AccountId, root.Id).FirstOrDefault ();
+            if (null != folder) {
+                folderName = folder.DisplayName;
             }
             if (string.IsNullOrEmpty(accountName) || accountName == folderName) {
                 calendarName.Text = folderName;

--- a/NachoClient.iOS/NachoUI.iOS/Support/CalendarTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/CalendarTableViewSource.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using NachoCore.Model;
 using NachoCore;
 using NachoCore.Utils;
+using System.Linq;
 
 namespace NachoClient.iOS
 {
@@ -258,14 +259,20 @@ namespace NachoClient.iOS
             // Subject label view
             var subject = Pretty.SubjectString (c.GetSubject ());
 
-            var dotView = cell.ContentView.ViewWithTag (DOT_TAG) as UIImageView;
             var subjectLabelView = cell.ContentView.ViewWithTag (SUBJECT_TAG) as UILabel;
             subjectLabelView.Hidden = false;
- 
             subjectLabelView.Text = subject;
+
+            int colorIndex = 0;
+            var folder = McFolder.QueryByFolderEntryId<McCalendar> (cRoot.AccountId, cRoot.Id).FirstOrDefault ();
+            if (null != folder) {
+                colorIndex = folder.DisplayColor;
+            }
+
+            var dotView = cell.ContentView.ViewWithTag (DOT_TAG) as UIImageView;
             dotView.Frame = new CGRect (30, 20, 9, 9);
             var size = new CGSize (10, 10);
-            dotView.Image = Util.DrawCalDot (A.Color_CalDotBlue, size);
+            dotView.Image = Util.DrawCalDot (Util.CalendarColor (colorIndex), size);
             dotView.Hidden = false;
 
             // Duration label view
@@ -552,4 +559,3 @@ namespace NachoClient.iOS
         }
     }
 }
-

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
@@ -211,8 +211,12 @@ namespace NachoClient.iOS
             subjectLabelView.Text = subject;
             subjectLabelView.Hidden = false;
 
-            var size = new CGSize (10, 10);
-            dotView.Image = Util.DrawCalDot (A.Color_CalDotBlue, size);
+            int colorIndex = 0;
+            var folder = McFolder.QueryByFolderEntryId<McCalendar> (cRoot.AccountId, cRoot.Id).FirstOrDefault ();
+            if (null != folder) {
+                colorIndex = folder.DisplayColor;
+            }
+            dotView.Image = Util.DrawCalDot (Util.CalendarColor (colorIndex), new CGSize (10, 10));
             dotView.Hidden = false;
 
             var startString = "";

--- a/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
@@ -383,6 +383,30 @@ namespace NachoClient
             return image;
         }
 
+        /// <summary>
+        /// Colors to use to identify calendar folders.  These are temporary.  The final set of colors
+        /// has not been decided yet.
+        /// </summary>
+        private static UIColor[] calendarColors = {
+            UIColor.Blue,
+            UIColor.Red,
+            UIColor.Yellow,
+            UIColor.Green,
+            UIColor.Orange,
+            UIColor.Purple,
+            UIColor.Brown,
+            UIColor.Gray,
+            UIColor.Black,
+        };
+
+        public static UIColor CalendarColor (int colorIndex)
+        {
+            if (0 == colorIndex) {
+                return UIColor.White;
+            }
+            return calendarColors [(colorIndex - 1) % calendarColors.Length];
+        }
+
         public static UIImage DrawCalDot (UIColor circleColor, CGSize size)
         {
             var origin = new CGPoint (0, 0);


### PR DESCRIPTION
The dots on the left of each entry in the calendar view are now given
a color to match the folder that owns the event.  This provides the
user with a way to know where the event came from without having to
open the event detail.  (This does not affect the dots under the date
in the week view or the month view, just the ones in the rows for
individual events.)

Make the same change for the dot on the left of the hot event view.
