### PR TITLE
Prevent user from creating calendar item in IMAP account

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McAccount.cs
+++ b/NachoClient.Android/NachoCore/Model/McAccount.cs
@@ -68,7 +68,6 @@ namespace NachoCore.Model
 
         public const AccountCapabilityEnum DeviceCapabilities = (
                                                                     AccountCapabilityEnum.CalReader |
-                                                                    AccountCapabilityEnum.CalWriter |
                                                                     AccountCapabilityEnum.ContactReader |
                                                                     AccountCapabilityEnum.ContactWriter
                                                                 );

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1531,6 +1531,7 @@
     <Compile Include="..\NachoClient.Android\NachoCore\Utils\LoginProtocolControl.cs">
       <Link>NachoCore\Utils\LoginProtocolControl.cs</Link>
     </Compile>
+    <Compile Include="NachoCore\Model\Migration\NcMigration33.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/NachoClient.iOS/NachoCore/Model/Migration/NcMigration33.cs
+++ b/NachoClient.iOS/NachoCore/Model/Migration/NcMigration33.cs
@@ -1,0 +1,27 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+
+namespace NachoCore.Model
+{
+    // McAccount.DeviceCapabilities was changed, removing CalWriter.  Update the device account with the new
+    // set of capabilities.
+    public class NcMigration33 : NcMigration
+    {
+        public override int GetNumberOfObjects ()
+        {
+            return 1;
+        }
+
+        public override void Run (System.Threading.CancellationToken token)
+        {
+            var deviceAccount = McAccount.GetDeviceAccount ();
+            if (null != deviceAccount) {
+                deviceAccount.AccountCapability = McAccount.DeviceCapabilities;
+                deviceAccount.Update ();
+            }
+            UpdateProgress (1);
+        }
+    }
+}
+


### PR DESCRIPTION
Change the capabilities of the device account, removing the CalWriter
capability.  (This requires a migration to correct the capability of
any existing device account.)

Prevent the user from creating a new event when none of the accounts
on the device support writing to a calendar.
