### PR TITLE
Fix recent migrations to be in both platforms, not iOS only

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -487,6 +487,9 @@
     <Compile Include="NachoUI.Android\Support\WebViewNoScroll.cs" />
     <Compile Include="NachoCore\Adapters\ILoginProtocol.cs" />
     <Compile Include="NachoCore\Utils\LoginProtocolControl.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration31.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration32.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration33.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\AboutAssets.txt" />

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration31.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration31.cs
@@ -4,6 +4,8 @@ using System;
 
 namespace NachoCore.Model
 {
+    // Fill in the UID field in McEvents.
+
     public class NcMigration31 : NcMigration
     {
         public override int GetNumberOfObjects ()
@@ -21,4 +23,3 @@ namespace NachoCore.Model
         }
     }
 }
-

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration32.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration32.cs
@@ -1,14 +1,15 @@
 ﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
 //
 using System;
+using System.Linq;
 using NachoCore.ActiveSync;
 using NachoCore.Utils;
-using System.Linq;
 
 namespace NachoCore.Model
 {
     // Set the DisplayColor field for existing calendar folders.  Each calendar folder needs to have a unique
     // value, and the values should be continuous.
+
     public class NcMigration32 : NcMigration
     {
         public override int GetNumberOfObjects ()
@@ -48,4 +49,3 @@ namespace NachoCore.Model
         }
     }
 }
-

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration33.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration33.cs
@@ -6,6 +6,7 @@ namespace NachoCore.Model
 {
     // McAccount.DeviceCapabilities was changed, removing CalWriter.  Update the device account with the new
     // set of capabilities.
+
     public class NcMigration33 : NcMigration
     {
         public override int GetNumberOfObjects ()

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1523,15 +1523,21 @@
     <Compile Include="..\NachoClient.Android\NachoCore\Utils\NcMailKitProtocolLogger.cs">
       <Link>NachoCore\Utils\NcMailKitProtocolLogger.cs</Link>
     </Compile>
-    <Compile Include="NachoCore\Model\Migration\NcMigration31.cs" />
-    <Compile Include="NachoCore\Model\Migration\NcMigration32.cs" />
     <Compile Include="..\NachoClient.Android\NachoCore\Adapters\ILoginProtocol.cs">
       <Link>NachoCore\Adapters\ILoginProtocol.cs</Link>
     </Compile>
     <Compile Include="..\NachoClient.Android\NachoCore\Utils\LoginProtocolControl.cs">
       <Link>NachoCore\Utils\LoginProtocolControl.cs</Link>
     </Compile>
-    <Compile Include="NachoCore\Model\Migration\NcMigration33.cs" />
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration31.cs">
+      <Link>NachoCore\Model\Migration\NcMigration31.cs</Link>
+    </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration32.cs">
+      <Link>NachoCore\Model\Migration\NcMigration32.cs</Link>
+    </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration33.cs">
+      <Link>NachoCore\Model\Migration\NcMigration33.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />


### PR DESCRIPTION
When I recently created several new migrations, I put them in the iOS
project only.  They should have been available in both iOS and
Android.  This update fixes that oversight.
