### PR TITLE
Fix nachocove/NachoClientX#2116

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -634,7 +634,7 @@ namespace NachoClient.iOS
             var match = searchBar.Text;
             var quoted = Lucene.Net.QueryParsers.QueryParser.Escape (match);
             var wildcard = (char.IsWhiteSpace (quoted.Last<char> ())) ? "" : "*";
-            var query = quoted + wildcard;
+            var query = "*" + quoted + wildcard;
             var matches = index.SearchAllEmailMessageFields (query);
             searchResultsMessages.UpdateMatches (matches);
             List<int> adds;


### PR DESCRIPTION
- For a query string of "xamarin.com", it searches for "xamarin.com*" which is a string prefixed by "xamarin.com". This will not match Pathak@xamarin.com
- The fix is to add a prefix wildcard so it will match arbitrary substring. (E.g. "xamarin.com" becomes "_xamarin.com_".)
