### PR TITLE
Various minor fixes for events that come from the device calendar

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McAccount.cs
+++ b/NachoClient.Android/NachoCore/Model/McAccount.cs
@@ -266,6 +266,15 @@ namespace NachoCore.Model
 
         public bool FastNotificationEnabled { get; set; }
 
+        /// <summary>
+        /// Does this account have the given capability or capabilities?
+        /// </summary>
+        /// <param name="capability">A combination of capabilities from AccountCapabilityEnum</param>
+        public bool HasCapability (McAccount.AccountCapabilityEnum capability)
+        {
+            return (AccountCapability & capability) == capability;
+        }
+
         public static IEnumerable<McAccount> QueryByEmailAddr (string emailAddr)
         {
             return NcModel.Instance.Db.Table<McAccount> ().Where (x => x.EmailAddr == emailAddr);
@@ -281,7 +290,7 @@ namespace NachoCore.Model
             List<McAccount> result = new List<McAccount> ();
             var accounts = NcModel.Instance.Db.Table<McAccount> ();
             foreach (McAccount acc in accounts) {
-                if (accountCapabilities == (accountCapabilities & acc.AccountCapability)) {
+                if (acc.HasCapability (accountCapabilities)) {
                     result.Add (acc);
                 }
             }

--- a/NachoClient.Android/NachoCore/Model/McEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McEvent.cs
@@ -108,9 +108,13 @@ namespace NachoCore.Model
 
         public void SetReminder (uint reminderMinutes)
         {
-            ReminderTime = GetStartTimeUtc () - new TimeSpan (reminderMinutes * TimeSpan.TicksPerMinute);
-            Update ();
-            LocalNotificationManager.ScheduleNotification (this);
+            // Don't set a reminder if the event came from a device calendar.  The device's calendar app should handle those notifications.
+            // A notification from Nacho Mail would probably be a duplicate.
+            if (AccountId != McAccount.GetDeviceAccount ().Id) {
+                ReminderTime = GetStartTimeUtc () - new TimeSpan (reminderMinutes * TimeSpan.TicksPerMinute);
+                Update ();
+                LocalNotificationManager.ScheduleNotification (this);
+            }
         }
 
         public override int Delete ()

--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -188,6 +188,25 @@ namespace NachoPlatform
                 }
                 cal.TimeZone = new AsTimeZone (CalendarHelper.SimplifiedTimeZone (eventTimeZone), cal.StartTime).toEncodedTimeZone ();
 
+                if (null == Event.Organizer) {
+                    cal.MeetingStatus = NcMeetingStatus.Appointment;
+                } else {
+                    if (Event.Organizer.IsCurrentUser) {
+                        if (EKEventStatus.Cancelled == Event.Status) {
+                            cal.MeetingStatus = NcMeetingStatus.MeetingOrganizerCancelled;
+                        } else {
+                            cal.MeetingStatus = NcMeetingStatus.MeetingOrganizer;
+                        }
+                    } else {
+                        if (EKEventStatus.Cancelled == Event.Status) {
+                            cal.MeetingStatus = NcMeetingStatus.MeetingAttendeeCancelled;
+                        } else {
+                            cal.MeetingStatus = NcMeetingStatus.MeetingAttendee;
+                        }
+                    }
+                }
+                cal.MeetingStatusIsSet = true;
+
                 var attendees = new List<McAttendee> ();
                 var ekAttendees = Event.Attendees;
                 if (null != ekAttendees) {

--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -215,8 +215,7 @@ namespace NachoClient.iOS
             } else {
                 account = NcApplication.Instance.Account;
             }
-            if (0 == (account.AccountCapability & McAccount.AccountCapabilityEnum.CalWriter)) {
-                Log.Info (Log.LOG_CALENDAR, "The current account does not support writing to calendars. Using the device account instead.");
+            if (account.HasCapability (McAccount.AccountCapabilityEnum.CalWriter)) {
                 account = McAccount.QueryByAccountCapabilities (McAccount.AccountCapabilityEnum.CalWriter).FirstOrDefault ();
                 if (null == account) {
                     Log.Warn (Log.LOG_CALENDAR,


### PR DESCRIPTION
Set the McCalendar.MeetingStatus field when copying events from the
device calendar.

Don't show the "Cancel meeting" button when the meeting came from the
device calendar.

Disable the Attend/Maybe/Decline buttons on the calendar detail view
when the meeting came from the device calendar.

Don't allow the user to change the reminder time for an event when the
event came from the device calendar.

Don't schedule any local notifications for events that came from the
device calendar.  The Calendar app should take care of those
notifications.  Any notifications from Nacho Mail would likely be a
duplicate.

Don't display the "Remove from calendar" button when a canceled
meeting came from the device calendar.
