### PR TITLE
Don't crash when contact detail view is opened with no contact

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
@@ -1056,8 +1056,10 @@ namespace NachoClient.iOS
 
         protected void VipButtonTouchUpInside (object sender, EventArgs e)
         {
-            contact.SetVIP (!contact.IsVip);
-            UpdateVipButton ();
+            if (null != contact) {
+                contact.SetVIP (!contact.IsVip);
+                UpdateVipButton ();
+            }
         }
 
         protected void UpdateVipButton ()
@@ -1099,6 +1101,10 @@ namespace NachoClient.iOS
 
         public void RefreshData ()
         {
+            if (null == contact) {
+                return;
+            }
+
             UITableView interactionsTableView = (UITableView)View.ViewWithTag (INTERACTIONS_TABLE_VIEW_TAG);
 
             NachoCore.Utils.NcAbate.HighPriority ("ContactDetailViewController RefreshData");

--- a/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
@@ -999,6 +999,10 @@ namespace NachoClient
 
         public static void CallContact (string segueIdentifier, McContact contact, NcUIViewController owner)
         {
+            if (null == contact) {
+                ComplainAbout ("No Phone Number", "This contact does not have a phone number.");
+                return;
+            }
             if (0 == contact.PhoneNumbers.Count) {
                 if (contact.CanUserEdit ()) {
                     owner.PerformSegue (segueIdentifier, new SegueHolder (contact, ContactDefaultSelectionViewController.DefaultSelectionType.PhoneNumberAdder));
@@ -1020,6 +1024,10 @@ namespace NachoClient
 
         public static void EmailContact (string segueIdentifier, McContact contact, NcUIViewController owner)
         {
+            if (null == contact) {
+                ComplainAbout ("No Email Address", "This contact does not have an email address.");
+                return;
+            }
             if (0 == contact.EmailAddresses.Count) {
                 if (contact.CanUserEdit ()) {
                     owner.PerformSegue (segueIdentifier, new SegueHolder (contact, ContactDefaultSelectionViewController.DefaultSelectionType.EmailAdder));


### PR DESCRIPTION
When viewing a meeting that came from the device calendar, the
organizer and attendees don't have any corresponding McContacts.  So
opening the contact detail view results in a
ContactDetailViewController with a null contact.  The contact detail
view code did not handle that situation.  The app would crash when
loading the view, and when that was fixed, the app would crash when
the user interacted with the view in any way.

ContactDetailViewController has been fixed to not crash when it is
given a null contact.

(In a later update, I might change EventViewController to not open the
contact detail view at all if there is no McContact, but I want to
make the contact detail view more robust first.)
