### PR TITLE
Fix nachocove/qa#478

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
@@ -1041,16 +1041,19 @@ namespace NachoClient.iOS
                 ComplainAbout ("No phone number", "You've selected a contact who does not have a phone number");
                 return;
             }
-            PerformAction ("tel", number);
+            if (!PerformAction ("tel", number)) {
+                ComplainAbout ("Cannot dial", "The phone number seems to be invalid");
+            }
         }
 
-        protected void PerformAction (string action, string number)
+        protected bool PerformAction (string action, string number)
         {
             try {
                 UIApplication.SharedApplication.OpenUrl (new Uri (String.Format ("{0}:{1}", action, number)));
+                return true;
             } catch (Exception e) {
-                ComplainAbout ("Cannot dial", "The phone number seems to be invalid");
-                Log.Warn (Log.LOG_UI, "Cannot dail an invalid # ({0})", e);
+                Log.Warn (Log.LOG_UI, "Cannot perform action {0} ({1})", action, e);
+                return false;
             }
         }
 


### PR DESCRIPTION
- Multiple '#' are not valid phone numbers. (I tried it on iOS dialer. It fails as well.)
- Catch the exception when dialing an invalid number and display an alert.
