### PR TITLE
Fix nachocove/qa#477

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactEditViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactEditViewController.cs
@@ -1949,6 +1949,10 @@ namespace NachoClient.iOS
                     LayoutView ();
                 } else {
                     Dismiss ();
+                    dateView.Hidden = true;
+                    this.dateLabel.TextColor = A.Color_NachoGreen;
+                    ConfigureView ();
+                    LayoutView ();
                 }
             }
 
@@ -1960,10 +1964,6 @@ namespace NachoClient.iOS
                 // then construct a new DateTime with that date in UTC.
                 DateTime selectedDate = datePicker.Date.ToDateTime ().ToLocalTime ().Date;
                 dateAttribute.Value = new DateTime (selectedDate.Year, selectedDate.Month, selectedDate.Day, 0, 0, 0, DateTimeKind.Utc);
-                dateView.Hidden = true;
-                this.dateLabel.TextColor = A.Color_NachoGreen;
-                ConfigureView ();
-                LayoutView ();
             }
 
             protected void TrashButtonClicked (object sender, EventArgs e)


### PR DESCRIPTION
- When "Save" is clicked, save the value of all visible date pickers and dismiss them.
- When edit an existing date, set the date picker to the existing value instead of the current date. (Use the current date only for new date attribute.)
