### PR TITLE
add apis needed for message deferral

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -490,6 +490,7 @@
     <Compile Include="NachoCore\Model\Migration\NcMigration31.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration32.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration33.cs" />
+    <Compile Include="NachoCore\BackEnd\IMAP\ImapProtoControlApis.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\AboutAssets.txt" />

--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapProtoControl.cs
@@ -12,7 +12,7 @@ using System.Threading;
 
 namespace NachoCore.IMAP
 {
-    public class ImapProtoControl : NcProtoControl, IPushAssistOwner
+    public partial class ImapProtoControl : NcProtoControl, IPushAssistOwner
     {
         public NcImapClient MainClient;
 

--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapProtoControlApis.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapProtoControlApis.cs
@@ -1,0 +1,84 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+using NachoCore;
+using NachoCore.Utils;
+using NachoCore.Model;
+
+namespace NachoCore.IMAP
+{
+    public partial class ImapProtoControl : NcProtoControl, IBEContext
+    {
+        public override NcResult SetEmailFlagCmd (int emailMessageId, string flagType, 
+            DateTime start, DateTime utcStart, DateTime due, DateTime utcDue)
+        {
+            NcResult result = NcResult.Error (NcResult.SubKindEnum.Error_UnknownCommandFailure);
+            NcResult.SubKindEnum subKind;
+            McEmailMessage emailMessage;
+            McFolder folder;
+            NcModel.Instance.RunInTransaction (() => {
+                if (!GetItemAndFolder<McEmailMessage> (emailMessageId, out emailMessage, -1, out folder, out subKind)) {
+                    result = NcResult.Error (subKind);
+                    return;
+                }
+                // TODO Do something to save this on the server.
+                // Set the Flag info in the DB item.
+                emailMessage.FlagStatus = (uint)McEmailMessage.FlagStatusValue.Active;
+                emailMessage.FlagType = flagType;
+                emailMessage.FlagStartDate = start;
+                emailMessage.FlagUtcStartDate = utcStart;
+                emailMessage.FlagDue = due;
+                emailMessage.FlagUtcDue = utcDue;
+                emailMessage.Update ();
+                result = NcResult.OK ();
+            });
+            StatusInd (NcResult.Info (NcResult.SubKindEnum.Info_EmailMessageSetFlagSucceeded));
+            Log.Warn (Log.LOG_IMAP, "Flag saved in DB, but not on server.");
+            return result;
+        }
+
+        public override NcResult ClearEmailFlagCmd (int emailMessageId)
+        {
+            NcResult result = NcResult.Error (NcResult.SubKindEnum.Error_UnknownCommandFailure);
+            NcResult.SubKindEnum subKind;
+            McEmailMessage emailMessage;
+            McFolder folder;
+            NcModel.Instance.RunInTransaction (() => {
+                if (!GetItemAndFolder<McEmailMessage> (emailMessageId, out emailMessage, -1, out folder, out subKind)) {
+                    result = NcResult.Error (subKind);
+                    return;
+                }
+
+                result = NcResult.OK ();
+                emailMessage.FlagStatus = (uint)McEmailMessage.FlagStatusValue.Cleared;
+                emailMessage.Update ();
+            });
+            StatusInd (NcResult.Info (NcResult.SubKindEnum.Info_EmailMessageClearFlagSucceeded));
+            Log.Warn (Log.LOG_IMAP, "Flag cleared in DB, but not on server.");
+            return result;
+        }
+
+        public override NcResult MarkEmailFlagDone (int emailMessageId,
+            DateTime completeTime, DateTime dateCompleted)
+        {
+            NcResult result = NcResult.Error (NcResult.SubKindEnum.Error_UnknownCommandFailure);
+            NcResult.SubKindEnum subKind;
+            McEmailMessage emailMessage;
+            McFolder folder;
+            NcModel.Instance.RunInTransaction (() => {
+                if (!GetItemAndFolder<McEmailMessage> (emailMessageId, out emailMessage, -1, out folder, out subKind)) {
+                    result = NcResult.Error (subKind);
+                    return;
+                }
+                result = NcResult.OK ();
+                emailMessage.FlagStatus = (uint)McEmailMessage.FlagStatusValue.Complete;
+                emailMessage.FlagCompleteTime = completeTime;
+                emailMessage.FlagDateCompleted = dateCompleted;
+                emailMessage.Update ();
+            });
+            Log.Warn (Log.LOG_IMAP, "Marked Done in DB, but not on server.");
+            return result;
+        }
+    }
+}
+

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1539,6 +1539,9 @@
     <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration33.cs">
       <Link>NachoCore\Model\Migration\NcMigration33.cs</Link>
     </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\BackEnd\IMAP\ImapProtoControlApis.cs">
+      <Link>NachoCore\BackEnd\IMAP\ImapProtoControlApis.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />


### PR DESCRIPTION
Gets saved in the DB, but not on the server

From Jeff: 

```
There are some back end Apis related to flags that IMAP doesn't implement because the protocol doesn't support them.

If you implement just the model setting part of the Apis then these features (nothing in the pending queue) then the features will work.
```
