### PR TITLE
Don't crash when message is deleted while message detail view is open

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -128,12 +128,15 @@ namespace NachoClient.iOS
             if (null != thread) {
                 var now = DateTime.UtcNow;
                 var message = thread.FirstMessageSpecialCase ();
-                Telemetry.RecordFloatTimeSeries ("MessageViewController.Duration", appearTime, (now - appearTime).TotalMilliseconds);
-                Telemetry.RecordIntTimeSeries ("McEmailMessage.Read.Id", appearTime, message.Id);
-                Telemetry.RecordFloatTimeSeries ("McEmailMessage.Read.Score", appearTime, message.Score);
-                var body = McBody.QueryById<McBody> (message.BodyId);
-                if (McBody.IsComplete (body)) {
-                    Telemetry.RecordIntTimeSeries ("McEmailMessage.Read.BodyFileLength", appearTime, (int)body.FileSize);
+                // The message may have been deleted while the view was open.
+                if (null != message) {
+                    Telemetry.RecordFloatTimeSeries ("MessageViewController.Duration", appearTime, (now - appearTime).TotalMilliseconds);
+                    Telemetry.RecordIntTimeSeries ("McEmailMessage.Read.Id", appearTime, message.Id);
+                    Telemetry.RecordFloatTimeSeries ("McEmailMessage.Read.Score", appearTime, message.Score);
+                    var body = McBody.QueryById<McBody> (message.BodyId);
+                    if (McBody.IsComplete (body)) {
+                        Telemetry.RecordIntTimeSeries ("McEmailMessage.Read.BodyFileLength", appearTime, (int)body.FileSize);
+                    }
                 }
             }
             base.ViewWillDisappear (animated);


### PR DESCRIPTION
Some recent telemetry changes assume that the message is still
available in MessageViewController.ViewWillDisappear().  That is not
true if the message was deleted while the view was open.  One common
way for the message to be deleted is for the user to accept a meeting
request.

Change the code to protect against a missing message.
