### PR TITLE
Improve the algorithm for choosing the hot event

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McAbstrCalendarRoot.cs
+++ b/NachoClient.Android/NachoCore/Model/McAbstrCalendarRoot.cs
@@ -117,6 +117,16 @@ namespace NachoCore.Model
             return HasResponseType () ? ResponseType : NcResponseType.None;
         }
 
+        public virtual bool HasMeetingStatus ()
+        {
+            return MeetingStatusIsSet;
+        }
+
+        public virtual NcMeetingStatus GetMeetingStatus ()
+        {
+            return HasMeetingStatus () ? MeetingStatus : NcMeetingStatus.Appointment;
+        }
+
         /// <summary>
         /// Return the UID for this event.  This method must be overridden by derived classes.
         /// </summary>

--- a/NachoClient.Android/NachoCore/Model/McEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McEvent.cs
@@ -132,45 +132,11 @@ namespace NachoCore.Model
             }
         }
 
-        /// <summary>
-        /// Return the event that is currently in progress, or the next one to start.
-        /// Ignore events associated with a canceled meeting.  Ignore events that are
-        /// more than a week away.  Return null if no event is found.
-        /// </summary>
-        public static McEvent GetCurrentOrNextEvent()
+        public static TableQuery<McEvent> UpcomingEvents (TimeSpan window)
         {
-            // Due to the way that all-day events are stored, the StartTime field of the event may be different than
-            // the start time that we want to present to the user.  So we have to handle the case where the database
-            // returns events in what appears to be the wrong order.
             DateTime now = DateTime.UtcNow;
-            DateTime weekInFuture = now + new TimeSpan (7, 0, 0, 0);
-            McEvent result = null;
-            foreach (var evt in NcModel.Instance.Db.Table<McEvent> ().Where (x => x.EndTime >= now && x.StartTime < weekInFuture).OrderBy (x => x.StartTime)) {
-                var cal = evt.GetCalendarItemforEvent ();
-                if (null != cal && (NcMeetingStatus.MeetingOrganizerCancelled == cal.MeetingStatus || NcMeetingStatus.MeetingAttendeeCancelled == cal.MeetingStatus)) {
-                    // A meeting that has been canceled.  Ignore it.
-                    continue;
-                }
-                if (null == result) {
-                    // The first event that we have looked at.  Make a note of it and keep looking.
-                    result = evt;
-                } else if (evt.GetStartTimeUtc () < result.GetStartTimeUtc ()) {
-                    // Found an out-of-order event.  None of the later events will be any earlier, so we can quit now.
-                    result = evt;
-                    break;
-                } else if (result.AllDayEvent && evt.GetStartTimeUtc () > result.GetStartTimeUtc ()) {
-                    // None of the later events will be any earlier than the all-day event that we already have,
-                    // so we can quit now.
-                    break;
-                } else if (!result.AllDayEvent && (evt.AllDayEvent || evt.GetStartTimeUtc () > DateTime.SpecifyKind (result.GetStartTimeLocal ().Date, DateTimeKind.Utc))) {
-                    // We found an event whose starting time (as recorded in the database) is later than the
-                    // starting time of an all-day event on the current day.  Therefore, if we keep looking we
-                    // will not find any all-day events that start earlier than the non-all-day event that we
-                    // already have.  So we can quit now.
-                    break;
-                }
-            }
-            return result;
+            DateTime end = now.Add (window);
+            return NcModel.Instance.Db.Table<McEvent> ().Where (x => x.EndTime >= now && x.StartTime < end).OrderBy (x => x.StartTime);
         }
 
         /// <summary>

--- a/NachoClient.Android/NachoCore/Model/McException.cs
+++ b/NachoClient.Android/NachoCore/Model/McException.cs
@@ -61,6 +61,16 @@ namespace NachoCore.Model
             return this.ResponseTypeIsSet ? this.ResponseType : CalendarItemOrSelf ().ResponseType;
         }
 
+        public override bool HasMeetingStatus ()
+        {
+            return this.MeetingStatusIsSet || CalendarItemOrSelf ().MeetingStatusIsSet;
+        }
+
+        public override NcMeetingStatus GetMeetingStatus ()
+        {
+            return this.MeetingStatusIsSet ? this.MeetingStatus : CalendarItemOrSelf ().MeetingStatus;
+        }
+
         public override string GetUID ()
         {
             var cal = CalendarItem ();

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
@@ -128,7 +128,8 @@ namespace NachoClient.iOS
 
         public void Configure ()
         {
-            currentEvent = McEvent.GetCurrentOrNextEvent ();
+            DateTime timerFireTime;
+            currentEvent = CalendarHelper.CurrentOrNextEvent (out timerFireTime);
             ConfigureCurrentEvent ();
 
             if (null != eventEndTimer) {
@@ -139,10 +140,10 @@ namespace NachoClient.iOS
             // Set a timer to fire at the end of the currently displayed event, so the view can
             // be reconfigured to show the next event.
             if (null != currentEvent) {
-                TimeSpan timerDuration = currentEvent.GetEndTimeUtc () - DateTime.UtcNow;
+                TimeSpan timerDuration = timerFireTime - DateTime.UtcNow;
                 if (timerDuration < TimeSpan.Zero) {
-                    // The event ended in between GetCurrentOrNextEvent running its query and now.
-                    // Configure the timer to fire immediately.
+                    // The time to reevaluate the current event was in the very near future, and that time was reached in between
+                    // CurrentOrNextEvent() and now.  Configure the timer to fire immediately.
                     timerDuration = TimeSpan.Zero;
                 }
                 eventEndTimer = new NcTimer ("HotEventView", (state) => {


### PR DESCRIPTION
The hot event view would often show an event that was not the event
that the user was most interested in seeing.  For example, it would
always show an all-day event for the day instead of events that happen
during the day.

Change the algorithm for choosing the hot event to take a number of
factors into account.  As a couple of examples, events that start in
the next 30 minutes are preferred over events that are currently in
progress, and non-all-day events are usually preferred over all-day
events.
