### PR TITLE
Fix notes view

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
@@ -191,7 +191,7 @@ namespace NachoClient.iOS
             }
             if (segue.Identifier.Equals ("ContactToNotes")) {
                 var dc = (NotesViewController)segue.DestinationViewController;
-                dc.SetOwner (this, contact.GetDisplayNameOrEmailAddress ());
+                dc.SetOwner (this, contact.GetDisplayNameOrEmailAddress (), insertDate: true);
                 return;
             }
             if (segue.Identifier.Equals ("ContactToContactEdit")) {

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -906,7 +906,7 @@ namespace NachoClient.iOS
 
             if (segue.Identifier.Equals ("EventToNotes")) {
                 var dc = (NotesViewController)segue.DestinationViewController;
-                dc.SetOwner (this, c.GetSubject ());
+                dc.SetOwner (this, c.GetSubject (), insertDate: false);
                 return;
             }
 

--- a/NachoClient.iOS/NachoUI.iOS/FileListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/FileListViewController.cs
@@ -347,7 +347,7 @@ namespace NachoClient.iOS
                 var dc = (NotesViewController)segue.DestinationViewController;
                 var holder = sender as SegueHolder;
                 selectedNote = (McNote)holder.value;
-                dc.SetOwner (this, null);
+                dc.SetOwner (this, null, insertDate: false);
                 return;
             }
             if (segue.Identifier.Equals (FilesToNotesModalSegueId)) {

--- a/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoNotesController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoNotesController.cs
@@ -8,7 +8,7 @@ namespace NachoClient.iOS
 {
     public interface INachoNotesController
     {
-        void SetOwner (INachoNotesControllerParent owner, string title);
+        void SetOwner (INachoNotesControllerParent owner, string title, bool insertDate);
     }
 
     public interface INachoNotesControllerParent

--- a/NachoClient.iOS/NachoUI.iOS/NotesViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NotesViewController.cs
@@ -16,16 +16,19 @@ namespace NachoClient.iOS
 
         private INachoNotesControllerParent owner;
         private string itemTitle;
+        private bool insertDate;
+        private string unmodifiedText;
 
         private NcTextView textView;
 
         private static nfloat HORIZONTAL_MARGIN = 15f;
         private static nfloat VERTICAL_MARGIN = 15f;
 
-        public void SetOwner (INachoNotesControllerParent owner, string title)
+        public void SetOwner (INachoNotesControllerParent owner, string title, bool insertDate)
         {
             this.owner = owner;
             this.itemTitle = title;
+            this.insertDate = insertDate;
         }
 
         protected override void CreateViewHierarchy ()
@@ -41,8 +44,16 @@ namespace NachoClient.iOS
 
         protected override void ConfigureAndLayout ()
         {
-            textView.Text = owner.GetNoteText ();
-            textView.SelectedRange = new NSRange (0, 0);
+            if (insertDate) {
+                string dateString = DateTime.Now.ToShortDateString ();
+                unmodifiedText = dateString + "\n\n\n" + owner.GetNoteText ();
+                textView.Text = unmodifiedText;
+                textView.SelectedRange = new NSRange (dateString.Length + 1, 0);
+            } else {
+                unmodifiedText = owner.GetNoteText ();
+                textView.Text = unmodifiedText;
+                textView.SelectedRange = new NSRange (0, 0);
+            }
             textView.BecomeFirstResponder ();
 
             Layout ();
@@ -87,7 +98,9 @@ namespace NachoClient.iOS
         public override void ViewWillDisappear (bool animated)
         {
             base.ViewWillDisappear (animated);
-            owner.SaveNote (textView.Text);
+            if (textView.Text != unmodifiedText) {
+                owner.SaveNote (textView.Text);
+            }
         }
 
         public override bool HidesBottomBarWhenPushed


### PR DESCRIPTION
The notes view (implemented by NotesViewController, and used to edit
notes for both calendars and contacts) was badly broken.  The top half
of the screen was useless empty space, and the view did not scroll to
keep the cursor visible.

Fix these problems by rewriting NotesViewController.  The view has
been greatly simplified, now consisting of only a UITextView.

Fix nachocove/qa#348
