### PR TITLE
Fix nachocove/qa#499

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NachoMessageSearchResults.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoMessageSearchResults.cs
@@ -61,20 +61,22 @@ namespace NachoCore
                 }
             }
 
-            list.RemoveAll ((McEmailMessageThread obj) => IsValid (obj));
+            var messageIdSet = new HashSet<string> ();
+
+            list.RemoveAll ((McEmailMessageThread messageIndex) => {
+                // As messages are moved, they change index & become
+                // unavailable.  Deferred messages should be hidden.
+                var message = messageIndex.FirstMessageSpecialCase ();
+                if ((null == message) || message.IsDeferred ()) {
+                    return true;
+                }
+                if (String.IsNullOrEmpty (message.MessageID)) {
+                    return false;
+                }
+                return !messageIdSet.Add (message.MessageID);
+            });
 
             Refresh (out adds, out deletes);
-        }
-
-        // As messages are moved, they change index & become
-        // unavailable.  Deferred messages should be hidden.
-        protected bool IsValid (McEmailMessageThread messageIndex)
-        {
-            var message = messageIndex.FirstMessageSpecialCase ();
-            if ((null == message) || message.IsDeferred ()) {
-                return true;
-            }
-            return false;
         }
 
         public bool Refresh (out List<int> adds, out List<int> deletes)


### PR DESCRIPTION
- For Gmail, there seems to be 2 copies of every email. One email is under "All Mail" and the other is in the normal folder (e.g. Inbox). I think this is because Gmail uses tag not folders and translating to a folder structure results in 2 copies in two folders. The problem is that when searching, both copies match.
- Turns out even though they have different db ids, they have the same MessageID. So, I can dedup match results using that.
