### PR TITLE
Missing '!' was causing crash when adding event to Gmail calendar

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -215,7 +215,7 @@ namespace NachoClient.iOS
             } else {
                 account = NcApplication.Instance.Account;
             }
-            if (account.HasCapability (McAccount.AccountCapabilityEnum.CalWriter)) {
+            if (!account.HasCapability (McAccount.AccountCapabilityEnum.CalWriter)) {
                 account = McAccount.QueryByAccountCapabilities (McAccount.AccountCapabilityEnum.CalWriter).FirstOrDefault ();
                 if (null == account) {
                     Log.Warn (Log.LOG_CALENDAR,


### PR DESCRIPTION
A mistake during refactoring resulted in a crash when the user tried
to create a calendar item when the current account was a Gmail or IMAP
account.  Fix the problem so that the user gets a proper error message
in this situation.

Fix nachocove/qa#520
Fix https://support.nachocove.com/helpdesk/tickets/156
