### PR TITLE
More login changes

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/ILoginProtocol.cs
+++ b/NachoClient.Android/NachoCore/Adapters/ILoginProtocol.cs
@@ -44,6 +44,8 @@ namespace NachoCore
         void ShowWaitingScreen (string waitingMessage);
 
         void ShowDuplicateAccount();
+
+        void ShowCertRejected();
     }
 }
 

--- a/NachoClient.Android/NachoCore/Utils/LoginHelpers.cs
+++ b/NachoClient.Android/NachoCore/Utils/LoginHelpers.cs
@@ -188,5 +188,10 @@ namespace NachoCore.Utils
             }
         }
 
+        public static bool AccountExists (string emailAddress)
+        {
+            var existingAccount = McAccount.QueryByEmailAddr (emailAddress).SingleOrDefault ();
+            return (null != existingAccount);
+        }
     }
 }

--- a/NachoClient.Android/NachoCore/Utils/LoginProtocolControl.cs
+++ b/NachoClient.Android/NachoCore/Utils/LoginProtocolControl.cs
@@ -17,6 +17,7 @@ namespace NachoCore.Utils
             SubmitWait,
             TutorialSupportWait,
             FinishWait,
+            Quit,
         };
 
         public enum Prompt
@@ -291,7 +292,7 @@ namespace NachoCore.Utils
                             new Trans { Event = (uint)Events.E.CertAccepted, Act = StartSync, State = (uint)States.SyncWait },
                             new Trans { Event = (uint)Events.E.TryAgain, Act = StartSync, State = (uint)States.SyncWait },
                             new Trans { Event = (uint)Events.E.Quit, Act = Quit, State = (uint)States.Start },
-                            new Trans { Event = (uint)Events.E.CertRejected, Act = ShowAdvancedConfiguration, State = (uint)States.SubmitWait },
+                            new Trans { Event = (uint)Events.E.CertRejected, Act = ShowCertRejected, State = (uint)States.Quit },
                             new Trans { Event = (uint)Events.E.AccountCreated, Act = StartSync, State = (uint)States.SyncWait },
                             new Trans { Event = (uint)Events.E.ShowSupport, Act = ShowSupport, State = (uint)States.TutorialSupportWait },
                         }
@@ -358,7 +359,6 @@ namespace NachoCore.Utils
                             (uint)Events.E.Running,
                             (uint)Events.E.ServerConfCallback,
                             (uint)Events.E.ServerUpdate,
-                            (uint)Events.E.ShowAdvanced,
                             (uint)Events.E.StartOver,
                             (uint)Events.E.ShowSupport,
                             (uint)Events.E.ShowTutorial,
@@ -368,6 +368,44 @@ namespace NachoCore.Utils
                         },
                         On = new Trans[] {
                             new Trans { Event = (uint)Events.E.AllDone, Act = Noop, State = (uint)States.Start },
+                            new Trans { Event = (uint)Events.E.ShowAdvanced, Act = ShowAdvancedConfiguration, State = (uint)States.SubmitWait },
+                        }
+                    },
+                    new Node {
+                        State = (uint)States.Quit,
+                        Drop = new uint [] {
+                            (uint)Events.E.AllDone,
+                            (uint)Events.E.AccountCreated,
+                            (uint)Events.E.CertAccepted,
+                            (uint)Events.E.CertAskCallback,
+                            (uint)Events.E.CertRejected,
+                            (uint)Events.E.CredUpdate,
+                            (uint)Events.E.CredReqCallback,
+                            (uint)Events.E.DuplicateAccount,
+                            (uint)Events.E.Error,
+                            (uint)Events.E.ExchangePicked,
+                            (uint)Events.E.GetPassword,
+                            (uint)Events.E.GmailPicked,
+                            (uint)Events.E.KnownServicePicked,
+                            (uint)Events.E.ImapPicked,
+                            (uint)Events.E.NoNetwork,
+                            (uint)Events.E.NoService,
+                            (uint)Events.E.NotYetStarted,
+                            (uint)Events.E.PostAutoDPostInboxSync,
+                            (uint)Events.E.PostAutoDPreInboxSync,
+                            (uint)Events.E.Running,
+                            (uint)Events.E.ServerConfCallback,
+                            (uint)Events.E.ServerUpdate,
+                            (uint)Events.E.ShowAdvanced,
+                            (uint)Events.E.StartOver,
+                            (uint)Events.E.ShowSupport,
+                            (uint)Events.E.ShowTutorial,
+                            (uint)Events.E.TryAgain,
+                        },
+                        Invalid = new uint [] {
+                        },
+                        On = new Trans[] {
+                            new Trans { Event = (uint)Events.E.Quit, Act = Quit, State = (uint)States.Start },
                         }
                     },
                 },
@@ -481,6 +519,11 @@ namespace NachoCore.Utils
         void ShowCredReq ()
         {
             owner.ShowCredReq ();
+        }
+
+        void ShowCertRejected()
+        {
+            owner.ShowCertRejected ();
         }
 
         void ShowWaitingScreen ()

--- a/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
@@ -203,7 +203,7 @@ namespace NachoClient.iOS
                 var holder = (SegueHolder)sender;
                 var thread = (McEmailMessageThread)holder.value;
                 var vc = (INachoDateController)segue.DestinationViewController;
-                vc.Setup (this, thread, DateControllerType.Defer);
+                vc.Setup (this, thread, NcMessageDeferral.MessageDateType.Defer);
                 return;
             }
             if (segue.Identifier == "MessageListToFolders") {
@@ -1135,14 +1135,13 @@ namespace NachoClient.iOS
             NachoCore.Utils.NcAbate.RegularPriority ("ContactDetailViewController RefreshData");
         }
 
-        public void DateSelected (MessageDeferralType request, McEmailMessageThread thread, DateTime selectedDate)
+        public void DateSelected (NcMessageDeferral.MessageDateType type, MessageDeferralType request, McEmailMessageThread thread, DateTime selectedDate)
         {
-            NcMessageDeferral.DeferThread (thread, request, selectedDate);
+            NcMessageDeferral.DateSelected (type, thread, request, selectedDate);
         }
 
         public void DismissChildDateController (INachoDateController vc)
         {
-            vc.Setup (null, null, DateControllerType.None);
             vc.DismissDateController (false, new Action (delegate {
                 this.DismissViewController (true, null);
             }));

--- a/NachoClient.iOS/NachoUI.iOS/IntentSelectionViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/IntentSelectionViewController.cs
@@ -97,7 +97,7 @@ namespace NachoClient.iOS
         {
             if (segue.Identifier == "SegueToMessagePriority") {
                 var vc = (INachoDateController)segue.DestinationViewController;
-                vc.Setup (dateOwner, null, DateControllerType.Intent);
+                vc.Setup (dateOwner, null, NcMessageDeferral.MessageDateType.Intent);
                 vc.SetIntentSelector (this);
                 return;
             }

--- a/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoDateController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoDateController.cs
@@ -3,25 +3,23 @@
 using System;
 using Foundation;
 using NachoCore.Model;
+using NachoCore.Brain;
 
 namespace NachoClient.iOS
 {
-    public enum DateControllerType {
-        None,
-        Defer,
-        Intent,
-    }
-
     public interface INachoDateController
     {
-        void Setup (INachoDateControllerParent owner, McEmailMessageThread thread, DateControllerType dateControllerType);
+        void Setup (INachoDateControllerParent owner, McEmailMessageThread thread, NcMessageDeferral.MessageDateType dateControllerType);
+
         void SetIntentSelector (IntentSelectionViewController selector);
+
         void DismissDateController (bool animated, Action action);
     }
 
     public interface INachoDateControllerParent
     {
-        void DateSelected (MessageDeferralType request, McEmailMessageThread thread, DateTime selectedDate);
+        void DateSelected (NcMessageDeferral.MessageDateType type, MessageDeferralType request, McEmailMessageThread thread, DateTime selectedDate);
+
         void DismissChildDateController (INachoDateController vc);
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/MainStoryboard_iPhone.storyboard
+++ b/NachoClient.iOS/NachoUI.iOS/MainStoryboard_iPhone.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="Ds7-Ad-QXl">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="Ds7-Ad-QXl">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
@@ -628,6 +628,7 @@
                         <segue destination="15q-DA-GFk" kind="push" identifier="SegueToEditEvent" id="twQ-jE-jZd"/>
                         <segue destination="v8Y-11-4jc" kind="modal" identifier="MessageViewToFolders" modalTransitionStyle="crossDissolve" id="c2Q-C8-ZgX"/>
                         <segue destination="tAw-fh-hJX" kind="push" identifier="SegueToMailTo" id="EUF-Gz-AvW"/>
+                        <segue destination="MCC-ND-pIu" kind="modal" identifier="SegueToMessageDeadline" modalTransitionStyle="crossDissolve" id="vSR-5M-L48"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LjP-vQ-4le" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -977,7 +978,7 @@
             <objects>
                 <viewController storyboardIdentifier="MessagePriorityViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="MCC-ND-pIu" customClass="MessagePriorityViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ojE-Gm-ggk">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="64" width="320" height="568"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
@@ -1514,7 +1515,6 @@
         <simulatedScreenMetrics key="destination" type="retina4"/>
     </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
-        <segue reference="62b-xt-XXd"/>
         <segue reference="V0S-kd-9OI"/>
         <segue reference="iqA-wd-xqD"/>
         <segue reference="A0a-NV-skH"/>
@@ -1527,23 +1527,24 @@
         <segue reference="qrX-U2-XFP"/>
         <segue reference="HwV-au-Wta"/>
         <segue reference="XQg-JR-vxA"/>
+        <segue reference="Aba-pv-mzB"/>
+        <segue reference="TEI-cG-N0R"/>
+        <segue reference="VR8-PG-xAi"/>
+        <segue reference="DcC-EH-FAx"/>
+        <segue reference="QDW-pm-HY2"/>
+        <segue reference="jZp-Tj-sBa"/>
+        <segue reference="c2Q-C8-ZgX"/>
+        <segue reference="twQ-jE-jZd"/>
+        <segue reference="vSR-5M-L48"/>
+        <segue reference="vUs-ft-xdy"/>
+        <segue reference="RHB-Or-A5o"/>
+        <segue reference="zby-Sy-Y3J"/>
+        <segue reference="xrp-ey-B0j"/>
         <segue reference="rew-s7-VAQ"/>
+        <segue reference="Vqu-N7-OvL"/>
         <segue reference="22b-Az-fdF"/>
         <segue reference="Kfq-r2-VA6"/>
         <segue reference="nJv-0g-ewn"/>
-        <segue reference="QDW-pm-HY2"/>
-        <segue reference="jZp-Tj-sBa"/>
-        <segue reference="vUs-ft-xdy"/>
-        <segue reference="VR8-PG-xAi"/>
-        <segue reference="Aba-pv-mzB"/>
-        <segue reference="TEI-cG-N0R"/>
-        <segue reference="DcC-EH-FAx"/>
-        <segue reference="Ruw-76-4Ym"/>
-        <segue reference="P25-H0-Oji"/>
-        <segue reference="Vqu-N7-OvL"/>
-        <segue reference="FUw-4q-4q9"/>
-        <segue reference="xrp-ey-B0j"/>
-        <segue reference="zby-Sy-Y3J"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.062745101749897003" green="0.27450981736183167" blue="0.30980393290519714" alpha="1" colorSpace="deviceRGB"/>
 </document>

--- a/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
@@ -1079,7 +1079,7 @@ namespace NachoClient.iOS
         }
 
         // INachoDateControllerParent called from IntentSelectionViewController -> Date selector
-        public void DateSelected (MessageDeferralType request, McEmailMessageThread thread, DateTime selectedDate)
+        public void DateSelected (NcMessageDeferral.MessageDateType type, MessageDeferralType request, McEmailMessageThread thread, DateTime selectedDate)
         {
             // Assumption -- SelectMessageIntent was already called
             NcAssert.True (McEmailMessage.IntentType.None != messageIntent);
@@ -1089,7 +1089,6 @@ namespace NachoClient.iOS
         // INachoDateControllerParent
         public void DismissChildDateController (INachoDateController vc)
         {
-            vc.Setup (null, null, DateControllerType.None);
             vc.DismissDateController (false, null);
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -426,7 +426,7 @@ namespace NachoClient.iOS
                 var holder = (SegueHolder)sender;
                 var thread = (McEmailMessageThread)holder.value;
                 var vc = (INachoDateController)segue.DestinationViewController;
-                vc.Setup (this, thread, DateControllerType.Defer);
+                vc.Setup (this, thread, NcMessageDeferral.MessageDateType.Defer);
                 return;
             }
             if (segue.Identifier == "MessageListToFolders") {
@@ -508,14 +508,13 @@ namespace NachoClient.iOS
             vc.DismissMessageEditor (false, null);
         }
 
-        public void DateSelected (MessageDeferralType request, McEmailMessageThread thread, DateTime selectedDate)
+        public void DateSelected (NcMessageDeferral.MessageDateType type, MessageDeferralType request, McEmailMessageThread thread, DateTime selectedDate)
         {
-            NcMessageDeferral.DeferThread (thread, request, selectedDate);
+            NcMessageDeferral.DateSelected (type, thread, request, selectedDate);
         }
 
         public void DismissChildDateController (INachoDateController vc)
         {
-            vc.Setup (null, null, DateControllerType.None);
             vc.DismissDateController (false, null);
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -277,7 +277,7 @@ namespace NachoClient.iOS
                 var holder = (SegueHolder)sender;
                 var thread = (McEmailMessageThread)holder.value;
                 var vc = (INachoDateController)segue.DestinationViewController;
-                vc.Setup (this, thread, DateControllerType.Defer);
+                vc.Setup (this, thread, NcMessageDeferral.MessageDateType.Defer);
                 return;
             }
             if (segue.Identifier == "NachoNowToFolders") {
@@ -444,14 +444,13 @@ namespace NachoClient.iOS
             vc.DismissMessageEditor (false, null);
         }
 
-        public void DateSelected (MessageDeferralType request, McEmailMessageThread thread, DateTime selectedDate)
+        public void DateSelected (NcMessageDeferral.MessageDateType type, MessageDeferralType request, McEmailMessageThread thread, DateTime selectedDate)
         {
-            NcMessageDeferral.DeferThread (thread, request, selectedDate);
+            NcMessageDeferral.DateSelected (type, thread, request, selectedDate);
         }
 
         public void DismissChildDateController (INachoDateController vc)
         {
-            vc.Setup (null, null, DateControllerType.None);
             vc.DismissDateController (false, null);
         }
 


### PR DESCRIPTION
Fix nachocove/qa#528, change default smtp port to 587.
Fix nachocove/qa#514, don't complain about dup accounts
when resettings passwords.  Fix nachocove/qa#540, do not
enable submit button unless email & password have values.
Fix nachocove/qa#456, handle rejected cert by quitting the
add-account process.  Change message priority to pick fixed
times instead of just offering the date spinner.  Show image
and name of a service when prompting for credentials.  Fix
nachocove/qa#529 crash when returning from support to advanced.
Fix nachocove/qa#494, don't crash if server name isn't set.
Fix nachocove/qa#400, make sure to save exchange user password.
