### PR TITLE
Fix nachocove/qa#542

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactSearchViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactSearchViewController.cs
@@ -163,6 +163,7 @@ namespace NachoClient.iOS
         public void ContactSelectedCallback (McContact contact)
         {
             address.contact = contact;
+            address.address = contact.GetEmailAddress ();
             owner.UpdateEmailAddress (this, address);
             if (null != owner) {
                 owner.DismissINachoContactChooser (this);


### PR DESCRIPTION
- A recent change in nachocove/qa#512 requires all NcEmailAddress.address to be set.
- The address from contact search view does not have it; hence the crash.
- Fill in the address field to avoid crash.
