### PR TITLE
Fix blank entries in calendar view. Several device calendar fixes.

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NcDeviceContacts.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcDeviceContacts.cs
@@ -108,7 +108,9 @@ namespace NachoCore
             }
             NcModel.Instance.RunInTransaction (() => {
                 Folder.Unlink (map.FolderEntryId, McAbstrFolderEntry.ClassCodeEnum.Contact);
-                McContact.DeleteById<McContact> (map.FolderEntryId);
+                if (null != contact) {
+                    contact.Delete ();
+                }
             });
             return false;
         }

--- a/NachoClient.Android/NachoCore/BackEnd/Device/DeviceProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/Device/DeviceProtoControl.cs
@@ -310,30 +310,48 @@ namespace NachoCore
                     var deviceContacts = DeviceContacts;
                     if (null != deviceContacts) {
                         lock (deviceContacts) {
-                            while (!deviceContacts.ProcessNextContact ()) {
-                                cToken.ThrowIfCancellationRequested ();
+                            bool somethingHappened = false;
+                            try {
+                                while (!deviceContacts.ProcessNextContact ()) {
+                                    somethingHappened = true;
+                                    cToken.ThrowIfCancellationRequested ();
+                                }
+                                while (!deviceContacts.RemoveNextStale ()) {
+                                    somethingHappened = true;
+                                    cToken.ThrowIfCancellationRequested ();
+                                }
+                                // The sync has completed.
+                                DeviceContacts = null;
+                            } finally {
+                                // Trigger status events and report progress both when the sync is complete and when the sync has been interrupted.
+                                if (somethingHappened) {
+                                    deviceContacts.Report ();
+                                }
                             }
-                            while (!deviceContacts.RemoveNextStale ()) {
-                                cToken.ThrowIfCancellationRequested ();
-                            }
-                            deviceContacts.Report ();
-                            // We completed the sync.
-                            DeviceContacts = null;
                         }
                     }
 
                     var deviceCalendars = DeviceCalendars;
                     if (null != deviceCalendars) {
                         lock (deviceCalendars) {
-                            while (!deviceCalendars.ProcessNextCal ()) {
-                                cToken.ThrowIfCancellationRequested ();
+                            bool somethingHappened = false;
+                            try {
+                                while (!deviceCalendars.ProcessNextCal ()) {
+                                    somethingHappened = true;
+                                    cToken.ThrowIfCancellationRequested ();
+                                }
+                                while (!deviceCalendars.RemoveNextStale ()) {
+                                    somethingHappened = true;
+                                    cToken.ThrowIfCancellationRequested ();
+                                }
+                                // The sync has completed.
+                                DeviceCalendars = null;
+                            } finally {
+                                // Trigger status events and report progress both when the sync is complete and when the sync has been interrupted.
+                                if (somethingHappened) {
+                                    deviceCalendars.Report ();
+                                }
                             }
-                            while (!deviceCalendars.RemoveNextStale ()) {
-                                cToken.ThrowIfCancellationRequested ();
-                            }
-                            deviceCalendars.Report ();
-                            // We completed the sync.
-                            DeviceCalendars = null;
                         }
                     }
 

--- a/NachoClient.Android/NachoCore/Model/McCalendar.cs
+++ b/NachoClient.Android/NachoCore/Model/McCalendar.cs
@@ -228,7 +228,7 @@ namespace NachoCore.Model
             // that references it.  But McEvents are treated differently.  We want to delete them
             // right now so they disappear from the calendar, even if the underlying McCalendar
             // might stick around for a while longer.
-            using (var capture = CaptureWithStart ("Insert")) {
+            using (var capture = CaptureWithStart ("Delete")) {
                 int retval = 0;
                 List<NcEventIndex> eventIds = null;
 
@@ -259,6 +259,26 @@ namespace NachoCore.Model
                 return retval;
             }
         }
+
+        /// <summary>
+        /// Delete an item that originally came from the device calendar.  This is the same as the
+        /// regular delete, except for two things. (1) Don't cancel local notifications, because
+        /// we don't set notifications for events that came from the device calendar. (2) Don't
+        /// fire the EventSetChanged event, because deleting device calendar items can come in
+        /// rapid succession leading to an overload of EventSetChanged events. The code that
+        /// manages device calendar events is responsible for firing EventSetChanged once all the
+        /// device calendar items have been processed.
+        /// </summary>
+        public int DeleteDeviceItem ()
+        {
+            using (var capture = CaptureWithStart ("Delete")) {
+                int retval = 0;
+                NcModel.Instance.RunInTransaction (() => {
+                    McEvent.DeleteEventsForCalendarItem (this.Id);
+                    retval = base.Delete ();
+                });
+                return retval;
+            }
+        }
     }
 }
-

--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -53,6 +53,9 @@ namespace NachoPlatform
 
             public override string ServerId {
                 get {
+                    if (string.IsNullOrEmpty (Event.EventIdentifier)) {
+                        return "";
+                    }
                     if (Event.IsDetached || !Event.HasRecurrenceRules) {
                         return Event.EventIdentifier;
                     }

--- a/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
@@ -34,7 +34,6 @@ namespace NachoClient.iOS
         UIPanGestureRecognizer DateDotMonthViewPanGestureRecognizer = null;
 
         public static bool BasicView = false;
-        public bool UseDeviceCalendar;
         protected bool adjustScrollPosition = true;
 
         public CalendarViewController (IntPtr handle) : base (handle)

--- a/NachoClient.iOS/NachoUI.iOS/Support/CalendarTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/CalendarTableViewSource.cs
@@ -158,6 +158,7 @@ namespace NachoClient.iOS
                 }
                 cell.SelectionStyle = UITableViewCellSelectionStyle.None;
                 cell.ContentView.BackgroundColor = UIColor.White;
+                cell.TextLabel.Font = A.Font_AvenirNextDemiBold17;
 
                 var cellWidth = tableView.Frame.Width;
 
@@ -243,15 +244,15 @@ namespace NachoClient.iOS
             var c = calendar.GetEventDetail (indexPath.Section, indexPath.Row);
             var cRoot =  CalendarHelper.GetMcCalendarRootForEvent (e.Id);
 
-            if (null == c) {
-                foreach (var v in cell.ContentView.Subviews) {
-                    v.Hidden = true;
-                }
-                var label = cell.ContentView.ViewWithTag (SUBJECT_TAG) as UILabel;
-                label.Text = "Event has been deleted...";
-                label.Hidden = false;
+            if (null == c || null == cRoot) {
+                cell.ContentView.ViewWithTag (SWIPE_TAG).Hidden = true;
+                cell.TextLabel.Hidden = false;
+                cell.TextLabel.Text = "This event has been deleted.";
                 return;
             }
+
+            cell.ContentView.ViewWithTag (SWIPE_TAG).Hidden = false;
+            cell.TextLabel.Hidden = true;
 
             // Save calendar item index
             cell.ContentView.Tag = c.Id;
@@ -260,7 +261,6 @@ namespace NachoClient.iOS
             var subject = Pretty.SubjectString (c.GetSubject ());
 
             var subjectLabelView = cell.ContentView.ViewWithTag (SUBJECT_TAG) as UILabel;
-            subjectLabelView.Hidden = false;
             subjectLabelView.Text = subject;
 
             int colorIndex = 0;
@@ -273,16 +273,11 @@ namespace NachoClient.iOS
             dotView.Frame = new CGRect (30, 20, 9, 9);
             var size = new CGSize (10, 10);
             dotView.Image = Util.DrawCalDot (Util.CalendarColor (colorIndex), size);
-            dotView.Hidden = false;
 
             // Duration label view
             var durationLabelView = cell.ContentView.ViewWithTag (DURATION_TAG) as UILabel;
             var locationLabelView = cell.ContentView.ViewWithTag (LOCATION_TEXT_TAG) as UILabel;
             var locationIconView = cell.ContentView.ViewWithTag (LOCATION_ICON_TAG) as UIImageView;
-
-            durationLabelView.Hidden = false;
-            locationLabelView.Hidden = false;
-            locationIconView.Hidden = false;
 
             // Starting time and duration
             var startAndDuration = "";
@@ -311,10 +306,11 @@ namespace NachoClient.iOS
             } else {
                 locationIconView.Image = UIImage.FromBundle ("cal-icn-pin");
                 locationLabelView.Text = locationString;
+                locationIconView.Hidden = false;
+                locationLabelView.Hidden = false;
             }
 
             var lineView = cell.ContentView.ViewWithTag (LINE_TAG);
-            lineView.Hidden = false;
             lineView.Frame = new CGRect (34, 0, 1, HeightForCalendarEvent (c));
 
             var view = (SwipeActionView)cell.ViewWithTag (SWIPE_TAG);


### PR DESCRIPTION
Fix nachocove/qa#160  Fix the problem of blank entries in the calendar
view.  The bug was caused by incorrect use of the Hidden property for
views.  When displaying an event that was recently deleted (but hadn't
been removed from the view controller's table yet), the main view was
set to Hidden, which turned off it and all its children.  When the
cell was later reused for a real event, "Hidden = false" was done for
all the child views, but never for the main view.  So the cell
remained blank forever.

When a device calendar item was deleted, the app's McCalendar item was
correctly deleted.  But the McEvent for that McCalendar was never
deleted from the database.  This resulted in a blank entry in the
calendar view.  Fix the device calendar sync code delete McEvents when
deleting McCalendars.  (And other ancillary data for the McCalendar,
such as McRecurrence and McAttendee.  These were also left behind, but
those orphans were not user visible.)

If a device calendar item was deleted while the app was synching the
device calendar, the app would see a device calendar item with empty
and inconsistent fields.  Fix the device calendar sync code to
recognize this situation and handle it gracefully.

When the only activity that happens when synching the device calendar
is to delete calendar items, make sure an EventSetChanged event gets
fired.
