### PR TITLE
Fix nachocove/qa#548

### DIFF
--- a/NachoClient.Android/NachoCore/Index/Index.cs
+++ b/NachoClient.Android/NachoCore/Index/Index.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using System.Linq;
 using MimeKit;
 using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Store;
@@ -208,12 +209,15 @@ namespace NachoCore.Index
         public List<MatchedItem> SearchFields (string type, string queryString, string[] fields, int maxMatches = 1000, bool leadingWildcard = false)
         {
             string newQueryString = "";
+            var queryTokens = queryString.Trim ().Split ().Select (x => (leadingWildcard ? "*" : "") + QueryParser.Escape (x) + "*");
+            var fieldQuery = String.Join (" ", queryTokens);
+
             if (null != type) {
                 newQueryString += "+type:" + type;
             }
             newQueryString += " +(";
             foreach (var f in fields) {
-                newQueryString += f + ":" + queryString + " ";
+                newQueryString += f + ":(" + fieldQuery + ") ";
             }
             newQueryString += ")";
             return Search (newQueryString, maxMatches, leadingWildcard);

--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -1456,17 +1456,16 @@ namespace NachoCore.Model
         {
             const int maxResults = 100;
             var emailAddressAttributes = new List<McContactEmailAddressAttribute> ();
-            if (String.IsNullOrEmpty (searchFor)) {
+            var trimmedSearchFor = searchFor.Trim ();
+            if (String.IsNullOrEmpty (trimmedSearchFor)) {
                 return emailAddressAttributes;
             }
-
-            var escapedSearchFor = Lucene.Net.QueryParsers.QueryParser.Escape (searchFor);
 
             // Query the index for contacts up to 100 of them
             var allContacts = new List<McContact> ();
             foreach (var account in McAccount.GetAllAccounts()) {
                 var index = NcBrain.SharedInstance.Index (account.Id);
-                var matches = index.SearchAllContactFields (escapedSearchFor + "*", maxResults);
+                var matches = index.SearchAllContactFields (searchFor, maxResults);
                 if (0 == matches.Count) {
                     continue;
                 }

--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -630,11 +630,7 @@ namespace NachoClient.iOS
             // On-device index
             var indexPath = NcModel.Instance.GetIndexPath (NcApplication.Instance.Account.Id);
             var index = new NachoCore.Index.NcIndex (indexPath);
-            var match = searchBar.Text;
-            var quoted = Lucene.Net.QueryParsers.QueryParser.Escape (match);
-            var wildcard = (char.IsWhiteSpace (quoted.Last<char> ())) ? "" : "*";
-            var query = "*" + quoted + wildcard;
-            var matches = index.SearchAllEmailMessageFields (query);
+            var matches = index.SearchAllEmailMessageFields (searchBar.Text);
             searchResultsMessages.UpdateMatches (matches);
             List<int> adds;
             List<int> deletes;


### PR DESCRIPTION
- It crashes on contact search string that ends with a " " because of incorrect formation of the query string.
  - Suppose the user enters a search string of "john ". A wildcard is appended as: "john *". The final query is: "+type:contact +(first_name:john \* middle_name:john \* ...)".
  - The crash occurs because the "*" is now standalone and is considers a leading wildcard (which we disabled for performance reason).
  - Another problem is that the query is simply wrong when there is more than one token. Suppose the search string is "john smith". The query is: "+type:contact +(first_name:john smith middle_name:john smith ...)". "smith" is not explicitly associated with any field; so, it is associated with the default field (turns out to be address).
- Move all token escaping and wildcard insertion inside the search function. UI can just directly pass in the search string in the text field.
- Properly process multi-token search string. For the "john smith" example, the query is now: "+type:contact +(first_name:(john\* smith_) middle_name:(john_ smith*) ...)".
