### PR TITLE
rework some states, remove NcTask where not needed

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/SMTP/SmtpCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/SMTP/SmtpCommand.cs
@@ -189,7 +189,17 @@ namespace NachoCore.SMTP
                 MimeHelpers.AddAttachments (mimeMessage, attachments);
             }
 
-            Client.Send (mimeMessage, Cts.Token);
+            try {
+                Client.Send (mimeMessage, Cts.Token);
+            } catch (SmtpCommandException ex) {
+                Log.Info (Log.LOG_SMTP, "SmtpCommandException {0}", ex.Message);
+                PendingResolveApply ((pending) => {
+                    pending.ResolveAsHardFail (BEContext.ProtoControl, 
+                        NcResult.Error (NcResult.SubKindEnum.Error_EmailMessageSendFailed,
+                            NcResult.WhyEnum.ProtocolError));
+                });
+                return Event.Create ((uint)SmEvt.E.HardFail, "SMTPSENDHARD");
+            }
             PendingResolveApply ((pending) => {
                 pending.ResolveAsSuccess (
                     BEContext.ProtoControl,


### PR DESCRIPTION
also catch some sending errors and mark the pending as failed

. Removed some NcTask calls for state-changes, which are now handled in the SmtpCommand.
. catch the error from sending mails and mark the message as failed.
. add states so that we can do proper sm management (similar to what IMAP SM does).
