### PR TITLE
Fix nachocove/qa#564

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactListViewController.cs
@@ -104,7 +104,11 @@ namespace NachoClient.iOS
             SwitchToAccount (NcApplication.Instance.Account);
 
             addContactButton.Clicked += (object sender, EventArgs e) => {
-                PerformSegue ("ContactsToContactEdit", new SegueHolder (null));
+                if (null == McFolder.GetDefaultContactFolder (NcApplication.Instance.Account.Id)) {
+                    NcAlertView.ShowMessage (this, "Unable to add contact", "Adding contact is not supported yet for this account.");
+                } else {
+                    PerformSegue ("ContactsToContactEdit", new SegueHolder (null));
+                }
             };
 
             searchButton.Clicked += (object sender, EventArgs e) => {


### PR DESCRIPTION
- It crashes when we add a contact to non-Exchange accounts because we don't have contact syncing for them yet.
- Disallow adding contact for account that does not have a default contact folder.
