### PR TITLE
Make set deadline view more consistent with the rest of the app

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/DatePickerViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/DatePickerViewController.cs
@@ -18,16 +18,29 @@ namespace NachoClient.iOS
         public override void ViewDidLoad ()
         {
             base.ViewDidLoad ();
+            View.BackgroundColor = A.Color_NachoGreen;
+
             datePicker.Mode = UIDatePickerMode.Date;
+            datePicker.TintAdjustmentMode = UIViewTintAdjustmentMode.Dimmed;
+            datePicker.BackgroundColor = UIColor.White;
+            datePicker.Alpha = (nfloat)0.4;
+            datePicker.AccessibilityLabel = "Pick deadline date";
+            datePicker.HorizontalAlignment = UIControlContentHorizontalAlignment.Center;
+
+            OKButton.HorizontalAlignment = UIControlContentHorizontalAlignment.Center;
+            OKButton.TintColor = UIColor.White;
+            OKButton.AccessibilityLabel = "Ok";
             OKButton.TouchUpInside += (object sender, EventArgs e) => {
-                var date = datePicker.Date.ToDateTime();
+                var date = datePicker.Date.ToDateTime ();
                 var dateTime = DateTime.SpecifyKind (date, DateTimeKind.Utc);
                 owner.DismissDatePicker (this, dateTime);
             };
 
+            cancelButton.HorizontalAlignment = UIControlContentHorizontalAlignment.Center;
             cancelButton.TouchUpInside += (object sender, EventArgs e) => {
                 DismissViewController (true, null);
             };
+            cancelButton.TintColor = UIColor.White;
             cancelButton.AccessibilityLabel = "Cancel";
         }
 


### PR DESCRIPTION
- Change background color to green.
- Center date picker and buttons. 
- Add accessibility labels.
- No native support for changing date picker text color. So, set the background color to white and use alpha to blend the dark green in.

This screen still looks a little bit different from other screens. It still lacks a title up top (e.g. "Select deadline date").

![ios simulator screen shot jul 12 2015 5 04 19 pm](https://cloud.githubusercontent.com/assets/6926104/8637217/04a65c6c-28b9-11e5-8d21-c51d1374ed1f.png)
