### PR TITLE
Improve contact search response

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -4,6 +4,7 @@ using System.Xml.Linq;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using NachoCore.Utils;
 using NachoCore.ActiveSync;
 using NachoCore.Brain;
@@ -1454,7 +1455,7 @@ namespace NachoCore.Model
 
         public static List<McContactEmailAddressAttribute> SearchIndexAllContacts (string searchFor, bool onlyWithEmailAddresses, bool withEclipsing)
         {
-            const int maxResults = 100;
+            const int maxResults = 30;
             var emailAddressAttributes = new List<McContactEmailAddressAttribute> ();
             var trimmedSearchFor = searchFor.Trim ();
             if (String.IsNullOrEmpty (trimmedSearchFor)) {
@@ -1463,34 +1464,44 @@ namespace NachoCore.Model
 
             // Query the index for contacts up to 100 of them
             var allContacts = new List<McContact> ();
+            var lockObj = new object ();
+            var tasks = new List<Task> ();
             foreach (var account in McAccount.GetAllAccounts()) {
-                var index = NcBrain.SharedInstance.Index (account.Id);
-                var matches = index.SearchAllContactFields (searchFor, maxResults);
-                if (0 == matches.Count) {
-                    continue;
-                }
-                var idList = matches.Select (x => x.Id).Distinct ().ToList ();
-                var contacts = McContact.QueryByIds (idList);
-                if (idList.Count > contacts.Count) {
-                    // Some ids in the index are no longer value. We need to remove those entries in the index
-                    var hash = new HashSet<int> ();
-                    contacts.ForEach ((x) => {
-                        hash.Add (x.Id);
-                    });
-                    foreach (var match in matches) {
-                        var id = int.Parse (match.Id);
-                        if (!hash.Contains (id)) {
-                            NcBrain.UnindexContact (new McContact () {
-                                Id = int.Parse (match.Id),
-                                AccountId = account.Id,
-                            });
-                        }
+                var task = NcTask.Run (() => {
+                    var index = NcBrain.SharedInstance.Index (account.Id);
+                    var matches = index.SearchAllContactFields (searchFor, maxResults);
+                    if (0 == matches.Count) {
+                        return;
                     }
-                } else {
-                    NcAssert.True (idList.Count == contacts.Count);
-                }
+                    var idList = matches.Select (x => x.Id).Distinct ().ToList ();
+                    var contacts = McContact.QueryByIds (idList);
+                    if (idList.Count > contacts.Count) {
+                        // Some ids in the index are no longer value. We need to remove those entries in the index
+                        var hash = new HashSet<int> ();
+                        contacts.ForEach ((x) => {
+                            hash.Add (x.Id);
+                        });
+                        foreach (var match in matches) {
+                            var id = int.Parse (match.Id);
+                            if (!hash.Contains (id)) {
+                                NcBrain.UnindexContact (new McContact () {
+                                    Id = int.Parse (match.Id),
+                                    AccountId = account.Id,
+                                });
+                            }
+                        }
+                    } else {
+                        NcAssert.True (idList.Count == contacts.Count);
+                    }
 
-                allContacts.AddRange (contacts);
+                    lock (lockObj) {
+                        allContacts.AddRange (contacts);
+                    }
+                }, "SearchContactOneAccount");
+                tasks.Add (task);
+            }
+            foreach (var task in tasks) {
+                task.Wait ();
             }
             allContacts.Sort (new McContactNameComparer ());
 

--- a/NachoClient.iOS/NachoUI.iOS/ContactChooserViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactChooserViewController.cs
@@ -235,20 +235,6 @@ namespace NachoClient.iOS
                 searchResults = McContact.SearchIndexAllContacts (forSearchString, true, true);
                 resultsTableView.ReloadData ();
                 NachoCore.Utils.NcAbate.RegularPriority ("ContactChooser UpdateAutocompleteResults with string");
-
-                /// This is a simple test code that issues a prefix search and print the results
-                /// in console. Once the real search window is done, please remove this chunk of code
-                /// HACK ALERT - TEST / DEMO CODE FOR INDEXING!!!!
-//                if (!String.IsNullOrEmpty (forSearchString)) {
-//                    var indexPath = NcModel.Instance.GetFileDirPath (2, "index");
-//                    NachoCore.Index.Index index = new NachoCore.Index.Index (indexPath);
-//                    var matches = index.Search (forSearchString + "*");
-//                    int n = 1;
-//                    foreach (var match in matches) {
-//                        Console.WriteLine (">>> {0}: {1} {2}", n, match.Type, match.Id);
-//                        n += 1;
-//                    }
-//                }
             }
         }
 


### PR DESCRIPTION
- Reduce the max # of contact matches to 30.
- Search all accounts in parallel.
