### PR TITLE
Fix nachocove/qa#585

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcSamples.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcSamples.cs
@@ -68,8 +68,8 @@ namespace NachoCore.Utils
                 var now = DateTime.UtcNow;
                 if ((now - LastReported).TotalSeconds >= ReportIntervalSec) {
                     Report ();
+                    LastReported = now;
                 }
-                LastReported = now;
             }
         }
 


### PR DESCRIPTION
- The crash occurred because while telemetry was walking the sample list, some code added another sample. An invalid operation was thrown when a list is modified during a foreach iteration.
- The solution is to create a new sample list while the old list is being recorded to telemetry to avoid InvalidOperationException.
