### PR TITLE
Fix nachocove/qa#603

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -809,6 +809,15 @@ namespace NachoCore.Model
             }
         }
 
+        public void UpdateLastAccessed ()
+        {
+            LastAccessed = DateTime.UtcNow;
+            NcModel.Instance.BusyProtect (() => {
+                return NcModel.Instance.Db.Execute ("UPDATE McContact SET LastAccessed = ? WHERE Id = ?",
+                    LastAccessed, Id);
+            });
+        }
+
         public void UpdateEmailAddressesEclipsing ()
         {
             NcModel.Instance.BusyProtect (() => {

--- a/NachoClient.iOS/NachoUI.iOS/ContactChooserViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactChooserViewController.cs
@@ -369,8 +369,7 @@ namespace NachoClient.iOS
                     }
                 }
 
-                contact.LastAccessed = DateTime.UtcNow;
-                contact.Update ();
+                contact.UpdateLastAccessed ();
 
                 Owner.UpdateEmailAddress (contact, Owner.searchResults [indexPath.Row].Value);
             }

--- a/NachoClient.iOS/NachoUI.iOS/ContactListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactListViewController.cs
@@ -234,7 +234,6 @@ namespace NachoClient.iOS
                 contactsNeedsRefresh = false;
                 ReloadCapture.Start ();
                 NachoCore.Utils.NcAbate.HighPriority ("ContactListViewController LoadContacts");
-                // RIC -- only highlight recents from the current account
                 var recents = McContact.QueryRecentlyAccessed (0, 5);
                 var contacts = McContact.AllContactsSortedByName (true);
                 contactTableViewSource.SetContacts (recents, contacts, true);

--- a/NachoClient.iOS/NachoUI.iOS/ContactSearchViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactSearchViewController.cs
@@ -162,8 +162,7 @@ namespace NachoClient.iOS
         /// IContactsTableViewSourceDelegate
         public void ContactSelectedCallback (McContact contact)
         {
-            contact.LastAccessed = DateTime.UtcNow;
-            contact.Update ();
+            contact.UpdateLastAccessed ();
             address.contact = contact;
             address.address = contact.GetEmailAddress ();
             owner.UpdateEmailAddress (this, address);

--- a/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
@@ -246,8 +246,7 @@ namespace NachoClient.iOS
         {
             string dummy;
             McContact contact = ContactFromIndexPath (tableView, indexPath, out dummy);
-            contact.LastAccessed = DateTime.UtcNow;
-            contact.Update ();
+            contact.UpdateLastAccessed ();
             owner.ContactSelectedCallback (contact);
             DumpInfo (contact);
             tableView.DeselectRow (indexPath, true);

--- a/Test.iOS/McContactTest.cs
+++ b/Test.iOS/McContactTest.cs
@@ -840,12 +840,6 @@ namespace Test.Common
             Assert.AreEqual (contact4.Id, contacts2 [1].Id);
         }
 
-        protected void UpdateLastAccessed (McContact contact)
-        {
-            contact.LastAccessed = DateTime.UtcNow;
-            contact.Update ();
-        }
-
         protected void CheckContactIds (List<NcContactIndex> recents, List<McContact> contacts, int[] expectedIds)
         {
             Assert.AreEqual (expectedIds.Length, recents.Count);
@@ -878,19 +872,19 @@ namespace Test.Common
             Assert.AreEqual (0, recents.Count);
 
             // Update 3 contacts. Should display them all.
-            UpdateLastAccessed (contacts [0]);
-            UpdateLastAccessed (contacts [4]);
-            UpdateLastAccessed (contacts [2]);
+            contacts [0].UpdateLastAccessed ();
+            contacts [4].UpdateLastAccessed ();
+            contacts [2].UpdateLastAccessed ();
             recents = McContact.QueryRecentlyAccessed (0, 5);
             CheckContactIds (recents, contacts, new int[] { 2, 4, 0 });
 
             // Update one more contact.
-            UpdateLastAccessed (contacts [3]);
+            contacts [3].UpdateLastAccessed ();
             recents = McContact.QueryRecentlyAccessed (0, 4);
             CheckContactIds (recents, contacts, new int[] { 3, 2, 4, 0 });
 
             // Update one more contact. The 5th most recent contact should be evicted.
-            UpdateLastAccessed (contacts [1]);
+            contacts [1].UpdateLastAccessed ();
             recents = McContact.QueryRecentlyAccessed (0, 4);
             CheckContactIds (recents, contacts, new int[] { 1, 3, 2, 4 });
 


### PR DESCRIPTION
- Add LastAccessed to McContact.
- When a contact is selected in contact list, chooser, or search view, the LastAccessed field is updated to the current UTC time.
- Add McContact.QueryRecentlyAccessed() to return the last N accessed contacts from all or a single account.
- Add unit test.
