### PR TITLE
Fix nachocove/qa#630.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -41,7 +41,7 @@ namespace NachoCore.Model
             if (!myIsLetter && otherIsLetter) {
                 return +1;
             }
-            return String.Compare (FirstLetter, other.FirstLetter, ignoreCase: true);
+            return String.Compare (FirstLetter, other.FirstLetter, StringComparison.OrdinalIgnoreCase);
         }
     }
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
@@ -68,7 +68,7 @@ namespace NachoClient.iOS
                 if (String.IsNullOrEmpty (c.FirstLetter)) {
                     c.FirstLetter = " ";
                 } else {
-                    c.FirstLetter = c.FirstLetter.ToUpper ();
+                    c.FirstLetter = c.FirstLetter.ToUpperInvariant ();
                 }
             }
             this.contacts.Sort ();


### PR DESCRIPTION
- All contacts disappear due to a weird interaction between FindRange() and SQLite.
- If you create a contact with the name "_", this contact is returned before all contacts with an alphabet first letter. The problem is that in ASCII ordinal, "_" > "A-Z". So, when FindRange() scans for "A", it sees "_" and falsely thinks it has gone too far and there is no "A". As a result, the first 26  sectionLength[] are 0s. The only contacts displayed are the ones with non-alphabet first letter and sorted before "_".
- There is another related problem I discover during debugging. If you have a Chinese contact, it's first letter is a Chinese character and put behind "Z". Since we only scan up to Z, those contacts are never displayed.
- The solution is:
  - Sort the the source contact list using a custom CompareTo() method. That put all non-alphabet first letter in the back and sort the rest alphabetically.
  - FindRange() then is simplified to scan forward until the next entry is no longer the same as the expected uppercaseLetter.
