### PR TITLE
Only sync one year's worth of device calendar events

### DIFF
--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -369,6 +369,7 @@ namespace NachoPlatform
                         // than the SetPositions field.
                         result.Type = NcRecurrenceType.YearlyOnDay;
                         result.DayOfWeek = ConvertDaysOfWeek (rule.DaysOfTheWeek);
+                        result.DayOfWeekIsSet = true;
                         int week = (int)rule.DaysOfTheWeek [0].WeekNumber;
                         if (0 >= week || 5 <= week) {
                             result.WeekOfMonth = 5;
@@ -496,14 +497,14 @@ namespace NachoPlatform
             }
 
             // Ask for all events from one month ago (which is as far back as the calendar normally goes) until
-            // way into the future.  iOS will only deliver several years of events at a time, so we won't actually
-            // get recurring events hundreds of years from now.  There is not a way to find out how far into the
-            // future the user has scrolled the calendar, nor is there a way for the calendar view to ask for more
-            // McCalendar items as the user scrolls, so the app needs to get events from iOS farther into the future
-            // than is necessary in the normal case.
+            // one year into the future.  There is not a way to find out how far into the future the user has
+            // scrolled the calendar, nor is there a way for the calendar view to ask for more McCalendar items
+            // as the user scrolls.  So we pick what seems like a reasonable time frame for synching device
+            // events.  If the user scrolls more than a year into the future, the calendar simply won't have
+            // any events from the device calendar.
             var result = new List<PlatformCalendarRecordiOS> ();
             var allCalendars = Es.GetCalendars (EKEntityType.Event);
-            var predicate = Es.PredicateForEvents (DateTime.UtcNow.AddDays (-31).ToNSDate (), NSDate.DistantFuture, allCalendars);
+            var predicate = Es.PredicateForEvents (DateTime.UtcNow.AddDays (-31).ToNSDate (), DateTime.UtcNow.AddYears (1).ToNSDate (), allCalendars);
             var deviceEvents = Es.EventsMatching (predicate);
             if (null != deviceEvents) {
                 foreach (var deviceEvent in deviceEvents) {


### PR DESCRIPTION
Sync just one year of device calendar events, rather than synching
everything that iOS will give us.  Asking for all events was resulting
in the app doing a lot of work that was of no real use to the user.

Fix on oversight in the conversion from iOS's EKRecurrenceRule to the
app's McRecurrence, which was resulting in an ominous sounding (but
harmless) warning message.

Fix nachocove/qa#629
