### PR TITLE
Don't resync device contacts whenever device cal sync was interrupted

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/Device/DeviceProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/Device/DeviceProtoControl.cs
@@ -320,10 +320,9 @@ namespace NachoCore
                                     somethingHappened = true;
                                     cToken.ThrowIfCancellationRequested ();
                                 }
-                                // The sync has completed.
-                                DeviceContacts = null;
                             } finally {
-                                // Trigger status events and report progress both when the sync is complete and when the sync has been interrupted.
+                                // Trigger status events and report progress both when the sync is complete
+                                // and when the sync has been interrupted.
                                 if (somethingHappened) {
                                     deviceContacts.Report ();
                                 }
@@ -344,10 +343,9 @@ namespace NachoCore
                                     somethingHappened = true;
                                     cToken.ThrowIfCancellationRequested ();
                                 }
-                                // The sync has completed.
-                                DeviceCalendars = null;
                             } finally {
-                                // Trigger status events and report progress both when the sync is complete and when the sync has been interrupted.
+                                // Trigger status events and report progress both when the sync is complete
+                                // and when the sync has been interrupted.
                                 if (somethingHappened) {
                                     deviceCalendars.Report ();
                                 }
@@ -355,7 +353,12 @@ namespace NachoCore
                         }
                     }
 
+                    // The sync has completed.  Reset things so the next DoSync will start over.
+                    DeviceContacts = null;
+                    DeviceCalendars = null;
+
                     Sm.PostEvent ((uint)DevEvt.E.SyncDone, "DEVNCCONSYNCED");
+
                 } catch (OperationCanceledException) {
                     // Abate was signaled.
                     Sm.PostEvent ((uint)DevEvt.E.SyncCancelled, "DEVNCCONCANCEL");


### PR DESCRIPTION
Whenever the synching of the device calendar was interrupted (which
happens with every abate signal), the device contacts would be
resynched from the beginning once the abate-off signal was received.
Fix the device account sync code so that the sync will resume the
calendar sync from where it left off and not redo the device contacts.

Fix nachocove/qa#610
