### PR TITLE
Fix nachocore/qa#626.  Add better checks for imap and exchange advanced view

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
@@ -324,6 +324,28 @@ namespace NachoCore.Utils
             return ParseServerWhyEnum.Success_0;
         }
 
+        public static string ParseServerWhyEnumToString (ParseServerWhyEnum why)
+        {
+            switch (why) {
+            case ParseServerWhyEnum.FailBadHost:
+                return "The host name has an error.";
+            case ParseServerWhyEnum.FailBadPort:
+                return "The port number has an error.";
+            case ParseServerWhyEnum.FailBadScheme:
+                return "The server name scheme has an error.";
+            case ParseServerWhyEnum.FailHadQuery:
+                return "The server name should not have a query string.";
+            case ParseServerWhyEnum.FailUnknown:
+                return "The server name has an error.";
+            case ParseServerWhyEnum.Success_0:
+                return "";
+            default:
+                NcAssert.CaseError ();
+                break;
+            }
+            return "";
+        }
+
         public static bool IsValidHost (string host)
         {
             UriHostNameType fullServerUri = Uri.CheckHostName (host.Trim ());

--- a/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
@@ -833,6 +833,16 @@ namespace NachoClient
             }
             return FindOutermostView (view.Superview);
         }
+            
+        public static UIViewController FindOutermostViewController()
+        {
+            var appDelegate = (AppDelegate)UIApplication.SharedApplication.Delegate;
+            var topVC = appDelegate.Window.RootViewController;
+            while(null != topVC.PresentedViewController) {
+                topVC = topVC.PresentedViewController;
+            }
+            return topVC;
+        }
 
         public static UIColor FindSolidBackgroundColor (UIView v)
         {


### PR DESCRIPTION
Fix nachocove/qa#626.  Add better checks for imap and exchange
advanced view. When editing the settings, use a pop up to show
the problem.  Highlight error text in red & reset the color to
black when the user changes the field.  Initialize the Connect
button status when first opening the view.
