### PR TITLE
Fix nachocove/qa#635

### DIFF
--- a/NachoClient.Android/NachoCore/Index/Index.cs
+++ b/NachoClient.Android/NachoCore/Index/Index.cs
@@ -209,7 +209,15 @@ namespace NachoCore.Index
         public List<MatchedItem> SearchFields (string type, string queryString, string[] fields, int maxMatches = 1000, bool leadingWildcard = false)
         {
             string newQueryString = "";
-            var queryTokens = queryString.Trim ().Split ().Select (x => (leadingWildcard ? "*" : "") + QueryParser.Escape (x) + "*");
+            queryString = queryString
+                .Replace ("*", " ")
+                .Replace ("?", " ")
+                .Trim ();
+            if (String.IsNullOrEmpty (queryString)) {
+                return new List<MatchedItem> ();
+            }
+
+            var queryTokens = queryString.Split ().Select (x => (leadingWildcard ? "*" : "") + QueryParser.Escape (x) + "*");
             var fieldQuery = String.Join (" ", queryTokens);
 
             if (null != type) {


### PR DESCRIPTION
- The crash happens when you type "*" in the search box. The query generates seems correct but Lucene.Net API does not accept it. It asks to search for a pattern of \** which should mean look for any pattern that starts with a "*" (as a literal). But the WildCardQuery seems to get confused by this.
- The solution is kind of a bandaid to code around this quirky behavior.
- It turns out StandardTokenizer used turns most punctuations (including "*" and "?") to whitespace anyways. So, suppose a phone # of "*123" can be searched by 123. Or a company named "A*123" can be searched by "A 123".
- So, replace '*' and '?' with whitespace.
