### PR TITLE
Fix nachocove/qa#618. The app's crashing with a null navigation controller.

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/ILoginProtocol.cs
+++ b/NachoClient.Android/NachoCore/Adapters/ILoginProtocol.cs
@@ -27,8 +27,6 @@ namespace NachoCore
 
         void StartSync ();
 
-        void TryAgainOrQuit ();
-
         void ShowSupport ();
 
         void ShowTutorial ();

--- a/NachoClient.Android/NachoCore/Utils/LoginProtocolControl.cs
+++ b/NachoClient.Android/NachoCore/Utils/LoginProtocolControl.cs
@@ -18,6 +18,7 @@ namespace NachoCore.Utils
             TutorialSupportWait,
             FinishWait,
             Quit,
+            Park,
         };
 
         public enum Prompt
@@ -40,7 +41,6 @@ namespace NachoCore.Utils
                 CredUpdate,
                 CredReqCallback,
                 DuplicateAccount,
-                Error,
                 ExchangePicked,
                 GetPassword,
                 GmailPicked,
@@ -85,7 +85,6 @@ namespace NachoCore.Utils
                             (uint)Events.E.CertAccepted,
                             (uint)Events.E.CertRejected,
                             (uint)Events.E.CredUpdate,
-                            (uint)Events.E.Error,
                             (uint)Events.E.ExchangePicked,
                             (uint)Events.E.GetPassword,
                             (uint)Events.E.GmailPicked,
@@ -103,13 +102,13 @@ namespace NachoCore.Utils
                             new Trans { Event = (uint)Events.E.NotYetStarted, Act = Start, State = (uint)States.SyncWait },
                             new Trans { Event = (uint)Events.E.Running, Act = ShowWaitingScreen, State = (uint)States.SyncWait },
                             new Trans { Event = (uint)Events.E.NoNetwork, Act = ShowNoNetwork, State = (uint)States.SubmitWait },
-                            new Trans { Event = (uint)Events.E.DuplicateAccount, Act = ShowDuplicateAccount, State = (uint)States.Start },
+                            new Trans { Event = (uint)Events.E.DuplicateAccount, Act = ShowDuplicateAccount, State = (uint)States.Quit },
                             new Trans { Event = (uint)Events.E.ServerConfCallback, Act = ShowServerConfCallback, State = (uint)States.SubmitWait },
                             new Trans { Event = (uint)Events.E.CredReqCallback, Act = ShowCredReq, State = (uint)States.SubmitWait },
                             new Trans { Event = (uint)Events.E.CertAskCallback, Act = ShowCertAsk, State = (uint)States.SubmitWait },
                             new Trans { Event = (uint)Events.E.PostAutoDPreInboxSync, Act = UpdateUI, State = (uint)States.SyncWait },
                             new Trans { Event = (uint)Events.E.PostAutoDPostInboxSync, Act = FinishUp, State = (uint)States.FinishWait },
-                            new Trans { Event = (uint)Events.E.Quit, Act = Quit, State = (uint)States.Start },
+                            new Trans { Event = (uint)Events.E.Quit, Act = Quit, State = (uint)States.Park },
                             new Trans { Event = (uint)Events.E.AccountCreated, Act = StartSync, State = (uint)States.SyncWait },
                         }
                     },
@@ -126,7 +125,6 @@ namespace NachoCore.Utils
                             (uint)Events.E.CredUpdate,
                             (uint)Events.E.CredReqCallback,
                             (uint)Events.E.DuplicateAccount,
-                            (uint)Events.E.Error,
                             (uint)Events.E.GetPassword,
                             (uint)Events.E.NoNetwork,
                             (uint)Events.E.NotYetStarted,
@@ -146,7 +144,7 @@ namespace NachoCore.Utils
                             new Trans { Event = (uint)Events.E.ImapPicked, Act = ShowAdvancedConfiguration, State = (uint)States.SubmitWait },
                             new Trans { Event = (uint)Events.E.KnownServicePicked, Act = PromptForCredentials, State = (uint)States.CredentialsWait },
                             new Trans { Event = (uint)Events.E.ShowAdvanced, Act = ShowAdvancedConfiguration, State = (uint)States.SubmitWait },
-                            new Trans { Event = (uint)Events.E.NoService, Act = Quit, State = (uint)States.ServiceWait },
+                            new Trans { Event = (uint)Events.E.NoService, Act = Quit, State = (uint)States.Park },
                             new Trans { Event = (uint)Events.E.ShowSupport, Act = ShowSupport, State = (uint)States.TutorialSupportWait },
                         }
                     },
@@ -181,9 +179,8 @@ namespace NachoCore.Utils
                         },
                         On = new Trans[] {
                             new Trans { Event = (uint)Events.E.AccountCreated, Act = StartSync, State = (uint)States.SyncWait },
-                            new Trans { Event = (uint)Events.E.DuplicateAccount, Act = ShowDuplicateAccount, State = (uint)States.Start },
-                            new Trans { Event = (uint)Events.E.Error, Act = TryAgainOrQuit, State = (uint)States.Start },
-                            new Trans { Event = (uint)Events.E.Quit, Act = Quit, State = (uint)States.Start },
+                            new Trans { Event = (uint)Events.E.DuplicateAccount, Act = ShowDuplicateAccount, State = (uint)States.Quit },
+                            new Trans { Event = (uint)Events.E.Quit, Act = Quit, State = (uint)States.Park },
                             new Trans { Event = (uint)Events.E.ShowSupport, Act = ShowSupport, State = (uint)States.TutorialSupportWait },
                         }
                     },
@@ -199,7 +196,6 @@ namespace NachoCore.Utils
                             (uint)Events.E.CredUpdate,
                             (uint)Events.E.CredReqCallback,
                             (uint)Events.E.DuplicateAccount,
-                            (uint)Events.E.Error,
                             (uint)Events.E.ExchangePicked,
                             (uint)Events.E.GetPassword,
                             (uint)Events.E.GmailPicked,
@@ -234,7 +230,6 @@ namespace NachoCore.Utils
                             (uint)Events.E.CertRejected,
                             (uint)Events.E.CredUpdate,
                             (uint)Events.E.DuplicateAccount,
-                            (uint)Events.E.Error,
                             (uint)Events.E.ExchangePicked,
                             (uint)Events.E.GetPassword,
                             (uint)Events.E.GmailPicked,
@@ -270,7 +265,6 @@ namespace NachoCore.Utils
                             (uint)Events.E.CertAskCallback,
                             (uint)Events.E.CredReqCallback,
                             (uint)Events.E.DuplicateAccount,
-                            (uint)Events.E.Error,
                             (uint)Events.E.ExchangePicked,
                             (uint)Events.E.GetPassword,
                             (uint)Events.E.GmailPicked,
@@ -292,7 +286,7 @@ namespace NachoCore.Utils
                             new Trans { Event = (uint)Events.E.CredUpdate, Act = Noop, State = (uint)States.SyncWait },
                             new Trans { Event = (uint)Events.E.CertAccepted, Act = Noop, State = (uint)States.SyncWait },
                             new Trans { Event = (uint)Events.E.TryAgain, Act = StartSync, State = (uint)States.SyncWait },
-                            new Trans { Event = (uint)Events.E.Quit, Act = Quit, State = (uint)States.Start },
+                            new Trans { Event = (uint)Events.E.Quit, Act = Quit, State = (uint)States.Park },
                             new Trans { Event = (uint)Events.E.CertRejected, Act = ShowCertRejected, State = (uint)States.Quit },
                             new Trans { Event = (uint)Events.E.AccountCreated, Act = StartSync, State = (uint)States.SyncWait },
                             new Trans { Event = (uint)Events.E.ShowSupport, Act = ShowSupport, State = (uint)States.TutorialSupportWait },
@@ -311,7 +305,6 @@ namespace NachoCore.Utils
                             (uint)Events.E.CredUpdate,
                             (uint)Events.E.CredReqCallback,
                             (uint)Events.E.DuplicateAccount,
-                            (uint)Events.E.Error,
                             (uint)Events.E.ExchangePicked,
                             (uint)Events.E.GetPassword,
                             (uint)Events.E.GmailPicked,
@@ -332,7 +325,7 @@ namespace NachoCore.Utils
                         On = new Trans[] {
                             new Trans { Event = (uint)Events.E.TryAgain, Act = FinishUp, State = (uint)States.FinishWait },
                             new Trans { Event = (uint)Events.E.ShowTutorial, Act = ShowTutorial, State = (uint)States.FinishWait },
-                            new Trans { Event = (uint)Events.E.AllDone, Act = Done, State = (uint)States.Start },
+                            new Trans { Event = (uint)Events.E.AllDone, Act = Done, State = (uint)States.Park },
                         }
                     },
                     new Node {
@@ -345,7 +338,6 @@ namespace NachoCore.Utils
                             (uint)Events.E.CredUpdate,
                             (uint)Events.E.CredReqCallback,
                             (uint)Events.E.DuplicateAccount,
-                            (uint)Events.E.Error,
                             (uint)Events.E.ExchangePicked,
                             (uint)Events.E.GetPassword,
                             (uint)Events.E.GmailPicked,
@@ -368,7 +360,7 @@ namespace NachoCore.Utils
                         Invalid = new uint [] {
                         },
                         On = new Trans[] {
-                            new Trans { Event = (uint)Events.E.AllDone, Act = Noop, State = (uint)States.Start },
+                            new Trans { Event = (uint)Events.E.AllDone, Act = Noop, State = (uint)States.SyncWait },
                             new Trans { Event = (uint)Events.E.ShowAdvanced, Act = ShowAdvancedConfiguration, State = (uint)States.SubmitWait },
                         }
                     },
@@ -383,7 +375,6 @@ namespace NachoCore.Utils
                             (uint)Events.E.CredUpdate,
                             (uint)Events.E.CredReqCallback,
                             (uint)Events.E.DuplicateAccount,
-                            (uint)Events.E.Error,
                             (uint)Events.E.ExchangePicked,
                             (uint)Events.E.GetPassword,
                             (uint)Events.E.GmailPicked,
@@ -406,7 +397,43 @@ namespace NachoCore.Utils
                         Invalid = new uint [] {
                         },
                         On = new Trans[] {
-                            new Trans { Event = (uint)Events.E.Quit, Act = Quit, State = (uint)States.Start },
+                            new Trans { Event = (uint)Events.E.Quit, Act = Quit, State = (uint)States.Park },
+                        }
+                    },
+                    new Node {
+                        State = (uint)States.Park,
+                        Drop = new uint [] {
+                            (uint)Events.E.AllDone,
+                            (uint)Events.E.AccountCreated,
+                            (uint)Events.E.CertAccepted,
+                            (uint)Events.E.CertAskCallback,
+                            (uint)Events.E.CertRejected,
+                            (uint)Events.E.CredUpdate,
+                            (uint)Events.E.CredReqCallback,
+                            (uint)Events.E.DuplicateAccount,
+                            (uint)Events.E.ExchangePicked,
+                            (uint)Events.E.GetPassword,
+                            (uint)Events.E.GmailPicked,
+                            (uint)Events.E.KnownServicePicked,
+                            (uint)Events.E.ImapPicked,
+                            (uint)Events.E.NoNetwork,
+                            (uint)Events.E.NoService,
+                            (uint)Events.E.NotYetStarted,
+                            (uint)Events.E.PostAutoDPostInboxSync,
+                            (uint)Events.E.PostAutoDPreInboxSync,
+                            (uint)Events.E.Quit,
+                            (uint)Events.E.Running,
+                            (uint)Events.E.ServerConfCallback,
+                            (uint)Events.E.ServerUpdate,
+                            (uint)Events.E.ShowAdvanced,
+                            (uint)Events.E.StartOver,
+                            (uint)Events.E.ShowSupport,
+                            (uint)Events.E.ShowTutorial,
+                            (uint)Events.E.TryAgain,
+                        },
+                        Invalid = new uint [] {
+                        },
+                        On = new Trans[] {
                         }
                     },
                 },
@@ -485,11 +512,6 @@ namespace NachoCore.Utils
         void StartSync ()
         {
             owner.StartSync ();
-        }
-
-        void TryAgainOrQuit ()
-        {
-            owner.TryAgainOrQuit ();
         }
 
         void ShowSupport ()

--- a/NachoClient.iOS/NachoUI.iOS/AdvancedLoginViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/AdvancedLoginViewController.cs
@@ -449,10 +449,6 @@ namespace NachoClient.iOS
             BackEnd.Instance.Start (account.Id);
         }
 
-        public void TryAgainOrQuit ()
-        {
-        }
-
         public void ShowSupport ()
         {
             RemoveWindows ();


### PR DESCRIPTION
Fix nachocove/qa#618. The app's crashing with a nul
navigation controller. This crash can happen when the
navigation controller is accessed from a view controller
after that view controller has been popped off the stack.
Telemetry showed events arriving after the login process
was completed, and those events would start the finishing
up process even if the finishing up process was already
completed.  Now, there's a new state Park for when advanced
login view is completing.
