### PR TITLE
Fix nachocove/qa#638.  Fix in the sense of prevent the crash and

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/SwitchAccountCustomSegue.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/SwitchAccountCustomSegue.cs
@@ -4,6 +4,7 @@ using CoreAnimation;
 using Foundation;
 using UIKit;
 using NachoClient.iOS;
+using NachoCore.Utils;
 
 [Register ("SwitchAccountCustomSegue")]
 public class SwitchAccountCustomSegue : UIStoryboardSegue
@@ -19,6 +20,20 @@ public class SwitchAccountCustomSegue : UIStoryboardSegue
 
     public override void Perform ()
     {
+        if (null == this.SourceViewController) {
+            Log.Error (Log.LOG_UI, "SwitchAccountCustomSegue: SourceViewController is null.");
+            return;
+        }
+        if (null == this.SourceViewController.NavigationController) {
+            Log.Error (Log.LOG_UI, "SwitchAccountCustomSegue: SourceViewController.NavigationController is null.");
+            return;
+        }
+        if ((null == SourceViewController.View) || (null == SourceViewController.View.Window)) {
+            Log.Error (Log.LOG_UI, "SwitchAccountCustomSegue: SourceViewController {0} is null.", (null == SourceViewController.View ? "view" : "window"));
+            this.SourceViewController.NavigationController.PushViewController (this.DestinationViewController, false);
+            return;
+        }
+            
         using (var image = NachoClient.Util.captureView (this.SourceViewController.View.Window)) {
             var imageView = new UIImageView (image);
             ViewFramer.Create (imageView).Y (-64);


### PR DESCRIPTION
Fix nachocove/qa#638.  Fix in the sense of prevent the crash and
log info about the system. Not sure why the source view would be
coming in null or, judging from telemetry, why switch account is
pressed before finished launching.
