### PR TITLE
Fix nachocove/qa#599. 

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcTask.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcTask.cs
@@ -63,9 +63,8 @@ namespace NachoCore.Utils
                     // Make sure that there is not another task by the same name already running
                     // No reverse mapping just walk. Should be few enough tasks that walking is not a problem.
                     foreach (var pair in TaskMap) {
-                        var taskname = pair.Value;
-                        if (taskName.StartsWith (name)) {
-                            Log.Info (Log.LOG_SYS, "NcTask {0} already running", taskName);
+                        if (pair.Value.StartsWith (name)) {
+                            Log.Warn (Log.LOG_SYS, "NcTask {0} already running", pair.Value);
                             return null; // an entry exists
                         }
                     }


### PR DESCRIPTION
- There were two instances of telemetry tasks both reading the same the file.
- This fix treats the symptom by fixing a bug in NcTask.Run()'s isUnique parameter.
- There is still another deeper problem of why cancellation is not happening or not happening in time. I see multiple other tasks are late exiting. (Brain, Start, and ImapSyncCommand tasks are some) I'll continue to investigate that meanwhile.
