### PR TITLE
Use less memory when constructing MIME; fix image resize bug

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
@@ -154,41 +154,42 @@ namespace NachoClient.iOS
             var mutableBodyAttributedText = new NSMutableAttributedString (bodyAttributedText);
             mutableBodyAttributedText.AddAttribute (UIStringAttributeKey.Font, UIFont.FromName ("Helvetica", 12), new NSRange (0, mutableBodyAttributedText.Length));
 
-            var body = new BodyBuilder ();
-            body.TextBody = bodyTextView.Text;
+            using (var body = new NcMimeBodyBuilder ()) {
+                body.TextBody = bodyTextView.Text;
 
-            var length = Math.Min (bodyTextView.Text.Length, 256);
-            var preview = bodyTextView.Text.Substring (0, length);
+                var length = Math.Min (bodyTextView.Text.Length, 256);
+                var preview = bodyTextView.Text.Substring (0, length);
 
-            NSError error = null;
-            NSData htmlData = mutableBodyAttributedText.GetDataFromRange (
+                NSError error = null;
+                NSData htmlData = mutableBodyAttributedText.GetDataFromRange (
                                   new NSRange (0, mutableBodyAttributedText.Length),
                                   new NSAttributedStringDocumentAttributes { DocumentType = NSDocumentType.HTML },
                                   ref error);
-            body.HtmlBody = htmlData.ToString ();
+                body.HtmlBody = htmlData.ToString ();
 
-            foreach (var attachment in attachmentView.AttachmentList) {
-                body.Attachments.Add (attachment.GetFilePath ());
-            }
+                foreach (var attachment in attachmentView.AttachmentList) {
+                    body.Attachments.Add (attachment.GetFilePath ());
+                }
 
-            mimeMessage.Body = body.ToMessageBody ();
+                mimeMessage.Body = body.ToMessageBody ();
 
-            var message = MimeHelpers.AddToDb (account.Id, mimeMessage);
-            message.BodyPreview = preview;
-            message.Intent = messageIntent;
-            message.IntentDate = messageIntentDateTime;
-            message.IntentDateType = messageIntentDateType;
-            message.QRType = QRType;
+                var message = MimeHelpers.AddToDb (account.Id, mimeMessage);
+                message.BodyPreview = preview;
+                message.Intent = messageIntent;
+                message.IntentDate = messageIntentDateTime;
+                message.IntentDateType = messageIntentDateType;
+                message.QRType = QRType;
 
-            message.ReferencedEmailId = (null == referencedMessage) ? 0 : referencedMessage.Id;
-            message.ReferencedIsForward = (action == EmailHelper.Action.Forward);
-            message.ReferencedBodyIsIncluded = !calendarInviteIsSet && null != initialQuotedText;
+                message.ReferencedEmailId = (null == referencedMessage) ? 0 : referencedMessage.Id;
+                message.ReferencedIsForward = (action == EmailHelper.Action.Forward);
+                message.ReferencedBodyIsIncluded = !calendarInviteIsSet && null != initialQuotedText;
 
-            message.Update ();
+                message.Update ();
 
-            EmailHelper.SaveEmailMessageInDrafts (message);
-            if (null != draftMessage) {
-                EmailHelper.DeleteEmailMessageFromDrafts (draftMessage);
+                EmailHelper.SaveEmailMessageInDrafts (message);
+                if (null != draftMessage) {
+                    EmailHelper.DeleteEmailMessageFromDrafts (draftMessage);
+                }
             }
         }
 
@@ -1202,7 +1203,7 @@ namespace NachoClient.iOS
             }
 
             // Compressing won't help
-            if ((sTotal == aTotal) && (mTotal == aTotal) && (lTotal == aTotal)) {
+            if ((sTotal >= aTotal) && (mTotal >= aTotal) && (lTotal >= aTotal)) {
                 NcActionSheet.Show (View, this, null,
                     String.Format ("This message is {0}", Pretty.PrettyFileSize (aTotal)),
                     new NcAlertAction ("Send", () => {
@@ -1225,9 +1226,21 @@ namespace NachoClient.iOS
                     ReallySendMessageAndClose ();
                 }),
                 new NcAlertAction (TextForScaling ("Medium", mTotal), () => {
+                    foreach (var attachment in attachmentView.AttachmentList) {
+                        var newAttachment = AttachmentHelper.ResizeAttachmentToSize (attachment, new CGSize (480, 640));
+                        if (null != newAttachment) {
+                            attachmentView.ReplaceAttachment (attachment, newAttachment);
+                        }
+                    }
                     ReallySendMessageAndClose ();
                 }),
                 new NcAlertAction (TextForScaling ("Large", lTotal), () => {
+                    foreach (var attachment in attachmentView.AttachmentList) {
+                        var newAttachment = AttachmentHelper.ResizeAttachmentToSize (attachment, new CGSize (960, 1280));
+                        if (null != newAttachment) {
+                            attachmentView.ReplaceAttachment (attachment, newAttachment);
+                        }
+                    }
                     ReallySendMessageAndClose ();
                 }),
                 new NcAlertAction (TextForScaling ("Actual Size", aTotal), () => {
@@ -1257,67 +1270,68 @@ namespace NachoClient.iOS
             var mutableBodyAttributedText = new NSMutableAttributedString (bodyAttributedText);
             mutableBodyAttributedText.AddAttribute (UIStringAttributeKey.Font, UIFont.FromName ("Helvetica", 12), new NSRange (0, mutableBodyAttributedText.Length));
 
-            var body = new BodyBuilder ();
-            body.TextBody = bodyTextView.Text;
+            using (var body = new NcMimeBodyBuilder ()) {
+                body.TextBody = bodyTextView.Text;
 
-            // For drafts in case message is viewed in Outbox
-            var length = Math.Min (bodyTextView.Text.Length, 256);
-            var preview = bodyTextView.Text.Substring (0, length);
+                // For drafts in case message is viewed in Outbox
+                var length = Math.Min (bodyTextView.Text.Length, 256);
+                var preview = bodyTextView.Text.Substring (0, length);
 
-            NSError error = null;
-            NSData htmlData = mutableBodyAttributedText.GetDataFromRange (
+                NSError error = null;
+                NSData htmlData = mutableBodyAttributedText.GetDataFromRange (
                                   new NSRange (0, mutableBodyAttributedText.Length),
                                   new NSAttributedStringDocumentAttributes { DocumentType = NSDocumentType.HTML },
                                   ref error);
-            body.HtmlBody = htmlData.ToString ();
+                body.HtmlBody = htmlData.ToString ();
 
-            foreach (var attachment in attachmentView.AttachmentList) {
-                body.Attachments.Add (attachment.GetFilePath ());
-            }
-            bool attachmentNeedsDownloading = false;
-            if (EmailHelper.IsForwardAction (action) && originalEmailIsEmbedded) {
-                // The user edited the body of the message being forwarded. That means the server won't
-                // automatically include the attachments from the forwarded message (if any).  That needs
-                // to be done explicitly.  If all of the necessary attachments are available, go ahead and
-                // add them to the message now.  If any of the attachments need to be downloaded, then
-                // wait until later to add them.
-                var originalAttachments = McAttachment.QueryByItemId (referencedMessage);
-                foreach (var attachment in originalAttachments) {
-                    if (McAbstrFileDesc.FilePresenceEnum.Complete != attachment.FilePresence) {
-                        attachmentNeedsDownloading = true;
-                        break;
-                    }
+                foreach (var attachment in attachmentView.AttachmentList) {
+                    body.Attachments.Add (attachment.GetFilePath ());
                 }
-                if (!attachmentNeedsDownloading) {
+                bool attachmentNeedsDownloading = false;
+                if (EmailHelper.IsForwardAction (action) && originalEmailIsEmbedded) {
+                    // The user edited the body of the message being forwarded. That means the server won't
+                    // automatically include the attachments from the forwarded message (if any).  That needs
+                    // to be done explicitly.  If all of the necessary attachments are available, go ahead and
+                    // add them to the message now.  If any of the attachments need to be downloaded, then
+                    // wait until later to add them.
+                    var originalAttachments = McAttachment.QueryByItemId (referencedMessage);
                     foreach (var attachment in originalAttachments) {
-                        body.Attachments.Add (attachment.GetFilePath ());
+                        if (McAbstrFileDesc.FilePresenceEnum.Complete != attachment.FilePresence) {
+                            attachmentNeedsDownloading = true;
+                            break;
+                        }
+                    }
+                    if (!attachmentNeedsDownloading) {
+                        foreach (var attachment in originalAttachments) {
+                            body.Attachments.Add (attachment.GetFilePath ());
+                        }
                     }
                 }
-            }
 
-            mimeMessage.Body = body.ToMessageBody ();
-            var messageToSend = MimeHelpers.AddToDb (account.Id, mimeMessage);
-            messageToSend.BodyPreview = preview;
-            messageToSend.Intent = messageIntent;
-            messageToSend.IntentDate = messageIntentDateTime;
-            messageToSend.IntentDateType = messageIntentDateType;
-            messageToSend.QRType = QRType;
+                mimeMessage.Body = body.ToMessageBody ();
+                var messageToSend = MimeHelpers.AddToDb (account.Id, mimeMessage);
+                messageToSend.BodyPreview = preview;
+                messageToSend.Intent = messageIntent;
+                messageToSend.IntentDate = messageIntentDateTime;
+                messageToSend.IntentDateType = messageIntentDateType;
+                messageToSend.QRType = QRType;
 
-            if (EmailHelper.IsForwardOrReplyAction (action) && !calendarInviteIsSet) {
-                messageToSend.ReferencedEmailId = referencedMessage.Id;
-                messageToSend.ReferencedBodyIsIncluded = originalEmailIsEmbedded;
-                messageToSend.ReferencedIsForward = EmailHelper.IsForwardAction (action);
-                messageToSend.WaitingForAttachmentsToDownload = attachmentNeedsDownloading;
-            }
+                if (EmailHelper.IsForwardOrReplyAction (action) && !calendarInviteIsSet) {
+                    messageToSend.ReferencedEmailId = referencedMessage.Id;
+                    messageToSend.ReferencedBodyIsIncluded = originalEmailIsEmbedded;
+                    messageToSend.ReferencedIsForward = EmailHelper.IsForwardAction (action);
+                    messageToSend.WaitingForAttachmentsToDownload = attachmentNeedsDownloading;
+                }
 
-            messageToSend.Update ();
+                messageToSend.Update ();
 
-            // Send the mesage
-            EmailHelper.SendTheMessage (action, messageToSend, originalEmailIsEmbedded, referencedMessage, calendarInviteIsSet, calendarInviteItem);
+                // Send the mesage
+                EmailHelper.SendTheMessage (action, messageToSend, originalEmailIsEmbedded, referencedMessage, calendarInviteIsSet, calendarInviteItem);
 
-            // and remove the draft, if any
-            if (null != draftMessage) {
-                EmailHelper.DeleteEmailMessageFromDrafts (draftMessage);
+                // and remove the draft, if any
+                if (null != draftMessage) {
+                    EmailHelper.DeleteEmailMessageFromDrafts (draftMessage);
+                }
             }
 
             // And close


### PR DESCRIPTION
When sending an outgoing message that has attachments, construct the
MIME for the message without loading the attachments into memory.  The
MIME is created by streaming the attachments from one file to another.
This was done by copying and modifying two MimeKit utility classes.
This is an intermediate fix and is only applicable to sending a
message or saving a draft.  A better fix, which could be used to
reduce memory in other places where MimeKit is used, requires changing
some classes closer to the core of MimeKit.  That fix may (or may not)
be attempted later.

Fix nachocove/qa#631.  When sending a message with large image
attachments, the "Medium" and "Large" choices now do what they say
they do.
