### PR TITLE
Fix nachocove/qa#691.  Move the fetch of the unread message count off the ui thread.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/UnreadMessagesView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/UnreadMessagesView.cs
@@ -48,7 +48,6 @@ namespace NachoClient.iOS
         public void Update (McAccount account)
         {
             NcTask.Run (() => {
-                System.Threading.Thread.Sleep (4000);
                 int unreadMessageCount;
                 int deferredMessageCount;
                 int deadlineMessageCount;


### PR DESCRIPTION
Move the fetch of the unread message count  for the current account off the ui thread. Other accounts already are off the ui thread.
