### PR TITLE
The imap backend was crashing badly because is was sending a null 'from' address.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
@@ -580,6 +580,10 @@ namespace NachoCore.Utils
         public static string Initials (string fromAddressString)
         {
             // Parse the from address
+            if (String.IsNullOrEmpty (fromAddressString)) {
+                Log.Error (Log.LOG_UTILS, "Initials passed a null or empty from string");
+                return "";
+            }
             var initials = "";
             var mailboxAddress = NcEmailAddress.ParseMailboxAddressString (fromAddressString);
             if (null != mailboxAddress) {


### PR DESCRIPTION
The imap backend was crashing badly because is was sending
a null 'from' to initials.  Let's add an error log to catch
the bad message and see why 'from' is null.

Let's see if this happens much & if so we can remove the log.
