### PR TITLE
Fix nachocove/qa#674. Speed up message loading.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -58,14 +58,6 @@ namespace NachoClient.iOS
         const int VIEW_INSET = 4;
         const int ATTACHMENTVIEW_INSET = 10;
         nfloat HEADER_TOP_MARGIN = 0;
-
-
-
-
-
-
-
-
 #else
         const int VIEW_INSET = 0;
         const int ATTACHMENTVIEW_INSET = 15;
@@ -416,32 +408,39 @@ namespace NachoClient.iOS
                 this.NavigationController.InteractivePopGestureRecognizer.Delegate = null;
             }
 
+            NachoCore.Utils.NcAbate.HighPriority ("MessageViewController");
+
             var message = thread.SingleMessageSpecialCase ();
 
             if (null == message) {
                 // TODO: Unavailable message
                 NavigationController.PopViewController (true);
+                NachoCore.Utils.NcAbate.RegularPriority ("MessageViewController");
                 return;
             }
                 
             attachments = McAttachment.QueryByItemId (message);
+            attachmentListView.Hidden = !HasAttachments;
 
+            NachoCore.Utils.NcAbate.RegularPriority ("MessageViewController");
+
+            // User image view
             var userImageView = headerView.ViewWithTag ((int)TagType.USER_IMAGE_TAG) as UIImageView;
             var userLabelView = headerView.ViewWithTag ((int)TagType.USER_LABEL_TAG) as UILabel;
-            var userImage = Util.ImageOfSender (message.AccountId, Pretty.EmailString (message.From));
+            userImageView.Hidden = true;
+            userLabelView.Hidden = true;
+
+            var userImage = Util.PortraitToImage (message.cachedPortraitId);
+
             if (null != userImage) {
                 userImageView.Hidden = false;
                 userImageView.Image = userImage;
-                userLabelView.Hidden = true;
             } else {
                 userLabelView.Hidden = false;
                 userLabelView.Text = message.cachedFromLetters;
                 userLabelView.BackgroundColor = Util.ColorForUser (message.cachedFromColor);
-                userImageView.Hidden = true;
             }
-
-            attachmentListView.Hidden = !HasAttachments;
-
+                
             var cursor = new VerticalLayoutCursor (headerView);
             cursor.AddSpace (35); // for From and top inset
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyView.cs
@@ -600,27 +600,35 @@ namespace NachoClient.iOS
 
         private void RenderMime (McBody body)
         {
-            var message = MimeHelpers.LoadMessage (body);
-            var list = new List<MimeEntity> ();
-            int nativeBodyType = 0;
-            if (item is McEmailMessage) {
-                nativeBodyType = ((McEmailMessage)item).NativeBodyType;
-            } else if (item is McAbstrCalendarRoot) {
-                nativeBodyType = ((McAbstrCalendarRoot)item).NativeBodyType;
-            }
-            MimeHelpers.MimeDisplayList (message, list, MimeHelpers.MimeTypeFromNativeBodyType (nativeBodyType));
+            NcAssert.NotNull (body);
 
-            foreach (var entity in list) {
-                var part = (MimePart)entity;
-                if (part.ContentType.Matches ("text", "html")) {
-                    RenderHtmlPart (part);
-                } else if (part.ContentType.Matches ("text", "rtf")) {
-                    RenderRtfPart (part);
-                } else if (part.ContentType.Matches ("text", "*")) {
-                    RenderTextPart (part);
-                } else if (part.ContentType.Matches ("image", "*")) {
-                    RenderImagePart (part);
+            try {
+                var path = body.GetFilePath ();
+                using (var fileStream = new FileStream (path, FileMode.Open, FileAccess.Read)) {
+                    var message = MimeMessage.Load (fileStream, true);
+                    var list = new List<MimeEntity> ();
+                    int nativeBodyType = 0;
+                    if (item is McEmailMessage) {
+                        nativeBodyType = ((McEmailMessage)item).NativeBodyType;
+                    } else if (item is McAbstrCalendarRoot) {
+                        nativeBodyType = ((McAbstrCalendarRoot)item).NativeBodyType;
+                    }
+                    MimeHelpers.MimeDisplayList (message, list, MimeHelpers.MimeTypeFromNativeBodyType (nativeBodyType));
+                    foreach (var entity in list) {
+                        var part = (MimePart)entity;
+                        if (part.ContentType.Matches ("text", "html")) {
+                            RenderHtmlPart (part);
+                        } else if (part.ContentType.Matches ("text", "rtf")) {
+                            RenderRtfPart (part);
+                        } else if (part.ContentType.Matches ("text", "*")) {
+                            RenderTextPart (part);
+                        } else if (part.ContentType.Matches ("image", "*")) {
+                            RenderImagePart (part);
+                        }
+                    }
                 }
+            } catch {
+                RenderTextString ("");
             }
         }
 


### PR DESCRIPTION
Fix nachocove/qa#674. Speed up message loading by parsing
the mime message on disk instead of in memory, make fewer
queries, and turn on the abate signal. Use the image that
is cached instead of a db query.  Fix nachocove/qa#522.
