### PR TITLE
Fix incorrect timeout values for ActiveSync SendMail command

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/AsAutodiscoverCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/AsAutodiscoverCommand.cs
@@ -807,14 +807,12 @@ namespace NachoCore.ActiveSync
             if (ProtocolState.DisableProvisionCommand) {
                 TestCmd = new AsSettingsCommand (this) {
                     DontReportCommResult = true,
-                    Timeout = new TimeSpan (0, 0, TestTimeoutSecs),
                     MaxTries = 2,
                     OmitDeviceInformation = true,
                 };
             } else {
                 TestCmd = new AsProvisionCommand (this) {
                     DontReportCommResult = true,
-                    Timeout = new TimeSpan (0, 0, TestTimeoutSecs),
                     MaxTries = 2,
                 };
             }
@@ -826,7 +824,6 @@ namespace NachoCore.ActiveSync
             DoCancel ();
             TestCmd = new AsOptionsCommand (this) {
                 DontReportCommResult = true,
-                Timeout = new TimeSpan (0, 0, TestTimeoutSecs),
                 MaxTries = 2,
             };
             // HotMail/GMail doesn't WWW-Authenticate on OPTIONS.

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
@@ -486,6 +486,13 @@ namespace NachoCore.ActiveSync
                 StepSm.Validate ();
             }
 
+            public virtual double TimeoutInSeconds
+            {
+                get {
+                    return 10.0;
+                }
+            }
+
             public void Execute ()
             {
                 StepSm.Name = Command.Sm.Name + ":" + StepSm.Name + "(" + Enum.GetName (typeof(Steps), Step) + ")";
@@ -562,7 +569,6 @@ namespace NachoCore.ActiveSync
                     DontReportCommResult = true,
                     TriesLeft = 2,
                     TimeoutExpander = KDefaultTimeoutExpander,
-                    Timeout = new TimeSpan (0, 0, 10),
                     DontReUseHttpClient = true,
                 };
             }

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsCommand.cs
@@ -37,14 +37,12 @@ namespace NachoCore.ActiveSync
         private bool Cancelled = false;
         private bool ProcessResponseOwnsPendingCleanup = false;
 
-        private TimeSpan _Timeout;
-        public TimeSpan Timeout { 
-            set { _Timeout = value;
-                if (null != Op) {
-                    Op.Timeout = _Timeout;
-                }
-            } 
-            get { return _Timeout; } }
+        public virtual double TimeoutInSeconds
+        {
+            get {
+                return 0.0;
+            }
+        }
 
         public uint MaxTries { set; get; }
 
@@ -58,7 +56,6 @@ namespace NachoCore.ActiveSync
 
         public AsCommand (string commandName, IBEContext beContext) : base (beContext)
         {
-            Timeout = TimeSpan.Zero;
             CommandName = commandName;
         }
         // Virtual Methods.
@@ -67,9 +64,6 @@ namespace NachoCore.ActiveSync
             Op = new AsHttpOperation (CommandName, this, BEContext) {
                 DontReportCommResult = DontReportCommResult,
             };
-            if (TimeSpan.Zero != Timeout) {
-                Op.Timeout = Timeout;
-            }
             if (0 != MaxTries) {
                 Op.MaxRetries = MaxTries - 1;
                 Op.TriesLeft = MaxTries;

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsOptionsCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsOptionsCommand.cs
@@ -17,6 +17,12 @@ namespace NachoCore.ActiveSync
         {
         }
 
+        public override double TimeoutInSeconds {
+            get {
+                return AsAutodiscoverCommand.TestTimeoutSecs;
+            }
+        }
+
         public override bool DoSendPolicyKey (AsHttpOperation Sender)
         {
             return false;

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsPingCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsPingCommand.cs
@@ -19,9 +19,14 @@ namespace NachoCore.ActiveSync
         {
             FoldersInRequest = pingKit.Folders;
             HeartbeatInterval = pingKit.MaxHeartbeatInterval;
-            // Add a 10-second fudge so that orderly timeout doesn't look like a network failure.
-            Timeout = new TimeSpan (0, 0, (int)HeartbeatInterval + 10);
             MaxTries = 1;
+        }
+
+        public override double TimeoutInSeconds {
+            get {
+                // Add a 10-second fudge so that orderly timeout doesn't look like a network failure.
+                return (int)HeartbeatInterval + 10;
+            }
         }
 
         public override bool DoSendPolicyKey (AsHttpOperation Sender)

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsProvisionCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsProvisionCommand.cs
@@ -136,6 +136,12 @@ namespace NachoCore.ActiveSync
             Sm.Validate ();
         }
 
+        public override double TimeoutInSeconds {
+            get {
+                return AsAutodiscoverCommand.TestTimeoutSecs;
+            }
+        }
+
         public override void Execute (NcStateMachine sm)
         {
             OwnerSm = sm;

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSendMailCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSendMailCommand.cs
@@ -39,14 +39,18 @@ namespace NachoCore.ActiveSync
             return true;
         }
 
+        public override double TimeoutInSeconds {
+            get {
+                return ((AsProtoControl)BEContext.ProtoControl).Strategy.UploadTimeoutSecs (new FileInfo (EmailMessage.MimePath ()).Length);
+            }
+        }
+
         protected override XDocument ToXDocument (AsHttpOperation Sender)
         {
             if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 return null;
             }
             var mimePath = EmailMessage.MimePath ();
-            var length = new FileInfo (mimePath).Length;
-            Timeout = new TimeSpan (0, 0, ((AsProtoControl)BEContext.ProtoControl).Strategy.UploadTimeoutSecs (length));
             var sendMail = new XElement (m_ns + Xml.ComposeMail.SendMail, 
                                new XElement (m_ns + Xml.ComposeMail.ClientId, EmailMessage.ClientId),
                                new XElement (m_ns + Xml.ComposeMail.SaveInSentItems),
@@ -62,7 +66,6 @@ namespace NachoCore.ActiveSync
             if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 long length;
                 var stream = EmailMessage.ToMime (out length);
-                Timeout = new TimeSpan (0, 0, ((AsProtoControl)BEContext.ProtoControl).Strategy.UploadTimeoutSecs (length));
                 return stream;
             }
             return null;

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSettingsCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSettingsCommand.cs
@@ -20,6 +20,12 @@ namespace NachoCore.ActiveSync
             // TODO: ability to have pending drive OOF setting, etc.
         }
 
+        public override double TimeoutInSeconds {
+            get {
+                return AsAutodiscoverCommand.TestTimeoutSecs;
+            }
+        }
+
         protected override XDocument ToXDocument (AsHttpOperation Sender)
         {
             // We ask for user information and send device information.

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSmartCommand/AsSmartCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSmartCommand/AsSmartCommand.cs
@@ -35,14 +35,18 @@ namespace NachoCore.ActiveSync
             };
         }
 
+        public override double TimeoutInSeconds {
+            get {
+                return ((AsProtoControl)BEContext.ProtoControl).Strategy.UploadTimeoutSecs (new FileInfo (EmailMessage.MimePath ()).Length);
+            }
+        }
+
         protected override XDocument ToXDocument (AsHttpOperation Sender)
         {
             if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 return null;
             }
             var mimePath = EmailMessage.MimePath ();
-            var length = new FileInfo (mimePath).Length;
-            Timeout = new TimeSpan (0, 0, ((AsProtoControl)BEContext.ProtoControl).Strategy.UploadTimeoutSecs (length));
             var smartMail = new XElement (m_ns + CommandName, 
                                 new XElement (m_ns + Xml.ComposeMail.ClientId, EmailMessage.ClientId),
                                 new XElement (m_ns + Xml.ComposeMail.Source,
@@ -64,7 +68,6 @@ namespace NachoCore.ActiveSync
             if (14.0 > Convert.ToDouble (BEContext.ProtocolState.AsProtocolVersion, System.Globalization.CultureInfo.InvariantCulture)) {
                 long length;
                 var stream = EmailMessage.ToMime (out length);
-                Timeout = new TimeSpan (0, 0, ((AsProtoControl)BEContext.ProtoControl).Strategy.UploadTimeoutSecs (length));
                 return stream;
             }
             return null;

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Operations/IAsHttpOperationOwner.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Operations/IAsHttpOperationOwner.cs
@@ -12,6 +12,11 @@ namespace NachoCore.ActiveSync
 {
     public interface IAsHttpOperationOwner
     {
+        /// <summary>
+        /// The number of seconds for the timeout timer for this command.  Return 0.0 to use the default timeout.
+        /// </summary>
+        double TimeoutInSeconds { get; }
+
         Dictionary<string,string> ExtraQueryStringParams (AsHttpOperation Sender);
         Event PreProcessResponse (AsHttpOperation Sender, HttpResponseMessage response);
         Event ProcessResponse (AsHttpOperation Sender, HttpResponseMessage response, CancellationToken cToken);


### PR DESCRIPTION
Fix two bugs in the ActiveSync command timeout calculations, both of
which affected primarily the SendMail command.

When an operation is retried, the timeout value is increased.  A bug
in the way this increase is calculated (using TimeSpan.Seconds instead
of TimeSpan.TotalSeconds) was resulting a timeout that was much too
short if the original timeout had been more than a minute.

The SendMail command calculates an appropriate timeout value based on
the size of the outgoing message.  But the timeout value was not being
set until after the timeout timer had been created.  So the initial
attempt of the SendMail command was always using the default timeout,
not its custom timeout.

Restructure the code for the timeout value for ActiveSync HTTP
operations to avoid these two problems.
