### PR TITLE
Better handling of device event with unknown time zone

### DIFF
--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -181,7 +181,12 @@ namespace NachoPlatform
                     // iOS's NSTimeZone does not expose the daylight saving transition rules, so there is no way
                     // to construct a TimeZoneInfo object from the NSTimeZone object.  Instead we have to look
                     // up the TimeZoneInfo by its ID.
-                    eventTimeZone = TimeZoneInfo.FindSystemTimeZoneById (Event.TimeZone.Name);
+                    try {
+                        eventTimeZone = TimeZoneInfo.FindSystemTimeZoneById (Event.TimeZone.Name);
+                    } catch (TimeZoneNotFoundException) {
+                        Log.Warn (Log.LOG_CALENDAR, "Device event has unknown time zone: {0}", Event.TimeZone.Name);
+                        // Leave eventTimeZone set to null, so it will be set to the local time zone below.
+                    }
                 }
                 if (null == eventTimeZone) {
                     // If the iOS event didn't specify a time zone, or if a time zone with that ID could not be


### PR DESCRIPTION
Do a better job of handling the situation where an event from the
device calendar has a time zone that cannot be looked up.  Instead of
logging an error with an exception stack trace and ignoring the event,
log a warning and continue processing the event in the local time
zone.

Fix nachocove/qa#698
