### PR TITLE
Fix unit test compilation error: TimeoutInSeconds not implemented

### DIFF
--- a/Test.Android/AsHttpOperationTest.cs
+++ b/Test.Android/AsHttpOperationTest.cs
@@ -46,6 +46,11 @@ namespace Test.iOS
 
         AsHttpOperation Op { set; get; }
 
+        public virtual double TimeoutInSeconds
+        {
+            get { return 0.0; }
+        }
+
         public virtual Dictionary<string,string> ExtraQueryStringParams (AsHttpOperation sender)
         {
             return null;


### PR DESCRIPTION
nachocove/qa#707 is improved to the point where the unit tests compile
and run.  But they don't all pass.  I still need to look at the
failures.
