### PR TITLE
Fix nachocove/qa#667.

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -498,6 +498,7 @@
     <Compile Include="NachoCore\Model\Migration\NcMigration34.cs" />
     <Compile Include="NachoCore\Utils\ContactsBinningHelper.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration35.cs" />
+    <Compile Include="NachoCore\Utils\SearchHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\AboutAssets.txt" />

--- a/NachoClient.Android/NachoCore/Utils/SearchHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/SearchHelper.cs
@@ -1,0 +1,61 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+using System.Collections.Generic;
+
+namespace NachoCore.Utils
+{
+    /// <summary>
+    /// Search helper provides an asynchronous interface for issuing searches.
+    /// </summary>
+    public class SearchHelper
+    {
+        public int Version { get; protected set; }
+
+        protected string Description;
+        protected Queue<string> SearchQueue;
+        protected object LockObj;
+        protected Action<string> SearchAction;
+
+        public SearchHelper (string description, Action<string> searchAction)
+        {
+            LockObj = new object ();
+            Description = description;
+            SearchQueue = new Queue<string> ();
+            SearchAction = searchAction;
+        }
+
+        protected void StartSearch (string searchString)
+        {
+            NcTask.Run (() => {
+                SearchAction (searchString);
+            }, "SearchHelper_" + Description).ContinueWith ((task) => {
+                lock (LockObj) {
+                    if (0 < SearchQueue.Count) {
+                        string newSearchString = null;
+                        while (0 < SearchQueue.Count) {
+                            newSearchString = SearchQueue.Dequeue ();
+                        }
+                        StartSearch (newSearchString);
+                    } else {
+                        NcAbate.RegularPriority (Description);
+                    }
+                }
+            });
+        }
+
+        public void Search (string searchString)
+        {
+            lock (LockObj) {
+                Version += 1;
+                if (0 < SearchQueue.Count) {
+                    SearchQueue.Enqueue (searchString);
+                    return;
+                }
+                NcAbate.HighPriority (Description);
+                StartSearch (searchString);
+            }
+        }
+    }
+}
+

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1577,6 +1577,9 @@
     <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration35.cs">
       <Link>NachoCore\Model\Migration\NcMigration35.cs</Link>
     </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Utils\SearchHelper.cs">
+      <Link>NachoCore\Utils\SearchHelper.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
@@ -34,10 +34,29 @@ namespace NachoClient.iOS
         protected string searchToken;
         McAccount accountForSearchAPI;
 
+        protected SearchHelper searcher;
+
         public ContactsTableViewSource ()
         {
             owner = null;
             allowSwiping = false;
+            searcher = new SearchHelper ("ContactsTableViewSourceUpdateSearchResults", (searchString) => {
+                if (String.IsNullOrEmpty (searchString)) {
+                    InvokeOnUIThread.Instance.Invoke (() => {
+                        SetSearchResults (new List<McContactEmailAddressAttribute> ());
+                        NcApplication.Instance.InvokeStatusIndEventInfo (null, NcResult.SubKindEnum.Info_ContactLocalSearchComplete);
+                    });
+                } else {
+                    int curVersion = searcher.Version;
+                    var results = McContact.SearchIndexAllContacts (searchString, false, true);
+                    if (curVersion == searcher.Version) {
+                        InvokeOnUIThread.Instance.Invoke (() => {
+                            SetSearchResults (results);
+                            NcApplication.Instance.InvokeStatusIndEventInfo (null, NcResult.SubKindEnum.Info_ContactLocalSearchComplete);
+                        });
+                    }
+                }
+            });
         }
 
         public void SetOwner (IContactsTableViewSourceDelegate owner, McAccount accountForSearchAPI, bool allowSwiping, UISearchDisplayController SearchDisplayController)
@@ -358,27 +377,10 @@ namespace NachoClient.iOS
                 }
             }
 
-            // Optionally issue an asynchronous search. By default, return false to skip
-            // ReloadData() because the search result is usually not ready by the time this
-            // call returns.
-            bool result = false;
-            NachoCore.Utils.NcAbate.HighPriority ("ContactTableViewSource UpdateSearchResults");
-            if (String.IsNullOrEmpty (forSearchString)) {
-                // If there is no search string, just update the search result synchronously
-                SetSearchResults (new List<McContactEmailAddressAttribute> ());
-                NachoCore.Utils.NcAbate.RegularPriority ("ContactTableViewSource UpdateSearchResults");
-                result = true;
-            } else {
-                NcTask.Run (() => {
-                    var results = McContact.SearchIndexAllContacts (forSearchString, false, true);
-                    InvokeOnUIThread.Instance.Invoke (() => {
-                        SetSearchResults (results);
-                        NcApplication.Instance.InvokeStatusIndEventInfo (null, NcResult.SubKindEnum.Info_ContactLocalSearchComplete);
-                        NachoCore.Utils.NcAbate.RegularPriority ("ContactTableViewSource UpdateSearchResults");
-                    });
-                }, "SearchLocalContacts");
-            }
-            return result;
+            // Issue an asynchronous search.
+            searcher.Search (forSearchString);
+
+            return false;
         }
 
         protected void DumpInfo (McContact contact)


### PR DESCRIPTION
- Create a search helper class that issues NcTask that perform a search & update action.
- It provides serialization of searches with skipping that omits search all intermediate search strings.
- It also provides a version # so that update of older version can be skipped to speed up responsiveness.
- The case with empty search string is now also asynchronous to avoid a race.
