### PR TITLE
Fix nachocove/qa#715

### DIFF
--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -599,11 +599,11 @@ namespace NachoCore
             Log.Info (Log.LOG_LIFECYCLE, "NcApplication: StopClass4Services called.");
             MonitorStop ();
             CrlMonitor.StopService ();
-            if (Class4EarlyShowTimer.DisposeAndCheckHasFired ()) {
+            if ((null != Class4EarlyShowTimer) && Class4EarlyShowTimer.DisposeAndCheckHasFired ()) {
                 Log.Info (Log.LOG_LIFECYCLE, "NcApplication: Class4EarlyShowTimer.DisposeAndCheckHasFired.");
             }
 
-            if (Class4LateShowTimer.DisposeAndCheckHasFired ()) {
+            if ((null != Class4LateShowTimer) && Class4LateShowTimer.DisposeAndCheckHasFired ()) {
                 Log.Info (Log.LOG_LIFECYCLE, "NcApplication: Class4LateShowTimer.DisposeAndCheckHasFired.");
                 NcCapture.PauseAll ();
                 NcTimeVariance.PauseAll ();


### PR DESCRIPTION
- During migration, the client is in foreground but class 4 service is not started. So, if it goes to background, OnResignActivation() is called and crashes because it tries to dispose timers that have not been started.
- The fix is to check that the timers are created before trying to dispose them.
