### PR TITLE
Fix nachocove/qa#665

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -584,6 +584,9 @@ namespace NachoClient.iOS
                 ShutdownTimer.Dispose ();
                 ShutdownTimer = null;
             }
+            if (doingPerformFetch) {
+                CompletePerformFetchWithoutShutdown ();
+            }
             if (FinalShutdownHasHappened) {
                 ReverseFinalShutdown ();
             }


### PR DESCRIPTION
- The client goes to background, starts a fetch.
- Perform fetch timer fires and the Error_SyncFailedToComplete status ind happens; before OnActivated() gets a chance to clean up the perform fetch states. This shuts down basal service.
- OnActivated() is called but it thinks basal services are already started (by WIllEnterForeground()).
- The fix is to clean up perform fetch states when entering foreground.
