### PR TITLE
Fix nachocove/qa#676

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcContactGleaner.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcContactGleaner.cs
@@ -95,7 +95,9 @@ namespace NachoCore.Brain
                 Source = McAbstrItem.ItemSource.Internal,
             };
 
-            gleanedContact.AddEmailAddressAttribute (accountId, "Email1Address", null, mbAddr.Address);
+            if (null == gleanedContact.AddEmailAddressAttribute (accountId, "Email1Address", null, mbAddr.Address)) {
+                return;
+            }
             NcEmailAddress.ParseName (mbAddr, ref gleanedContact);
             if (mbAddr.Address == mbAddr.Name) {
                 // Some mail clients generate email addresses like "bob@company.net <bob@company.net>"

--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -516,11 +516,12 @@ namespace NachoCore.Model
             f.Value = value;
             f.ContactId = this.Id;
             McEmailAddress emailAddress;
-            if (McEmailAddress.Get (AccountId, value, out emailAddress)) {
-                f.EmailAddress = emailAddress.Id;
-                if (0 == this.CircleColor) {
-                    this.CircleColor = emailAddress.ColorIndex;
-                }
+            if (!McEmailAddress.Get (AccountId, value, out emailAddress)) {
+                return null;
+            }
+            f.EmailAddress = emailAddress.Id;
+            if (0 == this.CircleColor) {
+                this.CircleColor = emailAddress.ColorIndex;
             }
             EmailAddresses.Add (f);
             return f;


### PR DESCRIPTION
- In McContact.AddEmailAddressAttribute(), if McEmailAddress.Get() return false because the email address is a group address or an invalid email address, it ends up adding an empty McContactEmailAddressAttribute.
- NcContactGleaner.CreateGleanContact() is only called for a valid email address. So, most likely it is a group address. This would result in creating a gleaned contact that is totally empty.
- The solution is to not create gleaned contacts if the email address cannot be parsed.
