### PR TITLE
Fix nachocove/qa#734.  Don't let null contacts be selected.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
@@ -212,7 +212,9 @@ namespace NachoClient.iOS
         {
             string dummy;
             McContact contact = ContactFromIndexPath (tableView, indexPath, out dummy);
-            owner.ContactSelectedCallback (contact);
+            if (null != contact) {
+                owner.ContactSelectedCallback (contact);
+            }
             DumpInfo (contact);
             tableView.DeselectRow (indexPath, true);
         }


### PR DESCRIPTION
Fix nachocove/qa#734.  It's possible for a contact to be deleted
and therefore be null.  Don't let a null contact be selected.
