### PR TITLE
Fix nachocove/qa#678, nachocove/qa#726

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -213,6 +213,7 @@ namespace NachoClient.iOS
                 })) {
                     // Can't find any account matching those contexts. Abort immediately
                     completionHandler (UIBackgroundFetchResult.NoData);
+                    return;
                 }
                 if (NcApplication.Instance.IsForeground) {
                     completionHandler (UIBackgroundFetchResult.NewData);


### PR DESCRIPTION
If completion handler is called due to notification context is not found, make sure it immediately exits the function and not continue to the next chunk of code.
