### PR TITLE
Don't notify about deleted messages; avoid duplicate notifications

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -969,10 +969,6 @@ namespace NachoClient.iOS
         // It is okay if this function is called more than it needs to be.
         private void BadgeNotifUpdate ()
         {
-            // There are extra messages about individual messages being processed to help us debug
-            // https://github.com/nachocove/qa/issues/722.  The number of info messages should be
-            // reduced once that issue is dealt with.
-
             Log.Info (Log.LOG_UI, "BadgeNotifUpdate: called");
             if (!BadgeNotifAllowed) {
                 Log.Info (Log.LOG_UI, "BadgeNotifUpdate: early exit");
@@ -987,8 +983,21 @@ namespace NachoClient.iOS
             int remainingVisibleSlots = 10;
             var accountTable = new Dictionary<int, McAccount> ();
 
+            var notifiedMessageIDs = new HashSet<string> ();
+
             foreach (var message in unreadAndHot) {
+                if (!string.IsNullOrEmpty (message.MessageID) && notifiedMessageIDs.Contains (message.MessageID)) {
+                    Log.Info (Log.LOG_UI, "BadgeNotifUpdate: Skipping message {0} because a message with that message ID has already been processed", message.Id);
+                    --badgeCount;
+                    message.HasBeenNotified = true;
+                    message.ShouldNotify = true;
+                    message.Update ();
+                    continue;
+                }
                 if (message.HasBeenNotified) {
+                    if (message.ShouldNotify && !string.IsNullOrEmpty (message.MessageID)) {
+                        notifiedMessageIDs.Add (message.MessageID);
+                    }
                     continue;
                 }
                 McAccount account = null;
@@ -1003,7 +1012,6 @@ namespace NachoClient.iOS
                     account = newAccount;
                 }
                 if ((null == account) || !NotificationHelper.ShouldNotifyEmailMessage (message, account)) {
-                    Log.Info (Log.LOG_UI, "BadgeNotifUpdate: Not notifying for message {0} because it doesn't match the account notification settings.", message.Id);
                     --badgeCount;
                     message.HasBeenNotified = true;
                     message.ShouldNotify = false;
@@ -1021,6 +1029,9 @@ namespace NachoClient.iOS
                 message.HasBeenNotified = true;
                 message.ShouldNotify = true;
                 message.Update ();
+                if (!string.IsNullOrEmpty (message.MessageID)) {
+                    notifiedMessageIDs.Add (message.MessageID);
+                }
                 Log.Info (Log.LOG_UI, "BadgeNotifUpdate: Notification for message {0}", message.Id);
                 --remainingVisibleSlots;
                 if (0 >= remainingVisibleSlots) {

--- a/Test.Android/PushAssistTest.cs
+++ b/Test.Android/PushAssistTest.cs
@@ -627,17 +627,22 @@ namespace Test.Common
                 emails [n].Insert ();
             }
 
+            var inbox = McFolder.Create (Owner.Account.Id, false, false, true, "0", "made-up", "Inbox", Xml.FolderHierarchy.TypeCode.DefaultInbox_2);
+            inbox.Insert ();
+            inbox.Link (emails [0]);
+            inbox.Link (emails [1]);
+
             emails [1].Score = 1.0;
             emails [1].Update ();
 
             emails [3].Score = 1.0;
             emails [3].Update ();
 
-            // Configuration #1 - All
+            // Configuration #1 - Inbox
             var account = Owner.Account;
             account.NotificationConfiguration = McAccount.NotificationConfigurationEnum.ALLOW_INBOX_64;
             account.Update ();
-            CheckShouldNotify (new bool[4] { true, true, true, true }, emails, account);
+            CheckShouldNotify (new bool[4] { true, true, false, false }, emails, account);
 
             // Configuration #2 - Hot only
             account.NotificationConfiguration = McAccount.NotificationConfigurationEnum.ALLOW_HOT_2;


### PR DESCRIPTION
nachocove/qa#722  This is an improvement, but not a complete fix.
Notifications about deleted messages should be fixed.  Duplicate
notifications should be greatly reduced, but not completely
eliminated.

The "Inbox" setting for notifications was looking for messages in any
folder, not just the Inbox.  Change the code to only look in the
Inbox.

When deciding if a message needs a notification, ignore any message
that is in the deleted items folder, even if it is hot or from a VIP.

Keep track of the message IDs of messages for which a notification has
been posted.  Don't notify the user about a message with a message ID
that is in this set of IDs.  This works around the issue of Gmail
placing the same message in multiple folders.
