### PR TITLE
prevent crash if robot is slow to die

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/AsAutodiscoverCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/AsAutodiscoverCommand.cs
@@ -91,6 +91,7 @@ namespace NachoCore.ActiveSync
         public const string ResponseSchema = "http://schemas.microsoft.com/exchange/autodiscover/mobilesync/responseschema/2006";
         public const int TestTimeoutSecs = 30;
         private List<StepRobot> Robots;
+        private object RobotsLockObj = new object ();
         private Queue<StepRobot> AskingRobotQ;
         private Queue<StepRobot> SuccessfulRobotQ;
         private ConcurrentQueue<Event> RobotEventsQ;
@@ -561,7 +562,7 @@ namespace NachoCore.ActiveSync
         private void AddAndStartRobot (StepRobot.Steps step, string domain, bool isUserSpecifiedDomain)
         {
             Log.Info (Log.LOG_AS, "AUTOD:{0}:BEGIN:Starting discovery for {1}/step {2}", step, domain, step);
-            var robot = new StepRobot (this, step, BEContext.Account.EmailAddr, domain, isUserSpecifiedDomain);
+            var robot = new StepRobot (this, step, BEContext.Account.EmailAddr, domain, isUserSpecifiedDomain, RobotEventsQ);
             Robots.Add (robot);
             robot.Execute ();
         }
@@ -570,7 +571,7 @@ namespace NachoCore.ActiveSync
         {
             Log.Info (Log.LOG_AS, "AUTOD::END:Stopping all robots.");
             if (null != Robots) {
-                lock (Robots) {
+                lock (RobotsLockObj) {
                     foreach (var robot in Robots) {
                         robot.Cancel ();
                         DisposedJunk.Add (robot);
@@ -712,7 +713,7 @@ namespace NachoCore.ActiveSync
             StepRobot robot = (StepRobot)Sm.Arg;
             // Robot can't be on either ask or success queue, or it would not be reporting failure.
             Robots.Remove (robot);
-            lock (Robots) {
+            lock (RobotsLockObj) {
                 if (ShouldDeQueueRobotEvents ()) {
                     SubdomainComplete = true;
                 }
@@ -759,12 +760,12 @@ namespace NachoCore.ActiveSync
         }
 
         // handle event from Robot
-        private void ProcessEventFromRobot (Event Event, StepRobot Robot)
+        private void ProcessEventFromRobot (Event Event, StepRobot Robot, ConcurrentQueue<Event> robotEventsQ)
         {
-            lock (Robots) {
+            lock (RobotsLockObj) {
                 if (ShouldEnQueueRobotEvent (Event, Robot)) {
                     Log.Info (Log.LOG_AS, "AUTOD:{0}:Enqueuing Event for base domain {1}", Robot.Step, Robot.SrDomain);
-                    RobotEventsQ.Enqueue (Event);
+                    robotEventsQ.Enqueue (Event);
                     return;
                 }
             }

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
@@ -96,8 +96,10 @@ namespace NachoCore.ActiveSync
             // Record re-dir source URLs to avoid any loops.
             private List<Uri> ReDirSource = new List<Uri> ();
             private Uri LastUri;
+            // A pointer to the cmd's event Q.
+            private ConcurrentQueue<Event> RobotEventsQ;
 
-            public StepRobot (AsAutodiscoverCommand command, Steps step, string emailAddr, string domain, bool isUerSpecifiedDomain)
+            public StepRobot (AsAutodiscoverCommand command, Steps step, string emailAddr, string domain, bool isUerSpecifiedDomain, ConcurrentQueue<Event> robotEventsQ)
             {
                 int timeoutSeconds = McMutables.GetOrCreateInt (McAccount.GetDeviceAccount ().Id, "AUTOD", "CertTimeoutSeconds", KDefaultCertTimeoutSeconds);
                 CertTimeout = new TimeSpan (0, 0, timeoutSeconds);
@@ -130,6 +132,7 @@ namespace NachoCore.ActiveSync
                 SrEmailAddr = emailAddr;
                 SrDomain = domain;
                 IsUserSpecifiedDomain = isUerSpecifiedDomain;
+                RobotEventsQ = robotEventsQ;
 
                 StepSm = new NcStateMachine ("AUTODSTEP") {
                     /* NOTE: There are three start states:
@@ -534,7 +537,7 @@ namespace NachoCore.ActiveSync
             {
                 // Once cancelled, we must post NO event to TL SM.
                 if (!Ct.IsCancellationRequested) {
-                    Command.ProcessEventFromRobot (Event, this);
+                    Command.ProcessEventFromRobot (Event, this, RobotEventsQ);
                 }
             }
 


### PR DESCRIPTION
a) pass the Q to the robot when we create it. if the robot takes forever to die after a cancel, then it retains the ref to a Q that the command is no longer referencing. prevents the crash, and prevents a really slow-to-die robot from injecting a message into the Q for a later attempt.
b) switched to a for-that-purpose lock-obj, cuz that is the way we want to do things here.
