### PR TITLE
Fix nachocove/qa#800.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
@@ -843,6 +843,9 @@ namespace NachoCore.Model
 
             if (null == thread) {
                 thread = Source.GetEmailThreadMessages (FirstMessageId);
+                if (null == thread) {
+                    yield break; // thread is gone. Maybe backend removed it asynchronously
+                }
             }
             using (IEnumerator<McEmailMessageThread> ie = thread.GetEnumerator ()) {
                 while (ie.MoveNext ()) {


### PR DESCRIPTION
- It looks like the message had been removed when the query was made so 'thread' is null.
- If the thread is gone, early exit the enumeration.
