### PR TITLE
Fix nachocove/qa#811.  Make the account switcher handle in-call status bar.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/SwitchAccountCustomSegue.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/SwitchAccountCustomSegue.cs
@@ -34,12 +34,19 @@ public class SwitchAccountCustomSegue : UIStoryboardSegue
             return;
         }
             
-        using (var image = NachoClient.Util.captureView (this.SourceViewController.View.Window)) {
+        var outermostView = NachoClient.Util.FindOutermostView(this.SourceViewController.View);
+        var screenLocation = this.SourceViewController.View.ConvertPointToView (this.SourceViewController.View.Frame.Location, null);
+
+        // Capture the outermost view & adjust the bounds so it appears that
+        // the original view is still around as the account view animates down.
+        // Keep in mind the in-call and navigation status bars.
+        using (var image = NachoClient.Util.captureView (outermostView)) {
             var imageView = new UIImageView (image);
-            ViewFramer.Create (imageView).Y (-64);
+            ViewFramer.Create (imageView).Y (-screenLocation.Y + 64);
             this.DestinationViewController.View.AddSubview (imageView);
             this.DestinationViewController.View.SendSubviewToBack (imageView);
         }
+
         this.SourceViewController.NavigationController.PushViewController (this.DestinationViewController, false);
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/SwitchAccountViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/SwitchAccountViewController.cs
@@ -62,10 +62,13 @@ namespace NachoClient.iOS
         }
 
         bool firstTime = true;
+        bool animating = false;
 
         public override void ViewWillAppear (bool animated)
         {
             base.ViewWillAppear (animated);
+
+            ViewFramer.Create (accountsTableView).Y (0);
 
             if (firstTime) {
                 firstTime = false;
@@ -73,11 +76,22 @@ namespace NachoClient.iOS
                 ViewFramer.Create (accountsTableView).Height (0);
                 UIView.Animate (0.4, 0, UIViewAnimationOptions.CurveLinear,
                     () => {
+                        animating = true;
                         ViewFramer.Create (accountsTableView).Height (h);
                     },
                     () => {
+                        animating = false;
                     }
                 );
+            }
+        }
+
+        public override void ViewDidLayoutSubviews ()
+        {
+            base.ViewDidLayoutSubviews ();
+            Console.WriteLine ("{0} {1}", accountsTableView.Frame.Height, View.Frame.Height);
+            if (!animating) {
+                ViewFramer.Create (accountsTableView).Height (View.Frame.Height);
             }
         }
 
@@ -147,6 +161,7 @@ namespace NachoClient.iOS
         {
             UIView.Animate (0.3, 0, UIViewAnimationOptions.CurveLinear,
                 () => {
+                    animating = true;
                     ViewFramer.Create (accountsTableView).Height (0);
                 },
                 () => {
@@ -154,6 +169,7 @@ namespace NachoClient.iOS
                     if (null != callback) {
                         callback (account);
                     }
+                    animating = false;
                 });
         }
 


### PR DESCRIPTION
Fix nachocove/qa#811.  The in-call status bar (and navigation bar)
can dynamically change the size of a view. The switch account drop
down animates over an image of the previous view.  That view needs
to take into account the in-call status bar. Also, when the status
bar appears, the view needs to be resized but not during animation
or else the animation is cancelled.
