### PR TITLE
Fix nachocove/qa#835.  A null vc causes this crash in logging.

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -402,8 +402,13 @@ namespace NachoClient.iOS
             if (NcApplication.ReadyToStartUI ()) {
                 var storyboard = UIStoryboard.FromName ("MainStoryboard_iPhone", null);
                 var vc = storyboard.InstantiateViewController ("NachoTabBarController");
-                Log.Info (Log.LOG_UI, "fast path to tab bar controller: {0}", vc);
-                Window.RootViewController = (UIViewController)vc;
+                if (null == vc) {
+                    // Might get null if we're running in background
+                    Log.Info (Log.LOG_UI, "fast path view controller is null");
+                } else {
+                    Log.Info (Log.LOG_UI, "fast path to tab bar controller");
+                    Window.RootViewController = (UIViewController)vc;
+                }
             }
 
             Log.Info (Log.LOG_LIFECYCLE, "FinishedLaunching: Exit");


### PR DESCRIPTION
Fix nachocove/qa#835.  A null vc causes this crash.  Log it
and drop into the normal finished launching flow instead of
using the fast-path login.
