### PR TITLE
Fix nachocove/qa#815

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -12,7 +12,7 @@ using NachoCore.Index;
 
 namespace NachoCore.Model
 {
-    public class NcContactIndex : IComparable<NcContactIndex>
+    public class NcContactIndex
     {
         public int Id { set; get; }
 
@@ -21,27 +21,6 @@ namespace NachoCore.Model
         public McContact GetContact ()
         {
             return McContact.QueryById<McContact> (Id);
-        }
-
-        private static bool SafeIsLetter (string s)
-        {
-            if (1 > s.Length) {
-                return false;
-            }
-            return Char.IsLetter (s [0]);
-        }
-
-        public int CompareTo (NcContactIndex other)
-        {
-            bool myIsLetter = SafeIsLetter (FirstLetter);
-            bool otherIsLetter = SafeIsLetter (other.FirstLetter);
-            if (myIsLetter && !otherIsLetter) {
-                return -1;
-            }
-            if (!myIsLetter && otherIsLetter) {
-                return +1;
-            }
-            return String.Compare (FirstLetter, other.FirstLetter, StringComparison.OrdinalIgnoreCase);
         }
     }
 

--- a/NachoClient.Android/NachoCore/Utils/ContactsBinningHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/ContactsBinningHelper.cs
@@ -24,16 +24,24 @@ namespace NachoCore.Utils
             }
         }
 
-        public static ContactBin[]  BinningContacts (List<NcContactIndex> contacts)
+        public static ContactBin[]  BinningContacts (ref List<NcContactIndex> contacts)
         {
+            var letterContacts = new List<NcContactIndex> ();
+            var nonLetterContacts = new List<NcContactIndex> ();
             foreach (var c in contacts) {
                 if (String.IsNullOrEmpty (c.FirstLetter)) {
                     c.FirstLetter = " ";
                 } else {
                     c.FirstLetter = c.FirstLetter.ToUpperInvariant ();
                 }
+                if (Char.IsLetter (c.FirstLetter [0])) {
+                    letterContacts.Add (c);
+                } else {
+                    nonLetterContacts.Add (c);
+                }
             }
-            contacts.Sort ();
+            contacts = letterContacts;
+            contacts.AddRange (nonLetterContacts);
 
             var bins = new ContactBin[27];
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
@@ -71,10 +71,9 @@ namespace NachoClient.iOS
         public void SetContacts (List<NcContactIndex> recent, List<NcContactIndex> contacts, bool multipleSections)
         {
             this.recent = recent;
+            sections = ContactsBinningHelper.BinningContacts (ref contacts);
             this.contacts = contacts;
             this.multipleSections = multipleSections;
-
-            sections = ContactsBinningHelper.BinningContacts (contacts);
 
             if (SearchDisplayController.Active) {
                 SearchDisplayController.Delegate.ShouldReloadForSearchScope (SearchDisplayController, 0);

--- a/Test.Android/ContactsBinningHelperTest.cs
+++ b/Test.Android/ContactsBinningHelperTest.cs
@@ -57,7 +57,7 @@ namespace Test.Common
                 },
             };
 
-            var bins = ContactsBinningHelper.BinningContacts (contacts);
+            var bins = ContactsBinningHelper.BinningContacts (ref contacts);
             Assert.AreEqual (27, bins.Length);
             for (int n = 0; n < 27; n++) {
                 var bin = bins [n];


### PR DESCRIPTION
- This regression was introduced when fixing the contact-of-death bug.
- Sorting the NcContactIndex list ends up losing the ordering info from SQL query.
- Move all contacts with a non-letter first letter to the back.
