### PR TITLE
fix nachocove/qa#827 - add first attachment by tapping label

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/UcAttachmentBlock.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/UcAttachmentBlock.cs
@@ -228,7 +228,7 @@ namespace NachoClient.iOS
 
             // Tapping on the view toggles between compact and regular size
             toggleCompactTapped = new UITapGestureRecognizer ();
-            toggleCompactTappedToken = toggleCompactTapped.AddTarget (ToggleCompactness);
+            toggleCompactTappedToken = toggleCompactTapped.AddTarget (ShowChooserOrToggleCompactness);
             contentView.AddGestureRecognizer (toggleCompactTapped);
         }
 
@@ -315,8 +315,22 @@ namespace NachoClient.iOS
 
         private void ChooserButtonClicked (object sender, EventArgs e)
         {
+            ShowChooser ();
+        }
+
+        private void ShowChooser()
+        {
             if (null != owner) {
                 owner.PerformSegueForAttachmentBlock ("SegueToAddAttachment", new SegueHolder (null));
+            }
+        }
+
+        private void ShowChooserOrToggleCompactness()
+        {
+            if (0 == list.Count) {
+                ShowChooser ();
+            } else {
+                ToggleCompactness ();
             }
         }
 


### PR DESCRIPTION
tapping an empty attachment cell now opens the attachment chooser.
tapping a non-empty cell toggles the full attachment list as before.
