### PR TITLE
fix nachocove/qa#839 - don't let labels overflow cell

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/UcNameValuePair.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/UcNameValuePair.cs
@@ -47,6 +47,9 @@ namespace NachoClient.iOS
             labelLabel.TextAlignment = UITextAlignment.Left;
             labelLabel.Text = labelString;
             labelLabel.SizeToFit ();
+            if (labelLabel.Frame.X + labelLabel.Frame.Width > rightMargin) {
+                labelLabel.Frame = new CGRect(labelLabel.Frame.X, labelLabel.Frame.Y, rightMargin - labelLabel.Frame.X, labelLabel.Frame.Height);
+            }
             ViewFramer.Create (labelLabel).Height (rect.Height);
             this.AddSubview (labelLabel);
 


### PR DESCRIPTION
This fix doesn't attempt to solve the situation where the
label is longer than the cell AND a value still needs to fit in
