### PR TITLE
Get rid of zombie PushAssistStartSession tasks (part 2)

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -1068,8 +1068,8 @@ namespace NachoCore
 
             // Set up the request
             HttpRequestMessage request = new HttpRequestMessage (HttpMethod.Post, url);
-            Log.Info (Log.LOG_PUSH, "PA request: scheme={0}, url={1}, port={2}, method={3}",
-                request.RequestUri.Scheme, request.RequestUri.AbsoluteUri, request.RequestUri.Port, request.Method);
+            Log.Info (Log.LOG_PUSH, "PA request ({4}): scheme={0}, url={1}, port={2}, method={3}",
+                request.RequestUri.Scheme, request.RequestUri.AbsoluteUri, request.RequestUri.Port, request.Method, ClientContext);
 
             // Set up the POST content
             try {
@@ -1085,20 +1085,20 @@ namespace NachoCore
             // Make the request
             var result = new PushAssistHttpResult ();
             ResetTimeout (timeoutAction);
-            using (var cts = CancellationTokenSource.CreateLinkedTokenSource (cToken, Cts.Token)) {
+            using (var joinCts = CancellationTokenSource.CreateLinkedTokenSource (cToken, Cts.Token)) {
                 try {
-                    var sendTask = Client.SendAsync (request, HttpCompletionOption.ResponseContentRead, cts.Token);
-                    sendTask.Wait ();
+                    var sendTask = Client.SendAsync (request, HttpCompletionOption.ResponseContentRead, joinCts.Token);
+                    sendTask.Wait (joinCts.Token);
                     var response = sendTask.Result;
                     if (null != response.Content) {
                         var readTask = response.Content.ReadAsStringAsync ();
-                        readTask.Wait ();
+                        readTask.Wait (joinCts.Token);
                         result.Content = readTask.Result;
                     }
                     if (HttpStatusCode.OK == response.StatusCode) {
-                        Log.Info (Log.LOG_PUSH, "PA response: statusCode={0}, content={1}", response.StatusCode, result.Content);
+                        Log.Info (Log.LOG_PUSH, "PA response ({0}): statusCode={1}, content={2}", ClientContext, response.StatusCode, result.Content);
                     } else {
-                        Log.Warn (Log.LOG_PUSH, "PA response: statusCode={0}", response.StatusCode);
+                        Log.Warn (Log.LOG_PUSH, "PA response ({0}): statusCode={1}", ClientContext, response.StatusCode);
                     }
                     result.Response = response;
                 } catch (AggregateException e) {


### PR DESCRIPTION
- Remote notification on multi-account leads to zombie start session tasks. It seems the start session requests for the account that is not receiving emails intermittently hang. (I was able to make this happens about half of the time.) Since it only cancels inside SendAsync task, these tasks never cancels and become zombies. When the # of zombie tasks approaches that of TPL thread limit, the task gets queued up and the execution slows down tremendously. (I suspect this is also when the thread id keeps going up.)
- The fix is to cancel on Wait() (in addition to SendAsync task) in order to make sure that start session task always cancels.
- Fix nachocove/qa#846, nachocove/qa#849.
