### PR TITLE
Clean up the connection during Idle, so we don't time out

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -506,6 +506,7 @@
     <Compile Include="NachoCore\BackEnd\SMTP\SmtpValidateConfig.cs" />
     <Compile Include="NachoCore\Brain\NcQualifier.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration38.cs" />
+    <Compile Include="NachoCore\BackEnd\SMTP\Commands\SmtpDisconnectCommand.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\AboutAssets.txt" />

--- a/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpCommand.cs
@@ -6,6 +6,7 @@ using MailKit.Security;
 using MailKit;
 using System.IO;
 using System.Net.Sockets;
+using MailKit.Net.Smtp;
 
 namespace NachoCore.SMTP
 {
@@ -35,7 +36,7 @@ namespace NachoCore.SMTP
             }
         }
 
-        public Event ExecuteConnectAndAuthEvent ()
+        public virtual Event ExecuteConnectAndAuthEvent ()
         {
             lock (Client.SyncRoot) {
                 try {
@@ -56,60 +57,68 @@ namespace NachoCore.SMTP
                     }
                 }
             }
-
         }
 
         public override void Execute (NcStateMachine sm)
         {
+            var cmdname = this.GetType ().Name;
             NcTask.Run (() => {
-                Log.Info (Log.LOG_SMTP, "{0}({1}): Started", this.GetType ().Name, BEContext.Account.Id);
+                Log.Info (Log.LOG_SMTP, "{0}({1}): Started", cmdname, BEContext.Account.Id);
                 try {
                     Event evt = ExecuteConnectAndAuthEvent ();
                     // In the no-exception case, ExecuteCommand is resolving McPending.
                     sm.PostEvent (evt);
                 } catch (SocketException ex) {
-                    Log.Error (Log.LOG_IMAP, "SocketException: {0}", ex.Message);
+                    Log.Error (Log.LOG_IMAP, "{0}: SocketException: {1}", cmdname, ex.Message);
                     ResolveAllFailed (NcResult.WhyEnum.InvalidDest);
                     var errResult = NcResult.Error (NcResult.SubKindEnum.Error_AutoDUserMessage);
                     errResult.Message = ex.Message;
                     sm.PostEvent ((uint)SmtpProtoControl.SmtpEvt.E.GetServConf, "SMTPCONNFAIL", AutoDFailureReason.CannotFindServer);
                 } catch (OperationCanceledException) {
-                    Log.Info (Log.LOG_SMTP, "OperationCanceledException");
+                    Log.Info (Log.LOG_SMTP, "{0}: OperationCanceledException", cmdname);
                     ResolveAllDeferred ();
                     // No event posted to SM if cancelled.
                 } catch (ServiceNotConnectedException) {
                     // FIXME - this needs to feed into NcCommStatus, not loop forever.
-                    Log.Info (Log.LOG_SMTP, "ServiceNotConnectedException");
+                    Log.Info (Log.LOG_SMTP, "{0}: ServiceNotConnectedException", cmdname);
                     ResolveAllDeferred ();
                     sm.PostEvent ((uint)SmtpProtoControl.SmtpEvt.E.ReDisc, "SMTPCONN");
-                } catch (AuthenticationException) {
-                    Log.Info (Log.LOG_SMTP, "AuthenticationException");
+                } catch (AuthenticationException ex) {
+                    Log.Info (Log.LOG_SMTP, "{0}: AuthenticationException: {1}", cmdname, ex.Message);
                     ResolveAllDeferred ();
                     sm.PostEvent ((uint)SmtpProtoControl.SmtpEvt.E.AuthFail, "SMTPAUTH1");
-                } catch (ServiceNotAuthenticatedException) {
-                    Log.Info (Log.LOG_SMTP, "ServiceNotAuthenticatedException");
+                } catch (ServiceNotAuthenticatedException ex) {
+                    Log.Info (Log.LOG_SMTP, "{0}: ServiceNotAuthenticatedException: {1}", cmdname, ex.Message);
                     ResolveAllDeferred ();
                     sm.PostEvent ((uint)SmtpProtoControl.SmtpEvt.E.AuthFail, "SMTPAUTH2");
-                } catch (IOException ex) {
-                    Log.Info (Log.LOG_SMTP, "IOException: {0}", ex.ToString ());
+                } catch (SmtpProtocolException ex) {
+                    Log.Info (Log.LOG_SMTP, "{0}: SmtpProtocolException: {1}", cmdname, ex.Message);
                     ResolveAllDeferred ();
-                    sm.PostEvent ((uint)SmEvt.E.TempFail, "SMTPIO");
+                    sm.PostEvent ((uint)SmEvt.E.TempFail, "SMTPPROTOEX");
+                } catch (SmtpCommandException ex) {
+                    Log.Info (Log.LOG_SMTP, "{0}: SmtpCommandException: {1}", cmdname, ex.Message);
+                    ResolveAllDeferred ();
+                    sm.PostEvent ((uint)SmEvt.E.TempFail, "SMTPCMDEX");
                 } catch (InvalidOperationException ex) {
-                    Log.Error (Log.LOG_SMTP, "InvalidOperationException: {0}", ex.ToString ());
+                    Log.Error (Log.LOG_SMTP, "{0}: InvalidOperationException: {1}", cmdname, ex.Message);
                     ResolveAllFailed (NcResult.WhyEnum.ProtocolError);
                     sm.PostEvent ((uint)SmEvt.E.HardFail, "SMTPHARD1");
                 } catch (FormatException ex) {
                     Log.Error (Log.LOG_SMTP, "FormatException: {0}", ex.ToString ());
                     ResolveAllFailed (NcResult.WhyEnum.ProtocolError);
                     sm.PostEvent ((uint)SmEvt.E.HardFail, "SMTPFORMATHARD");
+                } catch (IOException ex) {
+                    Log.Info (Log.LOG_SMTP, "{0}: IOException: {1}", cmdname, ex.ToString ());
+                    ResolveAllDeferred ();
+                    sm.PostEvent ((uint)SmEvt.E.TempFail, "SMTPIO");
                 } catch (Exception ex) {
-                    Log.Error (Log.LOG_SMTP, "Exception : {0}", ex.ToString ());
+                    Log.Error (Log.LOG_SMTP, "{0}: Exception : {1}", cmdname, ex.ToString ());
                     ResolveAllFailed (NcResult.WhyEnum.Unknown);
                     sm.PostEvent ((uint)SmEvt.E.HardFail, "SMTPHARD2");
                 } finally {
-                    Log.Info (Log.LOG_SMTP, "{0}({1}): Finished", this.GetType ().Name, BEContext.Account.Id);
+                    Log.Info (Log.LOG_SMTP, "{0}({1}): Finished", cmdname, BEContext.Account.Id);
                 }
-            }, this.GetType ().Name);
+            }, cmdname);
         }
 
         protected void ProtocolLoggerStopAndLog ()

--- a/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpDisconnectCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpDisconnectCommand.cs
@@ -1,0 +1,41 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using NachoCore.Utils;
+using System;
+
+namespace NachoCore.SMTP
+{
+    public class SmtpDisconnectCommand : SmtpCommand
+    {
+        public SmtpDisconnectCommand (IBEContext beContext, NcSmtpClient smtp) : base (beContext, smtp)
+        {
+        }
+        public override Event ExecuteConnectAndAuthEvent ()
+        {
+            // For this we don't want to connect-and-auth. Just override it and disconnect.
+            lock (Client.SyncRoot) {
+                try {
+                    if (null != Client.MailKitProtocolLogger && null != RedactProtocolLogFunc) {
+                        Client.MailKitProtocolLogger.Start (RedactProtocolLogFunc);
+                    }
+                    if (Client.IsConnected) {
+                        try {
+                            Client.Disconnect (true, Cts.Token);
+                        } catch (Exception ex) {
+                            Log.Warn (Log.LOG_SMTP, "SmtpDisconnectCommand: Exception (ignoring): {0}", ex);
+                            if (Client.IsConnected) {
+                                Log.Error (Log.LOG_SMTP, "SmtpDisconnectCommand: Disconnect failed.");
+                            }
+                        }
+                    }
+                    return Event.Create ((uint)SmEvt.E.Success, "SMTPDISCSUC");
+                } finally {
+                    if (null != Client.MailKitProtocolLogger && Client.MailKitProtocolLogger.Enabled ()) {
+                        ProtocolLoggerStopAndLog ();
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpSendMailCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpSendMailCommand.cs
@@ -55,17 +55,7 @@ namespace NachoCore.SMTP
         protected override Event ExecuteCommand ()
         {
             var mimeMessage = CreateMimeMessage ();
-            try {
-                Client.Send (mimeMessage, Cts.Token);
-            } catch (SmtpCommandException ex) {
-                Log.Info (Log.LOG_SMTP, "SmtpCommandException {0}", ex.Message);
-                PendingResolveApply ((pending) => {
-                    pending.ResolveAsHardFail (BEContext.ProtoControl, 
-                        NcResult.Error (NcResult.SubKindEnum.Error_EmailMessageSendFailed,
-                            NcResult.WhyEnum.ProtocolError));
-                });
-                return Event.Create ((uint)SmEvt.E.HardFail, "SMTPSENDHARD");
-            }
+            Client.Send (mimeMessage, Cts.Token);
             PendingResolveApply ((pending) => {
                 pending.ResolveAsSuccess (
                     BEContext.ProtoControl,

--- a/NachoClient.Android/NachoCore/BackEnd/SMTP/SmtpProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/SMTP/SmtpProtoControl.cs
@@ -324,7 +324,7 @@ namespace NachoCore.SMTP
                             new Trans { Event = (uint)SmtpEvt.E.ReDisc, Act = DoConn, State = (uint)Lst.DiscW },
                             new Trans { Event = (uint)SmtpEvt.E.ReConn, Act = DoConn, State = (uint)Lst.ConnW },
                             new Trans { Event = (uint)SmtpEvt.E.PkQOp, Act = DoArg, State = (uint)Lst.QOpW },
-                            new Trans { Event = (uint)SmtpEvt.E.PkIdle, Act = DoNop, State = (uint)Lst.IdleW },
+                            new Trans { Event = (uint)SmtpEvt.E.PkIdle, Act = DoIdle, State = (uint)Lst.IdleW },
                             new Trans { Event = (uint)SmEvt.E.Launch, Act = DoConn, State = (uint)Lst.ConnW },
                         }
                     },
@@ -350,7 +350,7 @@ namespace NachoCore.SMTP
                         },
                         On = new [] {
                             new Trans { Event = (uint)SmEvt.E.Launch, Act = DoConn, State = (uint)Lst.ConnW },
-                            new Trans { Event = (uint)SmEvt.E.Success, Act = DoPick, State = (uint)Lst.Pick },
+                            new Trans { Event = (uint)SmEvt.E.Success, Act = DoNop, State = (uint)Lst.IdleW },
                             new Trans { Event = (uint)PcEvt.E.PendQHot, Act = DoPick, State = (uint)Lst.Pick },
                             new Trans { Event = (uint)PcEvt.E.Park, Act = DoPark, State = (uint)Lst.Parked },
                         },
@@ -627,6 +627,12 @@ namespace NachoCore.SMTP
         {
             var cmd = Sm.Arg as SmtpCommand;
             SetCmd (cmd);
+            ExecuteCmd ();
+        }
+
+        protected void DoIdle ()
+        {
+            SetCmd (new SmtpDisconnectCommand (this, SmtpClient));
             ExecuteCmd ();
         }
 

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1374,7 +1374,7 @@
       <Link>NachoCore\BackEnd\IMAP\ImapProtoControl.cs</Link>
     </Compile>
     <Compile Include="..\NachoClient.Android\NachoCore\BackEnd\SMTP\SmtpProtoControl.cs">
-      <Link>NachoCore\BackEnd\SMTP\SmtpProtoControl.cs</Link>
+      <Link>NachoCore\BackEnd\SMTP\Commands\SmtpProtoControl.cs</Link>
     </Compile>
     <Compile Include="..\NachoClient.Android\NachoCore\Utils\TelemetryEvent.cs">
       <Link>NachoCore\Utils\TelemetryEvent.cs</Link>
@@ -1600,6 +1600,9 @@
     </Compile>
     <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration38.cs">
       <Link>NachoCore\Model\Migration\NcMigration38.cs</Link>
+    </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\BackEnd\SMTP\Commands\SmtpDisconnectCommand.cs">
+      <Link>NachoCore\BackEnd\SMTP\Commands\SmtpDisconnectCommand.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Also, catch some more exceptions so we retry a send a few times.
resolves nachocove/qa#855

In the AOL case, the Exception was because we were sitting idle and AOL is more aggressive than some others in timing out the connection (but it's something we need to deal with anyway). In order to keep things clean, and not waste resources (an open socket), I added a Disconnect Command and call that from Idle.

Also added a few more catches to make failures TEMPFAIL and this ResolveAsDeferred instead of HARDFAIL (fail them).
