### PR TITLE
Restore the white background when loading messages.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -572,7 +572,11 @@ namespace NachoClient.iOS
 
         protected void LayoutView ()
         {
-            ViewFramer.Create (headerView).Height (separator2YOffset);
+            // Header view is the background when loading a message.
+            // Size the header to be at least as large as the screen.
+
+            var headerSize = NMath.Max (separator2YOffset, View.Frame.Height);
+            ViewFramer.Create (headerView).Height (headerSize);
 
             var separator1View = headerView.ViewWithTag ((int)TagType.SEPARATOR1_TAG);
             ViewFramer.Create (separator1View).Y (separator1YOffset);


### PR DESCRIPTION
Fix nachocove/qa#847. The header view is used as the white
background when loading messages (and for small messages).
Make it big enough to cover the background. This regressed
when sizing the header to exactly fit the attachment list.
