### PR TITLE
Fix for qa#765 - crash when switching accounts in deferred view

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -748,6 +748,9 @@ namespace NachoClient.iOS
             MultiSelectToggle (messageSource, false);
             switchAccountButton.SetAccountImage (account);
             SetEmailMessages (GetNachoEmailMessages (account.Id));
+            List<int> adds;
+            List<int> deletes;
+            messageSource.RefreshEmailMessages (out adds, out deletes);
             threadsNeedsRefresh = false;
             TableView.ReloadData ();
         }


### PR DESCRIPTION
MaybeRefreshThreads calls messageSource.RefreshEmailMessages and then Util.UpdateTable, but those steps won't work as intended if the messageSource reference has changed, which it has in this case.

So instead of relying on MaybeRefreshThreads, we'll just reload the table data directly.  Since we're switching accounts, we've got a whole new list of messages anyway, and there's no performance concern.

We still have to call messageSource.RefreshEmailMessages, but see the comment for commit 34190cd regarding out it could be a duplicate call (which is no different than before, but perhaps something to change in the future).
