### PR TITLE
Have null check only when Source will be used.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
@@ -839,9 +839,8 @@ namespace NachoCore.Model
 
         public IEnumerator<McEmailMessage> GetEnumerator ()
         {
-            NcAssert.NotNull (Source);
-
             if (null == thread) {
+                NcAssert.NotNull (Source);
                 thread = Source.GetEmailThreadMessages (FirstMessageId);
                 if (null == thread) {
                     yield break; // thread is gone. Maybe backend removed it asynchronously


### PR DESCRIPTION
Fix nachocove/qa#658.  Have null check only when Source will be used.There's also a recent fix to return null for a null thread.
