### PR TITLE
Show an alert for the server error case before going to advanced settings

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/AccountSettingsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/AccountSettingsViewController.cs
@@ -505,10 +505,19 @@ namespace NachoClient.iOS
                     PerformSegue ("SegueToCertAsk", new SegueHolder (McAccount.AccountCapabilityEnum.EmailSender));
                     break;
                 case BackEndStateEnum.ServerConfWait:
-                    PerformSegue ("SegueToAdvancedSettings", this);
+                    ShowServerErrorAlert(serverWithIssue);
                     break;
                 }
             }
+        }
+
+        void ShowServerErrorAlert(McServer server)
+        {
+            var message = String.Format ("Sorry, we were unable to contact the server '{0}'.  We will attempt to reconnect automatically.", server.Host);
+            UIAlertController alertController = UIAlertController.Create ("Server Error", message, UIAlertControllerStyle.Alert);
+            alertController.AddAction (UIAlertAction.Create ("Advanced Settings", UIAlertActionStyle.Default, alert => PerformSegue ("SegueToAdvancedSettings", this)));
+            alertController.AddAction(UIAlertAction.Create("OK", UIAlertActionStyle.Default, null));
+            PresentViewController (alertController, true, null);
         }
 
         void onDeleteAccount (object sender, EventArgs e)


### PR DESCRIPTION
fixes nachocove/qa#856

Let me know if the text of the alert needs to change.  Trying to convey that the user probably doesn't have to do anything (because the server had been verified when they added the account and is likely temporarily unavailable), while still giving them the option to view the advanced settings.
