### PR TITLE
Keep current the number in the scroll-to-today button on calendar view

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
@@ -19,6 +19,7 @@ namespace NachoClient.iOS
         protected INcEventProvider eventCalendarMap;
         protected UITableView calendarTableView;
         SwitchAccountButton switchAccountButton;
+        protected DateTime todayButtonDate;
         public DateBarView DateDotView;
         public DateTime selectedDate = new DateTime ();
         public nint selectedDateTag = 0;
@@ -57,12 +58,13 @@ namespace NachoClient.iOS
             //     NavigationItem.SetHidesBackButton (true, false);
             // }
                 
-            var todayButton = new NcUIBarButtonItem ();
-            Util.SetAutomaticImageForButton (todayButton, Util.DrawTodayButtonImage (DateTime.Now.Day.ToString ()));
+            todayButton = new NcUIBarButtonItem ();
             todayButton.AccessibilityLabel = "Today";
             todayButton.Clicked += (object sender, EventArgs e) => {
                 ReturnToToday ();
             };
+            todayButtonDate = DateTime.MinValue;
+            UpdateDateInTodayButton ();
 
             var addEventButton = new NcUIBarButtonItem ();
             Util.SetAutomaticImageForButton (addEventButton, "cal-add");
@@ -101,6 +103,8 @@ namespace NachoClient.iOS
                 ReloadDataWithoutScrolling ();
                 UpdateDateDotView ();
             });
+
+            UpdateDateInTodayButton ();
 
             if (firstTime) {
                 firstTime = false;
@@ -172,6 +176,7 @@ namespace NachoClient.iOS
         public void StatusIndicatorCallback (object sender, EventArgs e)
         {
             var s = (StatusIndEventArgs)e;
+
             switch (s.Status.SubKind) {
 
             // When the events change, or when the time zone changes, refresh the UI to reflect the changes.
@@ -181,6 +186,12 @@ namespace NachoClient.iOS
                     ReloadDataWithoutScrolling ();
                     UpdateDateDotView ();
                 });
+                break;
+
+            case NcResult.SubKindEnum.Info_ExecutionContextChanged:
+                if (NcApplication.ExecutionContextEnum.Foreground == NcApplication.Instance.ExecutionContext) {
+                    UpdateDateInTodayButton ();
+                }
                 break;
             }
         }
@@ -330,6 +341,16 @@ namespace NachoClient.iOS
             todayMonthTag = DateDotView.GetMonthTag (DateTime.Today);
             DateDotView.UpdateButtons ();
 
+        }
+
+        protected void UpdateDateInTodayButton ()
+        {
+            // Change the number in the "Today" button if necessary.
+            DateTime today = DateTime.Today;
+            if (today != todayButtonDate) {
+                todayButtonDate = today;
+                Util.SetAutomaticImageForButton (todayButton, Util.DrawTodayButtonImage (todayButtonDate.Day.ToString ()));
+            }
         }
 
         protected void DisableGestureRecognizers ()


### PR DESCRIPTION
The scroll-to-today button in the navigation bar of the calendar view
contains the day of the month.  That number was being set when the
view was created, but was never adjusted later.  It would become wrong
if the user kept the app running for more than a day.

Update the number if necessary whenever the calendar view becomes
visible or when the app is brought to the foreground.

The number will not be adjusted when the user is looking at the
calendar view when the clock strikes midnight.  But it will be
corrected the next time the moves away from the calendar view and then
back to it.

Fix nachocove/qa#809

Tested via crowbar, so the app kept thinking that the date was changing.  (Because I didn't want to wait until tomorrow to finish testing.)
