### PR TITLE
Update the hot event when the app returns to the foreground

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
@@ -164,6 +164,15 @@ namespace NachoClient.iOS
             case NcResult.SubKindEnum.Info_SystemTimeZoneChanged:
                 Configure ();
                 break;
+
+            case NcResult.SubKindEnum.Info_ExecutionContextChanged:
+                // When the app goes into the background, eventEndTimer might get cancelled, but ViewWillAppear
+                // won't get called when the app returns to the foreground.  That might leave the view displaying
+                // an old event.  Watch for foreground events and refresh the view.
+                if (NcApplication.ExecutionContextEnum.Foreground == NcApplication.Instance.ExecutionContext) {
+                    Configure ();
+                }
+                break;
             }
         }
 


### PR DESCRIPTION
If the user backgrounded the app while in the Hot view, the hot event
was not being updated when the user brought the app to the foreground.
This could result in the Hot view showing an old event.

Fix this by having HotEventView listen for foreground events and then
updating the hot event.
