### PR TITLE
Protect against an exception in DnsQueryResponse.ParseResponse()

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Operations/AsDnsOperation.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Operations/AsDnsOperation.cs
@@ -147,9 +147,14 @@ namespace NachoCore.ActiveSync
                 complete = true;
                 StopTimer ();
                 if (null != answer) {
-                    DnsQueryResponse response = new DnsQueryResponse ();
-                    response.ParseResponse (answer, answerLength);
-                    stateMachine.PostEvent (owner.ProcessResponse (this, response));
+                    try {
+                        DnsQueryResponse response = new DnsQueryResponse ();
+                        response.ParseResponse (answer, answerLength);
+                        stateMachine.PostEvent (owner.ProcessResponse (this, response));
+                    } catch (Exception e) {
+                        Log.Error (Log.LOG_DNS, "DNS response parsing failed with an exception, likely because the response is malformed: {0}", e.ToString ());
+                        stateMachine.PostEvent ((uint)SmEvt.E.HardFail, "DNSHARDFAILEX");
+                    }
                 } else {
                     stateMachine.PostEvent ((uint)SmEvt.E.HardFail, "DNSHARDFAIL");
                 }


### PR DESCRIPTION
DnsQueryResponse.ParseResponse() doesn't fully validate that the DNS
response is in the correct format, and can throw an exception if the
response is malformed.  Catch the exception and treat it as a DNS
failure rather than letting the exception crash the app.

Fix nachocove/qa#712
