### PR TITLE
Fix nachocove/qa#901

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrainEventHandler.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainEventHandler.cs
@@ -201,10 +201,11 @@ namespace NachoCore.Brain
                     }
                     NcModel.Instance.RunInTransaction (() => {
                         var emailMessage = McEmailMessage.QueryById<McEmailMessage> ((int)emailMesasgeId);
-                        UpdateEmailMessageScore (emailMessage);
-                        if ((0 != action) && (0 != emailMessage.FromEmailAddressId)) {
-                            var fromEmailAddress = McEmailAddress.QueryById<McEmailAddress> (emailMessage.FromEmailAddressId);
-                            UpdateAddressUserAction (fromEmailAddress, action);
+                        if (UpdateEmailMessageScore (emailMessage)) {
+                            if ((0 != action) && (0 != emailMessage.FromEmailAddressId)) {
+                                var fromEmailAddress = McEmailAddress.QueryById<McEmailAddress> (emailMessage.FromEmailAddressId);
+                                UpdateAddressUserAction (fromEmailAddress, action);
+                            }
                         }
                     });
                     break;


### PR DESCRIPTION
 If email message has been deleted while the update email event is enqueued, do not try to deference the object. Use the returned value of UpdateEmailMessageScore as an indication to continue.
