### PR TITLE
Device sync should be cancellable and not run on UI thread

### DIFF
--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -512,7 +512,9 @@ namespace NachoPlatform
             var predicate = Es.PredicateForEvents (DateTime.UtcNow.AddDays (-31).ToNSDate (), DateTime.UtcNow.AddYears (1).ToNSDate (), allCalendars);
             var deviceEvents = Es.EventsMatching (predicate);
             if (null != deviceEvents) {
+                var cancellationToken = NcTask.Cts.Token;
                 foreach (var deviceEvent in deviceEvents) {
+                    cancellationToken.ThrowIfCancellationRequested ();
                     result.Add (new PlatformCalendarRecordiOS () {
                         Event = deviceEvent,
                     });

--- a/NachoClient.iOS/NachoPlatform.iOS/ContactsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/ContactsiOS.cs
@@ -115,7 +115,9 @@ namespace NachoPlatform
                 }
                 var sources = Ab.GetAllSources ();
                 Log.Info (Log.LOG_SYS, "GetContacts: Processing {0} sources", sources.Length);
+                var cancellationToken = NcTask.Cts.Token;
                 foreach (var source in sources) {
+                    cancellationToken.ThrowIfCancellationRequested ();
                     switch (source.SourceType) {
                     // FIXME - exclude only those sources we cover in EAS.
                     case ABSourceType.Exchange:
@@ -125,6 +127,7 @@ namespace NachoPlatform
                         var peeps = Ab.GetPeople (source);
                         Log.Info (Log.LOG_SYS, "GetContacts: Processing source {0} with {1} contacts", source.SourceType, peeps.Length);
                         foreach (var peep in peeps) {
+                            cancellationToken.ThrowIfCancellationRequested ();
                             retval.Add (new PlatformContactRecordiOS () {
                                 Person = peep,
                             });


### PR DESCRIPTION
A majority of the device sync was run on a background thread and would
check for cancellation.  But the beginning of the device sync process
would sometimes run on the UI thread and couldn't be cancelled.  Fix
both of these problems.

Fix nachocove/qa#900
