### PR TITLE
adjust switch-account segue image capture to align properly

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/SwitchAccountCustomSegue.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/SwitchAccountCustomSegue.cs
@@ -35,14 +35,14 @@ public class SwitchAccountCustomSegue : UIStoryboardSegue
         }
             
         var outermostView = NachoClient.Util.FindOutermostView(this.SourceViewController.View);
-        var screenLocation = this.SourceViewController.View.ConvertPointToView (this.SourceViewController.View.Frame.Location, null);
+        var screenLocation = this.SourceViewController.View.Superview.ConvertPointToView (this.SourceViewController.View.Frame.Location, outermostView);
 
         // Capture the outermost view & adjust the bounds so it appears that
         // the original view is still around as the account view animates down.
         // Keep in mind the in-call and navigation status bars.
         using (var image = NachoClient.Util.captureView (outermostView)) {
             var imageView = new UIImageView (image);
-            ViewFramer.Create (imageView).Y (-screenLocation.Y + 64);
+            ViewFramer.Create (imageView).Y (-screenLocation.Y);
             this.DestinationViewController.View.AddSubview (imageView);
             this.DestinationViewController.View.SendSubviewToBack (imageView);
         }


### PR DESCRIPTION
fix nachocove/qa#863

The previous code would fail to properly position the captured image
if the source view was scrolled.

What we want is to offset the captured image by the distance from the
outermost view to the top of the source view.  The source view frame
is in the coordinates of the source view's superview.  So, we should
convert the frame from the source view's superview to the outermost view.
