### PR TITLE
Don't rapid fire query for body or start download requests.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -655,13 +655,6 @@ namespace NachoClient.iOS
                 reminderImageView.Hidden = true;
                 reminderLabelView.Hidden = true;
             }
-
-            // Since there is a decent chance that the user will open this message, go ahead and
-            // download its body.
-            var body = message.GetBody ();
-            if (null == body || McBody.FilePresenceEnum.None == body.FilePresence) {
-                BackEnd.Instance.DnldEmailBodyCmd (message.AccountId, message.Id, doNotDelay: true);
-            }
         }
 
         protected void ConfigureDraftMessageCell (UITableView tableView, UITableViewCell cell, int messageThreadIndex)


### PR DESCRIPTION
IMAP is pulling previews now & we'll implement hint list for
BE strategy soon.

Removed reading the body from the routine that configures cells (if we add back, add to cache filler, but we are going to implement a different strategy routine soon).  Remove starting a download command from configure cell -- tele shows that this can be waiting on the ui thread to write the db entry for the cmd.
