### PR TITLE
Don't crash if Info_EmailMessageChanged does not include an id.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -425,7 +425,9 @@ namespace NachoClient.iOS
                 RefreshThreadsIfVisible ();
                 break;
             case NcResult.SubKindEnum.Info_EmailMessageChanged:
-                RefreshMessage ((int)s.Status.Value);
+                if (s.Status.Value is int) {
+                    RefreshMessage ((int)s.Status.Value);
+                }
                 break;
             case NcResult.SubKindEnum.Error_SyncFailed:
             case NcResult.SubKindEnum.Info_SyncSucceeded:


### PR DESCRIPTION
Fix nachocove/qa#933.  Turns out Info_EmailMessageChanged is not
always called with an id. Don't crash if the id is not supplied.
