### PR TITLE
Don't call MonitorReport when an NcTask's start is delayed

### DIFF
--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -689,12 +689,13 @@ namespace NachoCore
                 NcCommStatus.Instance.Status, NcCommStatus.Instance.Speed,
                 NachoPlatform.Power.Instance.BatteryLevel * 100.0, NachoPlatform.Power.Instance.PowerState);
             Log.Info (Log.LOG_SYS, "Monitor: DB Connections {0}", NcModel.Instance.NumberDbConnections);
-            Log.Info (Log.LOG_SYS, "Monitor: FD Max open files {0}", PlatformProcess.GetCurrentNumberOfFileDescriptors ());
-            Log.Info (Log.LOG_SYS, "Monitor: FD Current open files {0}", PlatformProcess.GetCurrentNumberOfInUseFileDescriptors ());
+            Log.Info (Log.LOG_SYS, "Monitor: Files: Max {0}, Currently open {1}",
+                PlatformProcess.GetCurrentNumberOfFileDescriptors (), PlatformProcess.GetCurrentNumberOfInUseFileDescriptors ());
             if (100 < PlatformProcess.GetCurrentNumberOfInUseFileDescriptors ()) {
                 Log.DumpFileDescriptors ();
             }
             NcModel.Instance.DumpLastAccess ();
+            NcTask.Dump ();
 
             if (null != MonitorEvent) {
                 MonitorEvent (this, EventArgs.Empty);

--- a/NachoClient.Android/NachoCore/Utils/NcTask.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcTask.cs
@@ -85,9 +85,7 @@ namespace NachoCore.Utils
                 DateTime startTime = DateTime.UtcNow;
                 double latency = (startTime - spawnTime).TotalMilliseconds;
                 if (200 < latency) {
-                    Log.Warn (Log.LOG_UTILS, "NcTask: Delay in running NcTask {0}, latency {1} msec", taskName, latency);
-                    NcApplication.Instance.MonitorReport ();
-                    NcTask.Dump ();
+                    Log.Warn (Log.LOG_UTILS, "NcTask: Delay in running NcTask {0}, latency {1:n0} msec", taskName, latency);
                 }
                 if (Thread.CurrentThread.ManagedThreadId == spawningId) {
                     Log.Warn (Log.LOG_UTILS, "NcTask {0} running on spawnning id", taskName);

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -461,7 +461,7 @@ namespace NachoClient.iOS
                 UIApplication.SharedApplication.EndBackgroundTask (BackgroundIosTaskId);
             }
             BackgroundIosTaskId = UIApplication.SharedApplication.BeginBackgroundTask (() => {
-                Log.Info (Log.LOG_LIFECYCLE, "BeginBackgroundTask: Callback time remaining: {0}", application.BackgroundTimeRemaining);
+                Log.Info (Log.LOG_LIFECYCLE, "BeginBackgroundTask: Callback time remaining: {0:n2}", application.BackgroundTimeRemaining);
                 FinalShutdown (null);
                 Log.Info (Log.LOG_LIFECYCLE, "BeginBackgroundTask: Callback exit");
             });
@@ -539,7 +539,7 @@ namespace NachoClient.iOS
             }
             DidEnterBackgroundCalled = true;
             var timeRemaining = application.BackgroundTimeRemaining;
-            Log.Info (Log.LOG_LIFECYCLE, "DidEnterBackground: time remaining: {0}", timeRemaining);
+            Log.Info (Log.LOG_LIFECYCLE, "DidEnterBackground: time remaining: {0:n2}", timeRemaining);
             if (25.0 > timeRemaining) {
                 FinalShutdown (null);
             } else {
@@ -550,7 +550,7 @@ namespace NachoClient.iOS
                         // iOS caveat: BackgroundTimeRemaining can be MAX_DOUBLE early on.
                         // It also seems to return to MAX_DOUBLE value after we call EndBackgroundTask().
                         var remaining = application.BackgroundTimeRemaining;
-                        Log.Info (Log.LOG_LIFECYCLE, "DidEnterBackground:ShutdownTimer: time remaining: {0}", remaining);
+                        Log.Info (Log.LOG_LIFECYCLE, "DidEnterBackground:ShutdownTimer: time remaining: {0:n2}", remaining);
                         if (!didShutdown && 25.0 > remaining) {
                             didShutdown = true;
                             FinalShutdown (opaque);


### PR DESCRIPTION
When the start of a new NcTask was delayed more than 200 ms,
MonitorReport was called to dump the app's current status.  When the
app is busy, running MonitorReport can take a couple of seconds.  This
delays the start of the new task exactly when the app cannot afford
any more delays.

Remove that call to MonitorReport.  Tweak the contents of the report
slightly.
