### PR TITLE
Disable dynamodb

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McTelemetryEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McTelemetryEvent.cs
@@ -87,8 +87,21 @@ namespace NachoCore.Model
 
         public int Insert ()
         {
-            NcAssert.True (false); // T2 should not be used anymore.
-            return 0;
+            NcAssert.True (0 == Id);
+            try {
+                InsertCapture.Start ();
+                int rc = NcModel.Instance.TeleDb.Insert (this);
+                InsertCapture.Stop ();
+                InsertCapture.Reset ();
+                return rc;
+            } catch (SQLiteException e) {
+                if (SQLite3.Result.Corrupt == e.Result) {
+                    NcModel.Instance.ResetTeleDb ();
+                    return 0;
+                } else {
+                    throw;
+                }
+            }
         }
 
         public int Delete ()


### PR DESCRIPTION
- If teledb file is empty, do not initialize DynamoDB client and tables.
- This allows us to delete DynamoDB tables / policies for dev and alpha projects.
