### PR TITLE
ImapCommand.Cancel() and ImapDisconnectCommand should not block

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapProtoControl.cs
@@ -847,11 +847,7 @@ namespace NachoCore.IMAP
             McPending.ResolveAllDelayNotAllowedAsFailed (ProtoControl, Account.Id);
 
             var disconnect = new ImapDisconnectCommand (this, MainClient);
-            try {
-                disconnect.Execute (this.Sm);
-            } catch (ImapCommand.ImapCommandLockTimeOutException ex) {
-                Log.Warn (Log.LOG_IMAP, "ImapCommandLockTimeOutException: {0}", ex.Message);
-            }
+            disconnect.Execute (this.Sm);
         }
 
         private void DoDrive ()


### PR DESCRIPTION
When ImapCommand.Cancel() is called during back end shutdown, it can't
block at all waiting for the command to process the cancellation.  It
has to issue the cancellation and then return.

ImapDisconnectCommand is usually executed during back end shutdown.
So it can't block while waiting to get the lock.  If the lock is not
available, start a separate task to do the disconnect.

nachocove/qa#938 part 3, with at least one more change yet to come.
