### PR TITLE
Idle the IMAP state machine when done with quick sync

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapSyncCommand.cs
@@ -110,7 +110,7 @@ namespace NachoCore.IMAP
             var syncSet = ImapStrategy.QuickSyncSet (Synckit.Folder.ImapUidNext, Synckit.Folder, span);
             if (null == syncSet || !syncSet.Any ()) {
                 Finish (false);
-                return Event.Create ((uint)SmEvt.E.Success, "IMAPSYNCQKNONE");
+                return Event.Create ((uint)NachoCore.IMAP.ImapProtoControl.ImapEvt.E.Wait, "IMAPSYNCQKNONE", 60);
             }
             Synckit.SyncSet = syncSet;
             Synckit.UploadMessages = McEmailMessage.QueryImapMessagesToSend (BEContext.Account.Id, Synckit.Folder.Id, span);


### PR DESCRIPTION
When the app is in quick sync mode and the IMAP engine determines that
the Inbox is up to date with nothing left to sync, put the state
machine into the IdleW state instead of keeping it in the SyncW state.

The existing code was causing the IMAP accounts to continually check
for updates to the Inbox.  This would unnecessarily use up CPU and
networking bandwidth.  It contributed to the app not always shutting
down in time when the PerformFetch window ran out.

nachocove/qa#938 part 4, and hopefully the last
