### PR TITLE
Avoid race condition that would result in a stopped back end

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -690,6 +690,9 @@ namespace NachoClient.iOS
 
             case NcResult.SubKindEnum.Error_SyncFailedToComplete:
                 Log.Info (Log.LOG_LIFECYCLE, "FetchStatusHandler:Error_SyncFailedToComplete");
+                // Stop the back end first, so that any accounts still running will give up the CPU
+                // as soon as possible.
+                BackEnd.Instance.Stop ();
                 BadgeNotifUpdate ();
                 CompletePerformFetch ();
                 break;
@@ -765,12 +768,11 @@ namespace NachoClient.iOS
             // iOS only allows a limited amount of time to fetch data in the background.
             // Set a timer to force everything to shut down before iOS kills the app.
             performFetchTimer = new Timer (((object state) => {
-                // Stop the back end right away, so that any accounts still synching
-                // will stop ASAP, freeing the CPU for the rest of the shutdown work.
-                // Then fire an event.  The listener for the event will take care of
-                // the rest of the shutdown process.
+                // Just fire an event.  The listener for the event will take care of
+                // shutting things down.  (The UI thread is the synchronization method
+                // for lifecycle events, so the timer expiration needs to be channelled
+                // through the UI thread.)
                 Log.Info (Log.LOG_LIFECYCLE, "PerformFetch timer fired. Shutting down the app.");
-                BackEnd.Instance.Stop ();
                 NcApplication.Instance.InvokeStatusIndEvent (new StatusIndEventArgs () {
                     Account = NcApplication.Instance.Account,
                     Status = NcResult.Error (NcResult.SubKindEnum.Error_SyncFailedToComplete)


### PR DESCRIPTION
An earlier update that called BackEnd.Stop() as soon as the
PerformFetch timer fired introduced a race condition that could result
in the back end being stopped while the app was in the foreground.  If
WillEnterForeground() was called by iOS after the PerformFetch timer
fired but before CompletePerformFetch() was called, the app would move
to the foreground state without BackEnd.Start() ever being called.

To avoid this race condition, the earlier update was mostly undone.
BackEnd.Stop() is still called as soon as possible, but "as soon as
possible" is not until control has been transferred to the UI thread
via a status indicator event.

nachocove/qa#938 part 5, and most likely the last change for that issue
