### PR TITLE
better field focus when opening draft email

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
@@ -104,6 +104,9 @@ namespace NachoClient.iOS
             ccView.SetAddressList (draftMessage.Cc, NcEmailAddress.Kind.Cc);
             bccView.SetAddressList (draftMessage.Bcc, NcEmailAddress.Kind.Bcc);
 
+            startInSubjectField = !String.IsNullOrEmpty(draftMessage.To) && String.IsNullOrEmpty(draftMessage.Subject);
+            startInBodyField = !String.IsNullOrEmpty(draftMessage.To) && !String.IsNullOrEmpty(draftMessage.Subject);
+
             QRType = draftMessage.QRType;
             messageIntent = draftMessage.Intent;
             messageIntentDateTime = draftMessage.IntentDate;
@@ -338,7 +341,11 @@ namespace NachoClient.iOS
             } else if (startInBodyField) {
                 ConfigureBodyEditView (false);
                 bodyTextView.BecomeFirstResponder ();
-                bodyTextView.SelectedRange = new NSRange (EmailTemplate.Length, 0);
+                if (EmailTemplate == null) {
+                    bodyTextView.SelectedRange = new NSRange (0, 0);
+                } else {
+                    bodyTextView.SelectedRange = new NSRange (EmailTemplate.Length, 0);
+                }
             } else if (calendarInviteIsSet) {
                 toView.SetEditFieldAsFirstResponder ();
             } else {


### PR DESCRIPTION
fixes nachocove/qa#879

This will put the focus in the subject or body depending on what is/isn't populated when re-opening a draft email.  If it's the body, the cursor is always placed at the start.  Ideally it would be placed at the end of the draft text, excluding any signature or quoted message.  Because that exclusion logic can be tricky, I'd like to defer any improvement to cursor placement within the body until the web view compose stuff is sorted out.
