### PR TITLE
Defer SwitchAccount call until after view is loaded

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -391,16 +391,18 @@ namespace NachoClient.iOS
 
         void SwitchToAccount (McAccount account)
         {
-            currentAccount = account;
-            priorityInboxNeedsRefresh = false;
-            NachoCore.Utils.NcAbate.HighPriority ("NachoNowViewController SwitchToAccount");
-            priorityInbox = NcEmailManager.PriorityInbox (currentAccount.Id);
-            hotListSource = new HotListTableViewSource (this, priorityInbox);
-            hotListView.Source = hotListSource;
-            hotListView.ReloadData ();
-            hotListSource.ConfigureFooter (hotListView);
-            switchAccountButton.SetAccountImage (account);
-            NachoCore.Utils.NcAbate.RegularPriority ("NachoNowViewController SwitchToAccount");
+            if (IsViewLoaded) {
+                currentAccount = account;
+                priorityInboxNeedsRefresh = false;
+                NachoCore.Utils.NcAbate.HighPriority ("NachoNowViewController SwitchToAccount");
+                priorityInbox = NcEmailManager.PriorityInbox (currentAccount.Id);
+                hotListSource = new HotListTableViewSource (this, priorityInbox);
+                hotListView.Source = hotListSource;
+                hotListView.ReloadData ();
+                hotListSource.ConfigureFooter (hotListView);
+                switchAccountButton.SetAccountImage (account);
+                NachoCore.Utils.NcAbate.RegularPriority ("NachoNowViewController SwitchToAccount");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
fixes nachocove/qa#948

I haven't been able to reproduce this one, but from the stack trace it seems clear what's going on.

When receiving a notifiation SwitchAccount may be called before the view
is loaded, resulting in null reference errors to views within SwitchAccount.  Since
SwitchAccount is always called during ViewDidLoad, we can safely ignore any call
before the view is loaded, preventing crashes without affecting app behavior.
