### PR TITLE
fixed nachocove/qa#699

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
@@ -1091,8 +1091,12 @@ namespace NachoCore.ActiveSync
                             if (null == serverUri) {
                                 Log.Error (Log.LOG_AS, "URI not extracted from: {0} in: {1}", xmlUrlValue, xmlSettings);
                             } else {
-                                SrServerUri = serverUri;
-                                haveServerSettings = true;
+                                if (McServer.PathIsEWS (serverUri.ToString ())) {
+                                    Log.Error (Log.LOG_AS, "ProcessXmlSettings: Url seems to be EWS: {0}.", serverUri.ToString ());
+                                } else {
+                                    SrServerUri = serverUri;
+                                    haveServerSettings = true;
+                                }
                             }
                         }
                         // TODO: add support for CertEnroll.

--- a/NachoClient.Android/NachoCore/Model/McServer.cs
+++ b/NachoClient.Android/NachoCore/Model/McServer.cs
@@ -20,6 +20,7 @@ namespace NachoCore.Model
         public string Host { get; set; }
 
         public const string Default_Path = "/Microsoft-Server-ActiveSync";
+        public const string EWS_Path_Substring = "EWS/Exchange.asmx";
         // Well known server/host values:
         public const string GMail_Host = "m.google.com";
         public const string HotMail_Host = "s.outlook.com";
@@ -94,6 +95,11 @@ namespace NachoCore.Model
         public bool HostIsGMail ()
         {
             return Host.EndsWith (McServer.GMail_Host, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool PathIsEWS (string path)
+        {
+            return path.IndexOf (EWS_Path_Substring, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         public static McServer Create (int accountId, McAccount.AccountCapabilityEnum capabilities, Uri uri)

--- a/Test.Android/McServerTest.cs
+++ b/Test.Android/McServerTest.cs
@@ -130,6 +130,26 @@ namespace Test.Android
             serv.Host = "hotmail.com";
             Assert.IsTrue (serv.HostIsHotMail ());
         }
+
+        [Test]
+        public void TestPathIsEWS ()
+        {
+            Assert.IsTrue (McServer.PathIsEWS ("https://mail.bouldercolorado.gov/EWS/Exchange.asmx"));
+            Assert.IsTrue (McServer.PathIsEWS ("https://mail.bouldercolorado.gov/ews/exchange.asmx"));
+            Assert.IsTrue (McServer.PathIsEWS ("https://mail.bouldercolorado.gov/EWS/EXCHANGE.asmx"));
+            Assert.IsTrue (McServer.PathIsEWS ("https://mail.bouldercolorado.gov/EWS/EXCHANGE.ASMX/noreally"));
+            Assert.IsTrue (McServer.PathIsEWS ("EWS/Exchange.asmx/noreally"));
+            Assert.IsTrue (McServer.PathIsEWS ("noreally/EWS/Exchange.asmx/"));
+            Assert.IsTrue (McServer.PathIsEWS ("noreallyEWS/Exchange.asmx/"));
+            Assert.IsTrue (McServer.PathIsEWS ("EWS/Exchange.asmx"));
+            Assert.IsTrue (McServer.PathIsEWS ("/EWS/Exchange.asmx"));
+            Assert.IsFalse (McServer.PathIsEWS ("Microsoft-Server-ActiveSync"));
+            Assert.IsFalse (McServer.PathIsEWS ("/Microsoft-Server-ActiveSync"));
+            Assert.IsFalse (McServer.PathIsEWS ("https://s.outlook.com/Microsoft-Server-ActiveSync"));
+            Assert.IsFalse (McServer.PathIsEWS ("https://s.outlook.com"));
+            Assert.IsFalse (McServer.PathIsEWS ("s.outlook.com"));
+            Assert.IsFalse (McServer.PathIsEWS (""));
+        }
     }
 }
 


### PR DESCRIPTION
We saw a case where a server returned an EWS endpoint when we were looking for the EAS endpoint.
The process for auto-d is identical between EAS and EWS (POX), except for the XML request and responses. It is clear that we're getting something that looks like an EAS response, so we now filter for EWS URLs and reject them.
