### PR TITLE
Fix nachocove/qa#967

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -71,6 +71,13 @@ namespace NachoCore.Utils
 
         public void Initialize ()
         {
+            // Clean up all leftover gzipped JSON files
+            foreach (var gzFilePath in Directory.EnumerateFiles (NcApplication.GetDataDirPath ())) {
+                if (gzFilePath.EndsWith (".gz")) {
+                    SafeFileDelete (gzFilePath);
+                }
+            }
+
             InitializeTables ();
         }
 


### PR DESCRIPTION
- It is possible to have some leftover gzipped JSON file if the app crashes or is killed.
- These .gz JSON files are regenerated so they can be cleaned up when telemetry task starts.
