### PR TITLE
Avoid "Organizer unavailable" in meeting request messages

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -1136,7 +1136,8 @@ namespace NachoClient.iOS
             c.attachments = attachmentView.AttachmentList;
                 
             // Extras
-            c.OrganizerName = Pretty.UserNameForAccount (account);
+            // The app does not keep track of the account owner's name.  Use the e-mail address instead.
+            c.OrganizerName = account.EmailAddr; //Pretty.UserNameForAccount (account);
             c.OrganizerEmail = account.EmailAddr;
             c.DtStamp = DateTime.UtcNow;
             if (0 == c.attendees.Count) {


### PR DESCRIPTION
In outgoing meeting request messages, don't set the organizer's name
to "Organizer unavailable".  Use the user's e-mail address instead.

Fix nachocove/qa#290
