### PR TITLE
fix exception when using the wrong variable

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapCommand.cs
@@ -208,16 +208,20 @@ namespace NachoCore.IMAP
                             break;
                         } catch (ImapProtocolException e) {
                             Log.Info (Log.LOG_IMAP, "Protocol Error during auth: {0}", e);
-                            // some servers (icloud.com) seem to close the connection on a bad password/username.
-                            throw new AuthenticationException (ex.Message);
+                            if (BEContext.ProtocolState.ImapServiceType == McAccount.AccountServiceEnum.iCloud) {
+                                // some servers (icloud.com) seem to close the connection on a bad password/username.
+                                throw new AuthenticationException (e.Message);
+                            } else {
+                                throw;
+                            }
                         }
                     } catch (AuthenticationException e) {
                         ex = e;
-                        Log.Warn (Log.LOG_IMAP, "AuthenticationException: {0}", e.Message);
+                        Log.Info (Log.LOG_IMAP, "ConnectAndAuthenticate: AuthenticationException: (i={0}) {1}", i, e.Message);
                         continue;
                     } catch (ServiceNotAuthenticatedException e) {
                         ex = e;
-                        Log.Warn (Log.LOG_IMAP, "ServiceNotAuthenticatedException: {0}", e.Message);
+                        Log.Info (Log.LOG_IMAP, "ConnectAndAuthenticate: ServiceNotAuthenticatedException: (i={0}) {1}", i, e.Message);
                         continue;
                     }
                 }

--- a/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpCommand.cs
@@ -184,16 +184,21 @@ namespace NachoCore.SMTP
                             break;
                         } catch (SmtpProtocolException e) {
                             Log.Info (Log.LOG_SMTP, "Protocol Error during auth: {0}", e);
-                            // some servers (icloud.com) seem to close the connection on a bad password/username.
-                            throw new AuthenticationException (e.Message);
+                            if (BEContext.ProtocolState.ImapServiceType == McAccount.AccountServiceEnum.iCloud) {
+                                // some servers (icloud.com) seem to close the connection on a bad password/username.
+                                throw new AuthenticationException (e.Message);
+                            } else {
+                                throw;
+                            }
                         }
                     } catch (AuthenticationException e) {
                         ex = e;
-                        Log.Warn (Log.LOG_SMTP, "AuthenticationException: {0}", ex.Message);
+                        Log.Info (Log.LOG_SMTP, "ConnectAndAuthenticate: AuthenticationException: (i={0}) {1}", i, ex.Message);
                         continue;
                     } catch (ServiceNotAuthenticatedException e) {
                         ex = e;
-                        Log.Warn (Log.LOG_SMTP, "ServiceNotAuthenticatedException: {0}", e.Message);
+                        Log.Info (Log.LOG_SMTP, "ConnectAndAuthenticate: ServiceNotAuthenticatedException: (i={0}) {1}", i, ex.Message);
+                        continue;
                     }
                 }
                 if (null != ex) {


### PR DESCRIPTION
also clean up log messages a bit and narrow the cases where
ImapProtocolException is treated as an AuthenticationException to
iCloud only.
resolves nachocove/qa#1023
