### PR TITLE
get the status after an idle/noop

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapFetchCommands/ImapFetchBody.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapFetchCommands/ImapFetchBody.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using System.Text;
 using MimeKit.IO;
 using MimeKit.IO.Filters;
-using System;
 
 namespace NachoCore.IMAP
 {
@@ -183,27 +182,18 @@ namespace NachoCore.IMAP
             string terminator = "\r\n";
             string line;
             bool skip = true;
-            int bytes_written = 0;
-            try {
-                using (var streamReader = new StreamReader (src)) {
-                    using (var streamWriter = new StreamWriter (dst)) {
-                        streamWriter.NewLine = terminator;
-                        while ((line = streamReader.ReadLine ()) != null) {
-                            if (skip && line.Equals (string.Empty)) {
-                                skip = false;
-                                continue; // skip the empty line. Next iteration will start writing.
-                            }
-                            if (!skip) {
-                                streamWriter.WriteLine (line);
-                                bytes_written += line.Length;
-                            }
+            using (var streamReader = new StreamReader (src)) {
+                using (var streamWriter = new StreamWriter (dst)) {
+                    streamWriter.NewLine = terminator;
+                    while ((line = streamReader.ReadLine ()) != null) {
+                        if (skip && line.Equals (string.Empty)) {
+                            skip = false;
+                            continue; // skip the empty line. Next iteration will start writing.
+                        }
+                        if (!skip) {
+                            streamWriter.WriteLine (line);
                         }
                     }
-                }
-            } catch (ArgumentException) {
-                // happens if there was nothing written to the stream.
-                if (bytes_written != 0) {
-                    throw;
                 }
             }
         }

--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapSyncCommand.cs
@@ -684,18 +684,14 @@ namespace NachoCore.IMAP
                         return null;
                     }
 
-                    if (stream.Length > 0) {
-                        using (var decoded = new MemoryStream ()) {
-                            CopyFilteredStream (stream, decoded, part.ContentType.Charset, TransferEncoding, CopyDataAction);
-                            var buffer = decoded.GetBuffer ();
-                            var length = (int)decoded.Length;
-                            preview = Encoding.UTF8.GetString (buffer, 0, length);
-                        }
-                    } else {
-                        preview = string.Empty;
+                    using (var decoded = new MemoryStream ()) {
+                        CopyFilteredStream (stream, decoded, part.ContentType.Charset, TransferEncoding, CopyDataAction);
+                        var buffer = decoded.GetBuffer ();
+                        var length = (int)decoded.Length;
+                        preview = Encoding.UTF8.GetString (buffer, 0, length);
                     }
 
-                    if (!isPlainText && !string.IsNullOrEmpty (preview)) {
+                    if (!isPlainText) {
                         var p = Html2Text (preview);
                         if (string.Empty == p) {
                             preview = string.Empty;


### PR DESCRIPTION
some servers don’t handle closing well (for various reasons), and so
reopening doesn’t always work.
Just use the ‘status’ call to fetch the latest data, which is all we
were after anyway.
resolves nachocove/qa#1009
