### PR TITLE
Dismiss the meeting invitation message view when user responds

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -25,7 +25,7 @@ using MapKit;
 
 namespace NachoClient.iOS
 {
-    public partial class EventViewController : NcUIViewControllerNoLeaks, INachoNotesControllerParent
+    public partial class EventViewController : NcUIViewControllerNoLeaks, INachoNotesControllerParent, IBodyViewOwner
     {
         // Model information
         protected McEvent e;
@@ -308,7 +308,7 @@ namespace NachoClient.iOS
 
             // Location label, image, and detail
             Util.AddTextLabelWithImageView (yOffset, "LOCATION", "event-location", TagType.EVENT_LOCATION_TITLE_TAG, eventCardView);
-            locationView = new UcLocationView (yOffset, EVENT_CARD_WIDTH - 60, onLinkSelected);
+            locationView = new UcLocationView (0, yOffset, EVENT_CARD_WIDTH - 60, LinkSelected);
             locationView.Tag = (int)TagType.EVENT_LOCATION_DETAIL_LABEL_TAG;
             locationView.Font = A.Font_AvenirNextRegular14;
             locationView.TextColor = A.Color_NachoDarkText;
@@ -318,7 +318,7 @@ namespace NachoClient.iOS
             // Description, for which we use a BodyView.
             Util.AddTextLabelWithImageView (yOffset, "DESCRIPTION", "event-description", TagType.EVENT_DESCRIPTION_TITLE_TAG, eventCardView);
             yOffset += 16 + 6;
-            descriptionView = BodyView.VariableHeightBodyView (new CGPoint (42, yOffset), EVENT_CARD_WIDTH - 60, scrollView.Frame.Size, LayoutView, onLinkSelected);
+            descriptionView = BodyView.VariableHeightBodyView (new CGPoint (42, yOffset), EVENT_CARD_WIDTH - 60, scrollView.Frame.Size, this);
             descriptionView.Tag = (int)TagType.EVENT_DESCRIPTION_LABEL_TAG;
             eventCardView.AddSubview (descriptionView);
 
@@ -981,7 +981,7 @@ namespace NachoClient.iOS
 
             if (hasLocation) {
                 AdjustViewLayout (TagType.EVENT_LOCATION_TITLE_TAG, 0, ref internalYOffset, 18, EVENT_CARD_WIDTH - 100);
-                AdjustViewLayout (TagType.EVENT_LOCATION_DETAIL_LABEL_TAG, 42, ref internalYOffset, 5, EVENT_CARD_WIDTH - 60);
+                AdjustViewLayout (TagType.EVENT_LOCATION_DETAIL_LABEL_TAG, 37, ref internalYOffset, 5, EVENT_CARD_WIDTH - 60);
             }
 
             AdjustViewLayout (TagType.EVENT_DESCRIPTION_TITLE_TAG, 0, ref internalYOffset, 18, EVENT_CARD_WIDTH - 100);
@@ -1551,7 +1551,14 @@ namespace NachoClient.iOS
             scrollView.SetContentOffset (new CGPoint (0, contentView.Frame.Height - scrollView.Frame.Height), true);
         }
 
-        public void onLinkSelected (NSUrl url)
+        #region IBodyViewOwner implementation
+
+        void IBodyViewOwner.SizeChanged ()
+        {
+            LayoutView ();
+        }
+
+        public void LinkSelected (NSUrl url)
         {
             if (EmailHelper.IsMailToURL (url.AbsoluteString)) {
                 PerformSegue ("SegueToMailTo", new SegueHolder (url.AbsoluteString));
@@ -1559,5 +1566,12 @@ namespace NachoClient.iOS
                 UIApplication.SharedApplication.OpenUrl (url);
             }
         }
+
+        void IBodyViewOwner.DismissView ()
+        {
+            NavigationController.PopViewController (true);
+        }
+
+        #endregion
     }
 }

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -16,13 +16,15 @@ namespace NachoClient.iOS
     /// </summary>
     public abstract class BodyWebView : UIWebView, IBodyRender
     {
+        public delegate void LinkSelectedCallback (NSUrl url);
+
         protected NSUrl baseUrl;
         protected nfloat preferredWidth;
         private Action sizeChangedCallback;
         private bool loadingComplete;
-        private BodyView.LinkSelectedCallback onLinkSelected;
+        private LinkSelectedCallback onLinkSelected;
 
-        public BodyWebView (nfloat Y, nfloat preferredWidth, nfloat initialHeight, Action sizeChangedCallback, NSUrl baseUrl, BodyView.LinkSelectedCallback onLinkSelected)
+        public BodyWebView (nfloat Y, nfloat preferredWidth, nfloat initialHeight, Action sizeChangedCallback, NSUrl baseUrl, LinkSelectedCallback onLinkSelected)
             : base (new CGRect(0, Y, preferredWidth, initialHeight))
         {
             this.baseUrl = baseUrl;
@@ -163,7 +165,7 @@ namespace NachoClient.iOS
         private const string disableJavaScript = "<meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'none'\">";
         private const string wrapPre = "<style>pre { white-space: pre-wrap;}</style>";
 
-        public BodyHtmlWebView (nfloat Y, nfloat preferredWidth, nfloat initialHeight, Action sizeChangedCallback, string html, NSUrl baseUrl, BodyView.LinkSelectedCallback onLinkSelected)
+        public BodyHtmlWebView (nfloat Y, nfloat preferredWidth, nfloat initialHeight, Action sizeChangedCallback, string html, NSUrl baseUrl, BodyWebView.LinkSelectedCallback onLinkSelected)
             : base (Y, preferredWidth, initialHeight, sizeChangedCallback, baseUrl, onLinkSelected)
         {
             this.html = html;
@@ -191,7 +193,7 @@ namespace NachoClient.iOS
     {
         private string rtf;
 
-        public BodyRtfWebView (nfloat Y, nfloat preferredWidth, nfloat initialHeight, Action sizeChangedCallback, string rtf, NSUrl baseUrl, BodyView.LinkSelectedCallback onLinkSelected)
+        public BodyRtfWebView (nfloat Y, nfloat preferredWidth, nfloat initialHeight, Action sizeChangedCallback, string rtf, NSUrl baseUrl, BodyWebView.LinkSelectedCallback onLinkSelected)
             : base (Y, preferredWidth, initialHeight, sizeChangedCallback, baseUrl, onLinkSelected)
         {
             this.rtf = rtf;
@@ -227,7 +229,7 @@ namespace NachoClient.iOS
             css.innerHTML = ""pre { font-family: AvenirNext-Regular,Helvetia,sans-serif; font-size: 17px; }"";
             document.getElementsByTagName('head')[0].appendChild(css);";
 
-        public BodyPlainWebView (nfloat Y, nfloat preferredWidth, nfloat initialHeight, Action sizeChangedCallback, string text, NSUrl baseUrl, BodyView.LinkSelectedCallback onLinkSelected)
+        public BodyPlainWebView (nfloat Y, nfloat preferredWidth, nfloat initialHeight, Action sizeChangedCallback, string text, NSUrl baseUrl, BodyWebView.LinkSelectedCallback onLinkSelected)
             : base (Y, preferredWidth, initialHeight, sizeChangedCallback, baseUrl, onLinkSelected)
         {
             this.text = text;

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
@@ -12,7 +12,7 @@ using NachoCore.Brain;
 
 namespace NachoClient.iOS
 {
-    public class HotListTableViewSource : UITableViewSource, INachoMessageEditorParent, INachoFolderChooserParent
+    public class HotListTableViewSource : UITableViewSource, INachoMessageEditorParent, INachoFolderChooserParent, IBodyViewOwner
     {
         INachoEmailMessages messageThreads;
         protected const string EmailMessageReuseIdentifier = "EmailMessage";
@@ -186,7 +186,7 @@ namespace NachoClient.iOS
 
             // Preview label view
             // Size fields will be recalculated after text is known
-            var previewLabelView = new ScrollableBodyView (new CGRect (12, 75, viewWidth - 15 - 12, view.Frame.Height - 128), onLinkSelected);
+            var previewLabelView = new ScrollableBodyView (new CGRect (12, 75, viewWidth - 15 - 12, view.Frame.Height - 128), this);
             previewLabelView.Tag = PREVIEW_TAG;
             view.AddSubview (previewLabelView);
 
@@ -780,7 +780,16 @@ namespace NachoClient.iOS
             targetContentOffset.Y = tableView.RectForRowAtIndexPath (next).Location.Y - 10;
         }
 
-        public void onLinkSelected (NSUrl url)
+        #region IBodyViewOwner implementation
+
+        // Items in the hot list can't react to size changes or be dismissed, so those implementations are empty.
+        // We do need to react to URL that are tapped.
+
+        void IBodyViewOwner.SizeChanged ()
+        {
+        }
+
+        void IBodyViewOwner.LinkSelected (NSUrl url)
         {
             if (EmailHelper.IsMailToURL (url.AbsoluteString)) {
                 owner.PerformSegueForDelegate ("SegueToMailTo", new SegueHolder (url.AbsoluteString));
@@ -789,6 +798,11 @@ namespace NachoClient.iOS
             }
         }
 
+        void IBodyViewOwner.DismissView ()
+        {
+        }
+
+        #endregion
     }
 
 }

--- a/NachoClient.iOS/NachoUI.iOS/Support/UcLocationView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/UcLocationView.cs
@@ -15,12 +15,14 @@ namespace NachoClient.iOS
     /// </summary>
     public class UcLocationView : UITextView
     {
-        protected BodyView.LinkSelectedCallback onLinkSelected;
+        protected BodyWebView.LinkSelectedCallback onLinkSelected;
 
-        public UcLocationView (nfloat Y, nfloat preferredWidth, BodyView.LinkSelectedCallback onLinkSelected)
-            : base (new CGRect (0, Y, preferredWidth, 1))
+        public UcLocationView (nfloat X, nfloat Y, nfloat preferredWidth, BodyWebView.LinkSelectedCallback onLinkSelected)
+            : base (new CGRect (X, Y, preferredWidth, 1))
         {
             this.onLinkSelected = onLinkSelected;
+
+            TextContainerInset = new UIEdgeInsets (0, 0, 0, 0);
 
             DataDetectorTypes = UIDataDetectorType.Link | UIDataDetectorType.PhoneNumber | UIDataDetectorType.Address;
             Delegate = new UcLocationViewDelegate (this);


### PR DESCRIPTION
The message detail view for a meeting invitation is now dismissed,
returning to the Hot view or the message list view, when the user taps
one of the Attend/Maybe/Decline buttons.  A meeting cancelation notice
is also dismissed when tapping the "Remove from calendar" button.

Links in the location field, including addresses, are now clickable in
the message detail view (when part of a meeting
request/response/cancelation).  Links were already clickable in the
event detail view.  This change extends the behavior to the message
detail view.

Fix a minor layout issue for the location field in the event detail
view.  The location was a few pixels too far to the right.

nachocove/qa#857
