### PR TITLE
Better job of synching existing device contact

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/Pretty.cs
+++ b/NachoClient.Android/NachoCore/Utils/Pretty.cs
@@ -201,6 +201,21 @@ namespace NachoCore.Utils
         }
 
         /// <summary>
+        /// Display a date that may or may not have a year associated with it, and for which the
+        /// day of the week is not important. For example, "August 27" or "August 27, 2000".
+        /// iOS uses a date in 1604 when the year doesn't matter, so leave off the year when the
+        /// date is earlier than 1700.
+        /// </summary>
+        static public string BirthdayOrAnniversary (DateTime d)
+        {
+            if (d.Year < 1700) {
+                return d.ToString ("MMMM d");
+            } else {
+                return d.ToString ("MMMM d, yyyy");
+            }
+        }
+
+        /// <summary>
         /// Compact version of event duration
         /// </summary>
         static public string PrettyEventDuration (DateTime startTime, DateTime endTime)

--- a/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
@@ -943,11 +943,8 @@ namespace NachoClient.iOS
                 icon = "contacts-icn-address";
                 break;
             case Xml.Contacts.Birthday:
-                value = contact.GetDateAttribute (whatType).ToLongDateString ();
-                icon = "contacts-icn-bday";
-                break;
             case Xml.Contacts.Anniversary:
-                value = contact.GetDateAttribute (whatType).ToLongDateString ();
+                value = Pretty.BirthdayOrAnniversary (contact.GetDateAttribute (whatType));
                 icon = "contacts-icn-bday";
                 break;
             case Xml.Contacts.Spouse:


### PR DESCRIPTION
When an existing device contact is changed, do a better job of
updating the corresponding app contact to match the device contact.
In the past, existing email addresses and phone numbers were never
changed or deleted from the app contact; new items were simply added
to the collections.

Improve the display of birthdays and anniversaries for contacts.
Don't show a year, just the month and day, when the device contact did
not specify a year for the birthday.

Fix nachocove/qa#566
