### PR TITLE
A couple fixes when editing the event attendee list

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcEmailAddress.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcEmailAddress.cs
@@ -222,7 +222,7 @@ namespace NachoCore.Utils
                 return null;
             }
 
-            if (null == mailbox.Name) {
+            if (string.IsNullOrEmpty (mailbox.Name) && null != this.contact) {
                 mailbox.Name = this.contact.GetDisplayName ();
             }
 

--- a/NachoClient.iOS/NachoUI.iOS/EventAttendeeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventAttendeeViewController.cs
@@ -534,6 +534,8 @@ namespace NachoClient.iOS
                 AttendeeList [address.index].AttendeeTypeIsSet = true;
                 break;
             case NcEmailAddress.Action.create:
+                // Get rid of any existing attendees with the same e-mail address.
+                AttendeeList.RemoveAll((McAttendee a) => { return a.Email == mailboxAddress.Address; });
                 var attendee = new McAttendee ();
                 attendee.AccountId = account.Id;
                 attendee.Name = name;


### PR DESCRIPTION
When adding an attendee to an event, show the contact's name (if
available) rather than showing the contact's e-mail address twice.

Prevent adding multiple attendees with the same e-mail address.

Fix nachocove/qa#1001
