### PR TITLE
Don't let the calendar month get jammed

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
@@ -418,7 +418,7 @@ namespace NachoClient.iOS
                 return;
             }
 
-            if (UIGestureRecognizerState.Ended == obj.State) {
+            if (UIGestureRecognizerState.Ended == obj.State || UIGestureRecognizerState.Cancelled == obj.State) {
                 if (xOffset < -(DateDotView.Frame.Width / 3) || obj.VelocityInView (DateDotView).X < -500) { 
                     UIView.Animate (.2, 0, UIViewAnimationOptions.CurveLinear,
                         () => {
@@ -547,7 +547,7 @@ namespace NachoClient.iOS
                     return;
                 }
             }
-            if (UIGestureRecognizerState.Ended == obj.State) {
+            if (UIGestureRecognizerState.Ended == obj.State || UIGestureRecognizerState.Cancelled == obj.State) {
                 if (isClosing) {
                     if ((yOffset < -60) || (obj.VelocityInView (DateDotView).Y < -500)) {
                         UIView.Animate (.5, 0, UIViewAnimationOptions.CurveEaseOut,
@@ -673,7 +673,7 @@ namespace NachoClient.iOS
                 return;
             }
 
-            if (UIGestureRecognizerState.Ended == obj.State) {
+            if (UIGestureRecognizerState.Ended == obj.State || UIGestureRecognizerState.Cancelled == obj.State) {
                 if (yOffset > 60 || obj.VelocityInView (DateDotView).Y > 500) {
                     UIView.Animate (.3, 0, UIViewAnimationOptions.CurveEaseOut,
                         () => {


### PR DESCRIPTION
The UIPanGestureRecognizers for the calendar view were ignoring cancel
events for the gestures.  This could leave the view in a bad state,
with the gesture recognizers all disabled, resulting in the month view
not responding to any UI gestures.  Fix the gesture recognizers to
look for the canceled events, treating them the same as normal end
events.

Fix nachocove/qa#727
