### PR TITLE
Add indexes to speed up QueryUnnotified().

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McAbstrItem.cs
+++ b/NachoClient.Android/NachoCore/Model/McAbstrItem.cs
@@ -32,6 +32,7 @@ namespace NachoCore.Model
         public uint PendingRefCount { get; set; }
 
         // Platform-specific code sets this when a user-notification is sent.
+        [Indexed]
         public bool HasBeenNotified { get; set; }
 
         /// The parser blew up when parsing this item, so we know it is missing some fields.

--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
@@ -301,6 +301,7 @@ namespace NachoCore.Model
         // Whether the email should be notified subjected to the current notification settings.
         // Note that this boolean is only meaningful within the context of a background duration;
         // as the settings can change during foreground.
+        [Indexed]
         public bool ShouldNotify { get; set; }
 
         /// True if its InReplyTo matches the MessageID of another McEmailMessage whose From
@@ -612,15 +613,15 @@ namespace NachoCore.Model
                 accountId, threadId, "Defer until");
         }
 
-        public static List<McEmailMessageThread> QueryForMessageThreadSet(List<int> indexList)
+        public static List<McEmailMessageThread> QueryForMessageThreadSet (List<int> indexList)
         {
             var set = String.Format ("( {0} )", String.Join (",", indexList.ToArray<int> ()));
             var cmd = String.Format (
-                "SELECT  e.Id as FirstMessageId, 1 as MessageCount FROM McEmailMessage AS e " +
-                "WHERE " +
-                "e.ID IN {0} " +
-                " ORDER BY e.DateReceived DESC ",
-                set);
+                          "SELECT  e.Id as FirstMessageId, 1 as MessageCount FROM McEmailMessage AS e " +
+                          "WHERE " +
+                          "e.ID IN {0} " +
+                          " ORDER BY e.DateReceived DESC ",
+                          set);
             return NcModel.Instance.Db.Query<McEmailMessageThread> (cmd); 
         }
 


### PR DESCRIPTION
- May fix #1046.
- Some whitespace diffs are due to Xamarin Studio wants to keep re-indenting the code.
