### PR TITLE
Fix code that ignores useless attachments in event TNEF parts

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
+++ b/NachoClient.Android/NachoCore/Utils/MimeHelpers.cs
@@ -688,7 +688,7 @@ namespace NachoCore.Utils
             if (null != entity.ContentDisposition &&
                 ((includeInline && ContentDisposition.Inline == entity.ContentDisposition.Disposition) ||
                     entity.ContentDisposition.IsAttachment) &&
-                (!insideTnef || !entity.ContentType.Matches ("application", "vnd.ms-tnef") || entity.ContentType.Name != "winmail.dat"))
+                (!insideTnef || !entity.ContentType.Matches ("application", "vnd.ms-tnef")))
             {
                 // It's an attachment that we are interested in.
                 result.Add (entity);


### PR DESCRIPTION
When a recurring calendar item has exceptions, the server includes an
application/vnd.ms_tnef attachment describing the exception within the
body of the main calendar item.  But the exception is also described
in the ActiveSync metadata, so the app doesn't have any use for the
vnd.ms_tnef attachment.  The app used to expect the attachment to be
named winmail.dat.  But it was discovered that different versions of
Exchange servers give the attachment different names.  So the code has
been changed to ignore all attachments of type vnd.ms_tnef regardless
of their name.
