### PR TITLE
Store attendees as a serialized string instead of McAttendee objects

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -508,6 +508,7 @@
     <Compile Include="NachoCore\Utils\TestMode.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration42.cs" />
     <Compile Include="NachoCore\BackEnd\NcPreFetchHints.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration43.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\AboutAssets.txt" />

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration43.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration43.cs
@@ -1,0 +1,25 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+
+namespace NachoCore.Model
+{
+    public class NcMigration43 : NcMigration
+    {
+        public override int GetNumberOfObjects ()
+        {
+            return 3;
+        }
+
+        public override void Run (System.Threading.CancellationToken token)
+        {
+            Db.Execute ("UPDATE McCalendar SET SerializedAttendeeList = 'OldStyle'");
+            UpdateProgress (1);
+            Db.Execute ("UPDATE McException SET SerializedAttendeeList = 'OldStyle'");
+            UpdateProgress (1);
+            Db.Execute ("UPDATE McMeetingRequest SET SerializedAttendeeList = 'OldStyle'");
+            UpdateProgress (1);
+        }
+    }
+}
+

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1631,6 +1631,9 @@
     <Compile Include="..\NachoClient.Android\NachoCore\BackEnd\NcPreFetchHints.cs">
       <Link>NachoCore\BackEnd\NcPreFetchHints.cs</Link>
     </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration43.cs">
+      <Link>NachoCore\Model\Migration\NcMigration43.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />


### PR DESCRIPTION
Storing meeting attendees in the database as individual McAttendee
objects was taking time and space with no real benefit.  Change the
app to store attendees as a serialized string in the McCalendar (or
McException or McMeetingRequest) object.

McAttendee objects are still created and are still used by the UI
code when viewing or editing a meeting.  But they are now created from
the serialized string and are stored back into the serialized string.
McAttendee objects in memory no longer have a corresponding object in
the database.

Existing meetings are not being migrated when the app is upgraded.  It
was feared that that would take too long.  Instead, attendees will be
migrated to the new format when each individual meeting is saved.  The
McAttendee table will remain in the database; it will be empty in
fresh installs and will slowly shrink towards being empty in upgraded
apps.
