### PR TITLE
cache accountId where possible to reduce DB hits

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
@@ -1057,7 +1057,7 @@ namespace NachoCore.ActiveSync
         private void DoSync ()
         {
             AsSyncCommand cmd = null;
-            var syncKit = Strategy.GenSyncKit (AccountId, ProtocolState);
+            var syncKit = Strategy.GenSyncKit (ProtocolState);
             if (null != syncKit) {
                 cmd = new AsSyncCommand (this, syncKit);
             } else {
@@ -1087,7 +1087,7 @@ namespace NachoCore.ActiveSync
             SetCmd (null);
             // Because we are going to stop for a while, we need to fail any
             // pending that aren't allowed to be delayed.
-            McPending.ResolveAllDelayNotAllowedAsFailed (ProtoControl, Account.Id);
+            McPending.ResolveAllDelayNotAllowedAsFailed (ProtoControl, AccountId);
         }
 
         private void DoDrive ()
@@ -1178,7 +1178,7 @@ namespace NachoCore.ActiveSync
         // PushAssist support.
         public PushAssistParameters PushAssistParameters ()
         {
-            var pingKit = Strategy.GenPingKit (AccountId, ProtocolState, true, false, true);
+            var pingKit = Strategy.GenPingKit (ProtocolState, true, false, true);
             if (null == pingKit) {
                 return null; // should never happen
             }

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControlApis.cs
@@ -37,7 +37,7 @@ namespace NachoCore.ActiveSync
                     result = NcResult.Error (subKind);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                     Operation = McPending.Operations.EmailSetFlag,
                     ServerId = emailMessage.ServerId,
                     ParentId = folder.ServerId,
@@ -80,7 +80,7 @@ namespace NachoCore.ActiveSync
                     return;
                 }
 
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                     Operation = McPending.Operations.EmailClearFlag,
                     ServerId = emailMessage.ServerId,
                     ParentId = folder.ServerId,
@@ -112,7 +112,7 @@ namespace NachoCore.ActiveSync
                     result = NcResult.Error (subKind);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                     Operation = McPending.Operations.EmailMarkFlagDone,
                     ServerId = emailMessage.ServerId,
                     ParentId = folder.ServerId,
@@ -152,7 +152,7 @@ namespace NachoCore.ActiveSync
                     result = NcResult.Error (subKind);
                     return;
                 }
-                var pending = new McPending (Account.Id) {
+                var pending = new McPending (AccountId) {
                     Operation = McPending.Operations.CalBodyDownload,
                     ServerId = cal.ServerId,
                     ParentId = folder.ServerId,
@@ -182,7 +182,7 @@ namespace NachoCore.ActiveSync
                     result = NcResult.Error (NcResult.SubKindEnum.Error_FolderMissing);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.CalReader, newEmailMessage) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.CalReader, newEmailMessage) {
                     Operation = McPending.Operations.CalForward,
                     ServerId = refdCalEvent.ServerId,
                     ParentId = folder.ServerId,
@@ -212,7 +212,7 @@ namespace NachoCore.ActiveSync
                     result = NcResult.Error (NcResult.SubKindEnum.Error_IsNontruncatedBodyComplete);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.ContactReader) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.ContactReader) {
                     Operation = McPending.Operations.ContactBodyDownload,
                     ServerId = contact.ServerId,
                 };
@@ -236,7 +236,7 @@ namespace NachoCore.ActiveSync
                     result = NcResult.Error (subKind);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.TaskWriter, task) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.TaskWriter, task) {
                     Operation = McPending.Operations.TaskCreate,
                     ParentId = folder.ServerId,
                     ClientId = task.ClientId,
@@ -260,7 +260,7 @@ namespace NachoCore.ActiveSync
                     result = NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
                     return;
                 }
-                var folders = McFolder.QueryByFolderEntryId<McTask> (Account.Id, taskId);
+                var folders = McFolder.QueryByFolderEntryId<McTask> (AccountId, taskId);
                 if (null == folders || 0 == folders.Count) {
                     result = NcResult.Error (NcResult.SubKindEnum.Error_FolderMissing);
                     return;
@@ -271,7 +271,7 @@ namespace NachoCore.ActiveSync
                     return;
                 }
 
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.TaskWriter, task) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.TaskWriter, task) {
                     Operation = McPending.Operations.TaskUpdate,
                     ParentId = primeFolder.ServerId,
                     ServerId = task.ServerId,
@@ -294,7 +294,7 @@ namespace NachoCore.ActiveSync
                     result = NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
                     return;
                 }
-                var folders = McFolder.QueryByFolderEntryId<McTask> (Account.Id, taskId);
+                var folders = McFolder.QueryByFolderEntryId<McTask> (AccountId, taskId);
                 if (null == folders || 0 == folders.Count) {
                     result = NcResult.Error (NcResult.SubKindEnum.Error_FolderMissing);
                     return;
@@ -305,7 +305,7 @@ namespace NachoCore.ActiveSync
                     return;
                 }
 
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.TaskWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.TaskWriter) {
                     Operation = McPending.Operations.ContactDelete,
                     ParentId = primeFolder.ServerId,
                     ServerId = task.ServerId,
@@ -329,7 +329,7 @@ namespace NachoCore.ActiveSync
             if (null == task) {
                 return NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
             }
-            var srcFolder = McFolder.QueryByFolderEntryId<McTask> (Account.Id, taskId).FirstOrDefault ();
+            var srcFolder = McFolder.QueryByFolderEntryId<McTask> (AccountId, taskId).FirstOrDefault ();
 
             return MoveItemCmd (McPending.Operations.TaskMove, McAccount.AccountCapabilityEnum.TaskWriter,
                 NcResult.SubKindEnum.Info_TaskSetChanged,
@@ -352,7 +352,7 @@ namespace NachoCore.ActiveSync
                     result = NcResult.Error (NcResult.SubKindEnum.Error_IsNontruncatedBodyComplete);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.TaskReader) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.TaskReader) {
                     Operation = McPending.Operations.TaskBodyDownload,
                     ServerId = task.ServerId,
                 };
@@ -419,7 +419,7 @@ namespace NachoCore.ActiveSync
                     }
                     cal.ResponseTypeIsSet = true;
                     cal.Update ();
-                    pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.CalWriter, cal) {
+                    pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.CalWriter, cal) {
                         Operation = McPending.Operations.CalUpdate,
                         ParentId = folder.ServerId,
                         ServerId = cal.ServerId,
@@ -445,7 +445,7 @@ namespace NachoCore.ActiveSync
                         return;
                     }
 
-                    pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.CalWriter) {
+                    pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.CalWriter) {
                         Operation = McPending.Operations.CalRespond,
                         ServerId = item.ServerId,
                         ParentId = folder.ServerId,

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/IAsStrategy.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/IAsStrategy.cs
@@ -55,11 +55,11 @@ namespace NachoCore.ActiveSync
     // This interface is here for mocking, unlikely to be useful beyond that.
     public interface IAsStrategy
     {
-        MoveKit GenMoveKit (int accountId);
+        MoveKit GenMoveKit ();
         FetchKit GenFetchKit ();
         FetchKit GenFetchKitHints ();
-        SyncKit GenSyncKit (int accountId, McProtocolState protocolState);
-        PingKit GenPingKit (int accountId, McProtocolState protocolState, bool isNarrow, bool stillHaveUnsyncedFolders, bool ignoreToClientExpected);
+        SyncKit GenSyncKit (McProtocolState protocolState);
+        PingKit GenPingKit (McProtocolState protocolState, bool isNarrow, bool stillHaveUnsyncedFolders, bool ignoreToClientExpected);
         Tuple<PickActionEnum, AsCommand> Pick ();
         Tuple<PickActionEnum, AsCommand> PickUserDemand ();
         int UploadTimeoutSecs (long length);

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/AsAutodiscoverCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/AsAutodiscoverCommand.cs
@@ -641,7 +641,7 @@ namespace NachoCore.ActiveSync
             var known = KnownServer (Domain);
             if (null == BEContext.Server && null != known) {
                 var server = new McServer () {
-                    AccountId = Account.Id,
+                    AccountId = AccountId,
                     Capabilities = McAccount.ActiveSyncCapabilities,
                     IsHardWired = true,
                     Host = known,
@@ -946,7 +946,7 @@ namespace NachoCore.ActiveSync
             Log.Info (Log.LOG_AS, "AUTOD::END: Auto discovery succeeded.");
             var robot = (StepRobot)Sm.Arg;
             NcAssert.NotNull (robot);
-            ServerCandidate = McServer.Create (Account.Id, McAccount.ActiveSyncCapabilities, robot.SrServerUri);
+            ServerCandidate = McServer.Create (AccountId, McAccount.ActiveSyncCapabilities, robot.SrServerUri);
             if (ServerCandidate.HostIsAsGMail ()) {
                 // Robot can do this because of MX record. Not that if the user had entered this value, we would 
                 // not want IsHardWired to be true.
@@ -966,7 +966,7 @@ namespace NachoCore.ActiveSync
         private void DoTestDefaultServer ()
         {
             AutoDSucceeded = false;
-            ServerCandidate = McServer.Create (Account.Id, McAccount.ActiveSyncCapabilities, 
+            ServerCandidate = McServer.Create (AccountId, McAccount.ActiveSyncCapabilities, 
                 McServer.BaseUriForHost (McServer.AS_GMail_Host));
             ServerCandidate.IsHardWired = true;
             DoTest ();

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsCommand.cs
@@ -443,7 +443,7 @@ namespace NachoCore.ActiveSync
                 PendingResolveApply (pending => {
                     pending.ResolveAsDeferredForce (BEContext.ProtoControl);
                 });
-                McFolder.UpdateSet_AsSyncMetaToClientExpected (BEContext.Account.Id, true);
+                McFolder.UpdateSet_AsSyncMetaToClientExpected (AccountId, true);
                 return Event.Create ((uint)AsProtoControl.AsEvt.E.ReSync, "TLS132-6");
 
             case Xml.StatusCode.CommandNotSupported_137:

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderCreateCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderCreateCommand.cs
@@ -54,12 +54,12 @@ namespace NachoCore.ActiveSync
                     return true;
                 });
                 var serverId = xmlFolderCreate.Element (m_ns + Xml.FolderHierarchy.ServerId).Value;
-                var pathElem = new McPath (BEContext.Account.Id);
+                var pathElem = new McPath (AccountId);
                 pathElem.ServerId = serverId;
                 pathElem.ParentId = PendingSingle.ParentId;
                 pathElem.IsFolder = true;
                 pathElem.Insert ();
-                var applyFolderCreate = new ApplyCreateFolder (BEContext.Account.Id) {
+                var applyFolderCreate = new ApplyCreateFolder (AccountId) {
                     PlaceholderId = PendingSingle.ServerId,
                     FinalServerId = serverId,
                 };

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderDeleteCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderDeleteCommand.cs
@@ -42,8 +42,8 @@ namespace NachoCore.ActiveSync
             }
             McProtocolState protocolState = BEContext.ProtocolState;
             var xmlFolderDelete = doc.Root;
-            var pathElem = McPath.QueryByServerId (BEContext.Account.Id, PendingSingle.ServerId);
-            var folder = McFolder.QueryByServerId<McFolder> (BEContext.Account.Id, PendingSingle.ServerId);
+            var pathElem = McPath.QueryByServerId (AccountId, PendingSingle.ServerId);
+            var folder = McFolder.QueryByServerId<McFolder> (AccountId, PendingSingle.ServerId);
             switch ((Xml.FolderHierarchy.FolderDeleteStatusCode)Convert.ToUInt32 (xmlFolderDelete.Element (m_ns + Xml.FolderHierarchy.Status).Value)) {
             case Xml.FolderHierarchy.FolderDeleteStatusCode.Success_1:
                 protocolState = protocolState.UpdateWithOCApply<McProtocolState> ((record) => {

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderSyncCommand/AsFolderSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderSyncCommand/AsFolderSyncCommand.cs
@@ -65,12 +65,12 @@ namespace NachoCore.ActiveSync
                                 break;
                             }
                             parentId = change.Element (m_ns + Xml.FolderHierarchy.ParentId).Value;
-                            pathElem = new McPath (BEContext.Account.Id);
+                            pathElem = new McPath (AccountId);
                             pathElem.ServerId = serverId;
                             pathElem.ParentId = parentId;
                             pathElem.IsFolder = true;
                             pathElem.Insert ();
-                            var applyAdd = new ApplyFolderAdd (BEContext.Account.Id) {
+                            var applyAdd = new ApplyFolderAdd (AccountId) {
                                 ServerId = serverId, 
                                 ParentId = parentId,
                                 DisplayName = change.Element (m_ns + Xml.FolderHierarchy.DisplayName).Value,
@@ -82,10 +82,10 @@ namespace NachoCore.ActiveSync
                             HadFolderChanges = true;
                             serverId = change.Element (m_ns + Xml.FolderHierarchy.ServerId).Value;
                             parentId = change.Element (m_ns + Xml.FolderHierarchy.ParentId).Value;
-                            pathElem = McPath.QueryByServerId (BEContext.Account.Id, serverId);
+                            pathElem = McPath.QueryByServerId (AccountId, serverId);
                             pathElem.ParentId = parentId;
                             pathElem.Update ();
-                            var applyUpdate = new ApplyFolderUpdate (BEContext.Account.Id) {
+                            var applyUpdate = new ApplyFolderUpdate (AccountId) {
                                 ServerId = serverId,
                                 ParentId = parentId,
                                 DisplayName = change.Element (m_ns + Xml.FolderHierarchy.DisplayName).Value,
@@ -96,12 +96,12 @@ namespace NachoCore.ActiveSync
                         case Xml.FolderHierarchy.Delete:
                             HadFolderChanges = true;
                             serverId = change.Element (m_ns + Xml.FolderHierarchy.ServerId).Value;
-                            var applyDelete = new ApplyFolderDelete (BEContext.Account.Id) {
+                            var applyDelete = new ApplyFolderDelete (AccountId) {
                                 ServerId = serverId,
                             };
                             applyDelete.ProcessServerCommand ();
                             // The path information can't be deleted until *after* conflict analysis is complete.
-                            pathElem = McPath.QueryByServerId (BEContext.Account.Id, serverId);
+                            pathElem = McPath.QueryByServerId (AccountId, serverId);
                             pathElem.Delete ();
                             break;
                         }
@@ -150,7 +150,7 @@ namespace NachoCore.ActiveSync
         public override void StatusInd (bool didSucceed)
         {
             if (didSucceed) {
-                McPending.MakeEligibleOnFSync (BEContext.Account.Id);
+                McPending.MakeEligibleOnFSync (AccountId);
             }
             base.StatusInd (didSucceed);
         }
@@ -158,8 +158,8 @@ namespace NachoCore.ActiveSync
         private void PerformFolderSyncEpochScrub ()
         {
             Log.Info (Log.LOG_AS, "PerformFolderSyncEpochScrub");
-            var laf = McFolder.GetLostAndFoundFolder (BEContext.Account.Id);
-            var orphaned = McFolder.QueryByIsClientOwned (BEContext.Account.Id, false)
+            var laf = McFolder.GetLostAndFoundFolder (AccountId);
+            var orphaned = McFolder.QueryByIsClientOwned (AccountId, false)
                 .Where (x => x.AsFolderSyncEpoch < BEContext.ProtocolState.AsFolderSyncEpoch).ToList ();
             Log.Info (Log.LOG_AS, "PerformFolderSyncEpochScrub: {0} folders.", orphaned.Count);
             foreach (var iterFolder in orphaned) {

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderUpdateCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderUpdateCommand.cs
@@ -52,7 +52,7 @@ namespace NachoCore.ActiveSync
                     target.AsSyncKey = xmlFolderUpdate.Element (m_ns + Xml.FolderHierarchy.SyncKey).Value;
                     return true;
                 });
-                var pathElem = McPath.QueryByServerId (BEContext.Account.Id, PendingSingle.ServerId);
+                var pathElem = McPath.QueryByServerId (AccountId, PendingSingle.ServerId);
                 pathElem.ParentId = PendingSingle.ParentId;
                 pathElem.Update ();
                 PendingResolveApply ((pending) => {

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsItemOperationsCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsItemOperationsCommand.cs
@@ -168,12 +168,12 @@ namespace NachoCore.ActiveSync
             } else if (null != xmlServerId) {
                 // This means we are processing a body download prefetch response.
                 NcModel.Instance.RunInTransaction (() => {
-                    var item = McEmailMessage.QueryByServerId<McEmailMessage> (BEContext.Account.Id, xmlServerId.Value);
+                    var item = McEmailMessage.QueryByServerId<McEmailMessage> (AccountId, xmlServerId.Value);
                     if (null == item) {
                         Log.Error (Log.LOG_AS, "MaybeErrorFileDesc: could not find McEmailMessage with ServerId {0}", xmlServerId.Value);
                     } else {
                         if (0 == item.BodyId) {
-                            var body = McBody.InsertError (BEContext.Account.Id);
+                            var body = McBody.InsertError (AccountId);
                             item = item.UpdateWithOCApply<McEmailMessage> ((record) => {
                                 var target = (McEmailMessage)record;
                                 target.BodyId = body.Id;
@@ -270,25 +270,25 @@ namespace NachoCore.ActiveSync
                             }
                             switch (op) {
                             case McPending.Operations.EmailBodyDownload:
-                                item = McEmailMessage.QueryByServerId<McEmailMessage> (BEContext.Account.Id, serverId);
+                                item = McEmailMessage.QueryByServerId<McEmailMessage> (AccountId, serverId);
                                 successInd = NcResult.SubKindEnum.Info_EmailMessageBodyDownloadSucceeded;
                                 if (null != pending) {
                                     Log.Info (Log.LOG_AS, "Processing DnldEmailBodyCmd({0}) {1}/{2} for email {3}", item.AccountId, pending.Id, pending.Token, item.Id);
                                 } else {
                                     Log.Info (Log.LOG_AS, "Processing DnldEmailBodyCmd({0}) for email {1}", item.AccountId, item.Id);
                                 }
-                                BackEnd.Instance.BodyFetchHints.RemoveHint (BEContext.Account.Id, item.Id);
+                                BackEnd.Instance.BodyFetchHints.RemoveHint (AccountId, item.Id);
                                 break;
                             case McPending.Operations.CalBodyDownload:
-                                item = McCalendar.QueryByServerId<McCalendar> (BEContext.Account.Id, serverId);
+                                item = McCalendar.QueryByServerId<McCalendar> (AccountId, serverId);
                                 successInd = NcResult.SubKindEnum.Info_CalendarBodyDownloadSucceeded;
                                 break;
                             case McPending.Operations.ContactBodyDownload:
-                                item = McContact.QueryByServerId<McContact> (BEContext.Account.Id, serverId);
+                                item = McContact.QueryByServerId<McContact> (AccountId, serverId);
                                 successInd = NcResult.SubKindEnum.Info_ContactBodyDownloadSucceeded;
                                 break;
                             case McPending.Operations.TaskBodyDownload:
-                                item = McTask.QueryByServerId<McTask> (BEContext.Account.Id, serverId);
+                                item = McTask.QueryByServerId<McTask> (AccountId, serverId);
                                 successInd = NcResult.SubKindEnum.Info_TaskBodyDownloadSucceeded;
                                 break;
                             default:

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsMoveItemsCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsMoveItemsCommand.cs
@@ -119,7 +119,7 @@ namespace NachoCore.ActiveSync
                     mustReSync = true;
                     pending.ResolveAsDeferred (BEContext.ProtoControl, McPending.DeferredEnum.UntilFSyncThenSync,
                         NcResult.Error (AppropriateSubKind (pending, false), NcResult.WhyEnum.MissingOnServer));
-                    McFolder.UpdateSet_AsSyncMetaToClientExpected (BEContext.Account.Id, true);
+                    McFolder.UpdateSet_AsSyncMetaToClientExpected (AccountId, true);
                     PendingList.Remove (pending);
                     break;
 
@@ -143,19 +143,19 @@ namespace NachoCore.ActiveSync
                             if (null != classCode) {
                                 switch (classCode) {
                                 case McAbstrFolderEntry.ClassCodeEnum.Email:
-                                    item = McAbstrItem.QueryByServerId<McEmailMessage> (BEContext.Account.Id, pending.ServerId);
+                                    item = McAbstrItem.QueryByServerId<McEmailMessage> (AccountId, pending.ServerId);
                                     break;
 
                                 case McAbstrFolderEntry.ClassCodeEnum.Calendar:
-                                    item = McAbstrItem.QueryByServerId<McCalendar> (BEContext.Account.Id, pending.ServerId);
+                                    item = McAbstrItem.QueryByServerId<McCalendar> (AccountId, pending.ServerId);
                                     break;
 
                                 case McAbstrFolderEntry.ClassCodeEnum.Contact:
-                                    item = McAbstrItem.QueryByServerId<McContact> (BEContext.Account.Id, pending.ServerId);
+                                    item = McAbstrItem.QueryByServerId<McContact> (AccountId, pending.ServerId);
                                     break;
 
                                 case McAbstrFolderEntry.ClassCodeEnum.Tasks:
-                                    item = McAbstrItem.QueryByServerId<McTask> (BEContext.Account.Id, pending.ServerId);
+                                    item = McAbstrItem.QueryByServerId<McTask> (AccountId, pending.ServerId);
                                     break;
 
                                 default:
@@ -177,13 +177,13 @@ namespace NachoCore.ActiveSync
                                 }
                             }
                         }
-                        var pathElem = McPath.QueryByServerId (BEContext.Account.Id, oldServerId);
+                        var pathElem = McPath.QueryByServerId (AccountId, oldServerId);
                         if (null == pathElem) {
                             Log.Error (Log.LOG_AS, "AsMoveItemsCommand: can't find McPath for {0}", oldServerId);
                         } else {
                             pathElem.Delete ();
                         }
-                        pathElem = new McPath (BEContext.Account.Id);
+                        pathElem = new McPath (AccountId);
                         pathElem.WasMoveDest = true;
                         pathElem.ServerId = newServerId;
                         pathElem.ParentId = pending.DestParentId;
@@ -216,7 +216,7 @@ namespace NachoCore.ActiveSync
                     pending.ResolveAsDeferred (BEContext.ProtoControl,
                         DateTime.UtcNow.AddSeconds (McPending.KDefaultDeferDelaySeconds),
                         NcResult.Error (AppropriateSubKind (pending, false), NcResult.WhyEnum.LockedOnServer));
-                    McFolder.UpdateSet_AsSyncMetaToClientExpected (BEContext.Account.Id, true);
+                    McFolder.UpdateSet_AsSyncMetaToClientExpected (AccountId, true);
                     PendingList.Remove (pending);
                     break;
 

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsPingCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsPingCommand.cs
@@ -83,7 +83,7 @@ namespace NachoCore.ActiveSync
                 var folders = doc.Root.Element (m_ns + Xml.Ping.Folders).Elements (m_ns + Xml.Ping.Folder);
                 foreach (var xmlFolder in folders) {
                     var folder = NcModel.Instance.Db.Table<McFolder> ().
-                        Where (rec => BEContext.Account.Id == rec.AccountId && xmlFolder.Value == rec.ServerId).
+                        Where (rec => AccountId == rec.AccountId && xmlFolder.Value == rec.ServerId).
                         Single ();
                     folder = folder.UpdateSet_AsSyncMetaToClientExpected (true);
                 }

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsProvisionCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsProvisionCommand.cs
@@ -246,7 +246,7 @@ namespace NachoCore.ActiveSync
                     // One or more EASProvisionDoc are required underneath the Data element.
                     var xmlData = xmlPolicy.Element (m_ns + Xml.Provision.Data);
                     if (null != xmlData) {
-                        var policy = McPolicy.QueryByAccountId<McPolicy> (BEContext.Account.Id).SingleOrDefault ();
+                        var policy = McPolicy.QueryByAccountId<McPolicy> (AccountId).SingleOrDefault ();
                         foreach (var xmlEASProvisionDoc in xmlData.Elements(m_ns+Xml.Provision.EASProvisionDoc)) {
                             // Right now, we serially apply EASProvisionDoc elements against the policy. It is not clear
                             // that there is ever really more than one EASProvisionDoc. Maybe someday we are required to

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSearchCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSearchCommand.cs
@@ -262,15 +262,15 @@ namespace NachoCore.ActiveSync
                 return;
             }
             var emailAddress = xmlEmailAddress.Value;
-            var galCacheFolder = McFolder.GetGalCacheFolder (BEContext.Account.Id);
-            if (TryUpdateGalCache (BEContext.Account.Id, galCacheFolder.Id, emailAddress, xmlProperties, Token)) {
+            var galCacheFolder = McFolder.GetGalCacheFolder (AccountId);
+            if (TryUpdateGalCache (AccountId, galCacheFolder.Id, emailAddress, xmlProperties, Token)) {
                 return;
             }
             NcModel.Instance.RunInTransaction (() => {
-                if (TryUpdateGalCache (BEContext.Account.Id, galCacheFolder.Id, emailAddress, xmlProperties, Token)) {
+                if (TryUpdateGalCache (AccountId, galCacheFolder.Id, emailAddress, xmlProperties, Token)) {
                     return;
                 }
-                var contact = McContact.CreateFromGalXml (BEContext.Account.Id, xmlProperties);
+                var contact = McContact.CreateFromGalXml (AccountId, xmlProperties);
                 contact.GalCacheToken = Token;
                 contact.Insert ();
                 galCacheFolder.Link (contact);
@@ -292,7 +292,7 @@ namespace NachoCore.ActiveSync
                         Log.Error (Log.LOG_AS, "Search result without From or DateReceived");
                     } else {
                         var dateRecv = AsHelpers.ParseAsDateTime (xmlDateReceived.Value);
-                        var hopefullyOne = McEmailMessage.QueryByDateReceivedAndFrom (BEContext.Account.Id, dateRecv, xmlFrom.Value);
+                        var hopefullyOne = McEmailMessage.QueryByDateReceivedAndFrom (AccountId, dateRecv, xmlFrom.Value);
                         if (1 < hopefullyOne.Count) {
                             Log.Warn (Log.LOG_AS, "Search result with > 1 match: {0}", hopefullyOne.Count);
                         } else if (1 == hopefullyOne.Count) {

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSendMailCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSendMailCommand.cs
@@ -80,7 +80,7 @@ namespace NachoCore.ActiveSync
                 pending.ResolveAsSuccess (BEContext.ProtoControl, NcResult.Info (NcResult.SubKindEnum.Info_EmailMessageSendSucceeded));
             });
 
-            var sentFolder = McFolder.GetDefaultSentFolder (BEContext.Account.Id);
+            var sentFolder = McFolder.GetDefaultSentFolder (AccountId);
             if (null != sentFolder) {
                 sentFolder.UpdateSet_AsSyncMetaToClientExpected (true);
             }

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSmartCommand/AsSmartCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSmartCommand/AsSmartCommand.cs
@@ -83,7 +83,7 @@ namespace NachoCore.ActiveSync
                     NcResult.Info (NcResult.SubKindEnum.Info_EmailMessageSendSucceeded));
             });
 
-            var sentFolder = McFolder.GetDefaultSentFolder (BEContext.Account.Id);
+            var sentFolder = McFolder.GetDefaultSentFolder (AccountId);
             if (null != sentFolder) {
                 sentFolder.UpdateSet_AsSyncMetaToClientExpected (true);
             }

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
@@ -459,7 +459,7 @@ namespace NachoCore.ActiveSync
                 List<McPending> pendingInFolder;
                 // Note: CollectionId, Status and SyncKey are required to be present.
                 var serverId = collection.Element (m_ns + Xml.AirSync.CollectionId).Value;
-                var folder = McFolder.ServerEndQueryByServerId (BEContext.Account.Id, serverId);
+                var folder = McFolder.ServerEndQueryByServerId (AccountId, serverId);
                 var oldSyncKey = folder.AsSyncKey;
                 var xmlSyncKey = collection.Element (m_ns + Xml.AirSync.SyncKey);
                 var xmlMoreAvailable = collection.Element (m_ns + Xml.AirSync.MoreAvailable);
@@ -681,7 +681,7 @@ namespace NachoCore.ActiveSync
             }
             if (HadDeletes) {
                 // We know that there will be updates to Deleted folder.
-                var deletedFolder = McFolder.GetDefaultDeletedFolder (BEContext.Account.Id);
+                var deletedFolder = McFolder.GetDefaultDeletedFolder (AccountId);
                 if (null != deletedFolder) {
                     deletedFolder.UpdateSet_AsSyncMetaToClientExpected (true);
                 }
@@ -732,7 +732,7 @@ namespace NachoCore.ActiveSync
         public override void StatusInd (bool didSucceed)
         {
             if (didSucceed) {
-                McPending.MakeEligibleOnSync (BEContext.Account.Id);
+                McPending.MakeEligibleOnSync (AccountId);
             }
             base.StatusInd (didSucceed);
         }
@@ -804,12 +804,12 @@ namespace NachoCore.ActiveSync
                 case Xml.AirSync.Add:
                     var addServerId = command.Element (m_ns + Xml.AirSync.ServerId).Value;
                     Log.Debug (Log.LOG_AS, "AsSyncCommand: Command Add {0} ServerId {1}", classCode, addServerId);
-                    var pathElem = new McPath (BEContext.Account.Id);
+                    var pathElem = new McPath (AccountId);
                     pathElem.ServerId = addServerId;
                     pathElem.ParentId = folder.ServerId;
                     NcModel.Instance.RunInTransaction (() => {
                         pathElem.Insert (BEContext.Server.HostIsAsGMail ());
-                        var applyAdd = new ApplyItemAdd (BEContext.Account.Id) {
+                        var applyAdd = new ApplyItemAdd (AccountId) {
                             ClassCode = classCode,
                             ServerId = addServerId,
                             XmlCommand = command,
@@ -843,7 +843,7 @@ namespace NachoCore.ActiveSync
                 case Xml.AirSync.Change:
                     var chgServerId = command.Element (m_ns + Xml.AirSync.ServerId).Value;
                     Log.Info (Log.LOG_AS, "AsSyncCommand: Command Change {0} ServerId {1}", classCode, chgServerId);
-                    var applyChange = new ApplyItemChange (BEContext.Account.Id) {
+                    var applyChange = new ApplyItemChange (AccountId) {
                         ClassCode = classCode,
                         ServerId = chgServerId,
                         XmlCommand = command,
@@ -874,13 +874,13 @@ namespace NachoCore.ActiveSync
                     var delServerId = command.Element (m_ns + Xml.AirSync.ServerId).Value;
                     Log.Info (Log.LOG_AS, "AsSyncCommand: Command (Soft)Delete {0} ServerId {1}", classCode, delServerId);
                     NcModel.Instance.RunInTransaction (() => {
-                        pathElem = McPath.QueryByServerId (BEContext.Account.Id, delServerId);
+                        pathElem = McPath.QueryByServerId (AccountId, delServerId);
                         if (null != pathElem) {
                             pathElem.Delete ();
                         } else {
                             Log.Info (Log.LOG_AS, "AsSyncCommand: McPath for Command {0}, ServerId {1} not in DB - may have been subject of MoveItems.", command.Name.LocalName, delServerId);
                         }
-                        var applyDelete = new ApplyItemDelete (BEContext.Account.Id) {
+                        var applyDelete = new ApplyItemDelete (AccountId) {
                             ClassCode = classCode,
                             ServerId = delServerId,
                         };
@@ -1079,16 +1079,16 @@ namespace NachoCore.ActiveSync
 
             switch (classCode) {
             case Xml.AirSync.ClassCode.Email:
-                item = McAbstrItem.QueryByClientId<McEmailMessage> (BEContext.Account.Id, clientId);
+                item = McAbstrItem.QueryByClientId<McEmailMessage> (AccountId, clientId);
                 break;
             case Xml.AirSync.ClassCode.Contacts:
-                item = McAbstrItem.QueryByClientId<McContact> (BEContext.Account.Id, clientId);
+                item = McAbstrItem.QueryByClientId<McContact> (AccountId, clientId);
                 break;
             case Xml.AirSync.ClassCode.Calendar:
-                item = McAbstrItem.QueryByClientId<McCalendar> (BEContext.Account.Id, clientId);
+                item = McAbstrItem.QueryByClientId<McCalendar> (AccountId, clientId);
                 break;
             case Xml.AirSync.ClassCode.Tasks:
-                item = McAbstrItem.QueryByClientId<McTask> (BEContext.Account.Id, clientId);
+                item = McAbstrItem.QueryByClientId<McTask> (AccountId, clientId);
                 break;
             default:
                 Log.Error (Log.LOG_AS, "AsSyncCommand ProcessCollectionResponses UNHANDLED class " + classCode);
@@ -1103,7 +1103,7 @@ namespace NachoCore.ActiveSync
             if (null == serverId) {
                 Log.Error (Log.LOG_AS, "AsSyncCommand: Add command response without ServerId.");
             } else {
-                var pathElem = new McPath (BEContext.Account.Id) {
+                var pathElem = new McPath (AccountId) {
                     ServerId = serverId,
                     ParentId = folder.ServerId,
                 };

--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapCommand.cs
@@ -23,7 +23,6 @@ namespace NachoCore.IMAP
 {
     public class ImapCommand : NcCommand
     {
-        protected int AccountId { get; set; }
         protected NcImapClient Client { get; set; }
         protected RedactProtocolLogFuncDel RedactProtocolLogFunc;
 
@@ -33,7 +32,6 @@ namespace NachoCore.IMAP
         {
             Client = imapClient;
             RedactProtocolLogFunc = null;
-            AccountId = BEContext.Account.Id;
         }
 
         // MUST be overridden by subclass.

--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapProtoControl.cs
@@ -815,7 +815,7 @@ namespace NachoCore.IMAP
             SetCmd (null);
             // Because we are going to stop for a while, we need to fail any
             // pending that aren't allowed to be delayed.
-            McPending.ResolveAllDelayNotAllowedAsFailed (ProtoControl, Account.Id);
+            McPending.ResolveAllDelayNotAllowedAsFailed (ProtoControl, AccountId);
 
             var disconnect = new ImapDisconnectCommand (this, MainClient);
             disconnect.Execute (this.Sm);

--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapStrategy/IImapStrategy.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapStrategy/IImapStrategy.cs
@@ -163,7 +163,7 @@ namespace NachoCore.IMAP
     public interface IImapStrategy
     {
         SyncKit GenSyncKit (ref McProtocolState protocolState, NcApplication.ExecutionContextEnum exeCtxt, McPending pending);
-        SyncKit GenSyncKit (int accountId, McProtocolState protocolState, McPending pending);
+        SyncKit GenSyncKit (McProtocolState protocolState, McPending pending);
         SyncKit GenSyncKit (ref McProtocolState protocolState, McFolder folder, McPending pending, bool quickSync);
 
         FetchKit GenFetchKit ();

--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapStrategy/ImapStrategySyncKit.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapStrategy/ImapStrategySyncKit.cs
@@ -32,7 +32,7 @@ namespace NachoCore.IMAP
 
         public SyncKit GenSyncKit (ref McProtocolState protocolState, NcApplication.ExecutionContextEnum exeCtxt, McPending pending)
         {
-            foreach (var folder in SyncFolderList (protocolState.AccountId, protocolState.ImapSyncRung, exeCtxt)) {
+            foreach (var folder in SyncFolderList (protocolState.ImapSyncRung, exeCtxt)) {
                 SyncKit syncKit = GenSyncKit (ref protocolState, folder, pending,
                     exeCtxt == NcApplication.ExecutionContextEnum.QuickSync);
                 if (null != syncKit) {
@@ -429,7 +429,7 @@ namespace NachoCore.IMAP
             }
         }
 
-        private List<McFolder> SyncFolderList (int AccountId, uint ImapSyncRung, NcApplication.ExecutionContextEnum exeCtxt)
+        private List<McFolder> SyncFolderList (uint ImapSyncRung, NcApplication.ExecutionContextEnum exeCtxt)
         {
             var folderList = new List<McFolder> ();
             McFolder defInbox = McFolder.GetDefaultInboxFolder (AccountId);

--- a/NachoClient.Android/NachoCore/BackEnd/NcCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/NcCommand.cs
@@ -13,6 +13,7 @@ namespace NachoCore
         protected const int KLockTimeout = 10000;
 
         protected IBEContext BEContext;
+        protected int AccountId { get; set; }
 
         /// <summary>
         /// A linked token, combining the InternalCts with the top-level per-ProtoControl Cts. Any underlying/subclassed
@@ -70,6 +71,7 @@ namespace NachoCore
         public NcCommand (IBEContext beContext)
         {
             BEContext = beContext;
+            AccountId = BEContext.Account.Id;
             PendingList = new List<McPending> ();
             PendingResolveLockObj = new object ();
             InternalCts = new CancellationTokenSource ();

--- a/NachoClient.Android/NachoCore/BackEnd/NcProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/NcProtoControl.cs
@@ -49,13 +49,13 @@ namespace NachoCore
 
         public McCred Cred {
             get {
-                return McCred.QueryByAccountId<McCred> (Account.Id).SingleOrDefault ();
+                return McCred.QueryByAccountId<McCred> (AccountId).SingleOrDefault ();
             }
         }
 
         public McServer Server { 
             get {
-                return McServer.QueryByAccountIdAndCapabilities (Account.Id, Capabilities);
+                return McServer.QueryByAccountIdAndCapabilities (AccountId, Capabilities);
             }
             set {
                 var update = value;
@@ -65,7 +65,7 @@ namespace NachoCore
 
         public McProtocolState ProtocolState { 
             get {
-                return McProtocolState.QueryByAccountId<McProtocolState> (Account.Id).SingleOrDefault ();
+                return McProtocolState.QueryByAccountId<McProtocolState> (AccountId).SingleOrDefault ();
             }
             set {
                 var update = value;
@@ -280,7 +280,7 @@ namespace NachoCore
                 return false;
             }
 
-            var folders = McFolder.QueryByFolderEntryId<T> (Account.Id, itemId);
+            var folders = McFolder.QueryByFolderEntryId<T> (AccountId, itemId);
             foreach (var maybe in folders) {
                 if (maybe.IsClientOwned && !clientOwnedOkay) {
                     subKind = NcResult.SubKindEnum.Error_ClientOwned;
@@ -328,7 +328,7 @@ namespace NachoCore
                     // Need to make sure the email is marked read to get it out of GFE Inbox.
                     var emailMessage = item as McEmailMessage;
                     if (null != emailMessage && !emailMessage.IsRead) {
-                        markUpdate = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                        markUpdate = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                             Operation = McPending.Operations.EmailMarkRead,
                             ServerId = emailMessage.ServerId,
                             ParentId = srcFolder.ServerId,
@@ -343,7 +343,7 @@ namespace NachoCore
                         });
                     }
                 }
-                var pending = new McPending (Account.Id, capability) {
+                var pending = new McPending (AccountId, capability) {
                     Operation = op,
                     ServerId = item.ServerId,
                     ParentId = srcFolder.ServerId,
@@ -422,8 +422,8 @@ namespace NachoCore
 
         public virtual NcResult SearchEmailReq (string keywords, uint? maxResults, string token)
         {
-            McPending.ResolvePendingSearchReqs (Account.Id, token, true);
-            var newSearch = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+            McPending.ResolvePendingSearchReqs (AccountId, token, true);
+            var newSearch = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                 Operation = McPending.Operations.EmailSearch,
                 Search_Prefix = keywords,
                 Search_MaxResults = (null == maxResults) ? 20 : (uint)maxResults,
@@ -447,8 +447,8 @@ namespace NachoCore
 
         public virtual NcResult SearchContactsReq (string prefix, uint? maxResults, string token)
         {
-            McPending.ResolvePendingSearchReqs (Account.Id, token, true);
-            var newSearch = new McPending (Account.Id, McAccount.AccountCapabilityEnum.ContactReader) {
+            McPending.ResolvePendingSearchReqs (AccountId, token, true);
+            var newSearch = new McPending (AccountId, McAccount.AccountCapabilityEnum.ContactReader) {
                 Operation = McPending.Operations.ContactSearch,
                 Search_Prefix = prefix,
                 Search_MaxResults = (null == maxResults) ? 50 : (uint)maxResults,
@@ -473,7 +473,7 @@ namespace NachoCore
                     result = NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailSender, emailMessage) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailSender, emailMessage) {
                     Operation = McPending.Operations.EmailSend,
                 };
                 pending.Insert ();
@@ -501,7 +501,7 @@ namespace NachoCore
                 var pendingCalCre = NcModel.Instance.Db.Table<McPending> ().LastOrDefault (x => calId == x.ItemId);
                 var pendingCalCreId = (null == pendingCalCre) ? 0 : pendingCalCre.Id;
 
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailSender, emailMessage) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailSender, emailMessage) {
                     Operation = McPending.Operations.EmailSend,
                 };
                 pending.Insert ();
@@ -557,7 +557,7 @@ namespace NachoCore
                     result = NcResult.Error (NcResult.SubKindEnum.Error_FolderMissing);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailSender, newEmailMessage) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailSender, newEmailMessage) {
                     Operation = Op,
                     ServerId = refdEmailMessage.ServerId,
                     ParentId = folder.ServerId,
@@ -621,7 +621,7 @@ namespace NachoCore
                     return;
                 }
 
-                var folders = McFolder.QueryByFolderEntryId<McEmailMessage> (Account.Id, emailMessageId);
+                var folders = McFolder.QueryByFolderEntryId<McEmailMessage> (AccountId, emailMessageId);
                 if (null == folders || 0 == folders.Count) {
                     result = NcResult.Error (NcResult.SubKindEnum.Error_FolderMissing);
                     return;
@@ -636,17 +636,17 @@ namespace NachoCore
                 McPending pending;
                 McFolder trash = null;
                 if (!justDelete) {
-                    trash = McFolder.GetDefaultDeletedFolder (Account.Id);
+                    trash = McFolder.GetDefaultDeletedFolder (AccountId);
                 }
                 if (justDelete || null == trash || trash.Id == primeFolder.Id) {
-                    pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                    pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                         Operation = McPending.Operations.EmailDelete,
                         ParentId = primeFolder.ServerId,
                         ServerId = emailMessage.ServerId,
                     };
                     emailMessage.Delete ();
                 } else {
-                    pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                    pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                         Operation = McPending.Operations.EmailMove,
                         ServerId = emailMessage.ServerId,
                         ParentId = primeFolder.ServerId,
@@ -683,7 +683,7 @@ namespace NachoCore
                     result = NcResult.Error (subKind);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                     Operation = McPending.Operations.EmailMarkRead,
                     ServerId = emailMessage.ServerId,
                     ParentId = folder.ServerId,
@@ -708,7 +708,7 @@ namespace NachoCore
             if (null == emailMessage) {
                 return NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
             }
-            var srcFolder = McFolder.QueryByFolderEntryId<McEmailMessage> (Account.Id, emailMessageId).FirstOrDefault ();
+            var srcFolder = McFolder.QueryByFolderEntryId<McEmailMessage> (AccountId, emailMessageId).FirstOrDefault ();
 
             return MoveItemCmd (McPending.Operations.EmailMove, McAccount.AccountCapabilityEnum.EmailReaderWriter,
                 NcResult.SubKindEnum.Info_EmailMessageSetChanged,
@@ -749,7 +749,7 @@ namespace NachoCore
                     result = NcResult.Error (NcResult.SubKindEnum.Error_FilePresenceIsComplete);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                     Operation = McPending.Operations.EmailBodyDownload,
                     ServerId = emailMessage.ServerId,
                     ParentId = folder.ServerId,
@@ -795,7 +795,7 @@ namespace NachoCore
                     result = NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                     Operation = McPending.Operations.AttachmentDownload,
                     ServerId = emailMessage.ServerId,
                     AttachmentId = attId,
@@ -833,7 +833,7 @@ namespace NachoCore
                     result = NcResult.Error (subKind);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.CalWriter, cal) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.CalWriter, cal) {
                     Operation = McPending.Operations.CalCreate,
                     ParentId = folder.ServerId,
                     ClientId = cal.ClientId,
@@ -859,13 +859,13 @@ namespace NachoCore
                     result = NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
                     return;
                 }
-                var folders = McFolder.QueryByFolderEntryId<McCalendar> (Account.Id, calId);
+                var folders = McFolder.QueryByFolderEntryId<McCalendar> (AccountId, calId);
                 if (null == folders || 0 == folders.Count) {
                     result = NcResult.Error (NcResult.SubKindEnum.Error_FolderMissing);
                     return;
                 }
                 var primeFolder = folders.First ();
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.CalWriter, cal) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.CalWriter, cal) {
                     Operation = McPending.Operations.CalUpdate,
                     ParentId = primeFolder.ServerId,
                     ServerId = cal.ServerId,
@@ -890,13 +890,13 @@ namespace NachoCore
                     result = NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
                     return;
                 }
-                var folders = McFolder.QueryByFolderEntryId<McCalendar> (Account.Id, calId);
+                var folders = McFolder.QueryByFolderEntryId<McCalendar> (AccountId, calId);
                 if (null == folders || 0 == folders.Count) {
                     result = NcResult.Error (NcResult.SubKindEnum.Error_FolderMissing);
                     return;
                 }
                 var primeFolder = folders.First ();
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.CalWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.CalWriter) {
                     Operation = McPending.Operations.CalDelete,
                     ParentId = primeFolder.ServerId,
                     ServerId = cal.ServerId,
@@ -920,7 +920,7 @@ namespace NachoCore
             if (null == cal) {
                 return NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
             }
-            var srcFolder = McFolder.QueryByFolderEntryId<McCalendar> (Account.Id, calId).FirstOrDefault ();
+            var srcFolder = McFolder.QueryByFolderEntryId<McCalendar> (AccountId, calId).FirstOrDefault ();
 
             return MoveItemCmd (McPending.Operations.CalMove, McAccount.AccountCapabilityEnum.CalWriter,
                 NcResult.SubKindEnum.Info_CalendarSetChanged,
@@ -958,7 +958,7 @@ namespace NachoCore
                     result = NcResult.Error (subKind);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.ContactWriter, contact) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.ContactWriter, contact) {
                     Operation = McPending.Operations.ContactCreate,
                     ParentId = folder.ServerId,
                     ClientId = contact.ClientId,
@@ -985,13 +985,13 @@ namespace NachoCore
                     result = NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
                     return;
                 }
-                var folders = McFolder.QueryByFolderEntryId<McContact> (Account.Id, contactId);
+                var folders = McFolder.QueryByFolderEntryId<McContact> (AccountId, contactId);
                 if (null == folders || 0 == folders.Count) {
                     result = NcResult.Error (NcResult.SubKindEnum.Error_FolderMissing);
                     return;
                 }
                 var primeFolder = folders.First ();
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.ContactWriter, contact) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.ContactWriter, contact) {
                     Operation = McPending.Operations.ContactUpdate,
                     ParentId = primeFolder.ServerId,
                     ServerId = contact.ServerId,
@@ -1015,13 +1015,13 @@ namespace NachoCore
                     result = NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
                     return;
                 }
-                var folders = McFolder.QueryByFolderEntryId<McContact> (Account.Id, contactId);
+                var folders = McFolder.QueryByFolderEntryId<McContact> (AccountId, contactId);
                 if (null == folders || 0 == folders.Count) {
                     result = NcResult.Error (NcResult.SubKindEnum.Error_FolderMissing);
                     return;
                 }
                 var primeFolder = folders.First ();
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.ContactWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.ContactWriter) {
                     Operation = McPending.Operations.ContactDelete,
                     ParentId = primeFolder.ServerId,
                     ServerId = contact.ServerId,
@@ -1045,7 +1045,7 @@ namespace NachoCore
             if (null == contact) {
                 return NcResult.Error (NcResult.SubKindEnum.Error_ItemMissing);
             }
-            var srcFolder = McFolder.QueryByFolderEntryId<McContact> (Account.Id, contactId).FirstOrDefault ();
+            var srcFolder = McFolder.QueryByFolderEntryId<McContact> (AccountId, contactId).FirstOrDefault ();
 
             return MoveItemCmd (McPending.Operations.ContactMove, McAccount.AccountCapabilityEnum.ContactWriter,
                 NcResult.SubKindEnum.Info_ContactSetChanged,
@@ -1106,7 +1106,7 @@ namespace NachoCore
                     }
                     destFldServerId = destFld.ServerId;
                 }
-                var folder = McFolder.Create (Account.Id,
+                var folder = McFolder.Create (AccountId,
                     false,
                     false,
                     false,
@@ -1118,7 +1118,7 @@ namespace NachoCore
                 folder.Insert ();
                 StatusInd (NcResult.Info (NcResult.SubKindEnum.Info_FolderSetChanged));
                 // TODO - base capabilities on folder type.
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                     Operation = McPending.Operations.FolderCreate,
                     ServerId = serverId,
                     ParentId = destFldServerId,
@@ -1159,7 +1159,7 @@ namespace NachoCore
                     return;
                 }
                 // TODO - base capabilities on folder type.
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                     Operation = McPending.Operations.FolderDelete,
                     ServerId = folder.ServerId,
                     ParentId = folder.ParentId,
@@ -1205,7 +1205,7 @@ namespace NachoCore
                     return;
                 }
                 // TODO - base capability on folder type.
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                     Operation = McPending.Operations.FolderUpdate,
                     ServerId = folder.ServerId,
                     ParentId = folder.ParentId,
@@ -1249,7 +1249,7 @@ namespace NachoCore
                     return;
                 }
                 // TODO - determine appropriate capability based on type of folder.
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                     Operation = McPending.Operations.FolderUpdate,
                     ServerId = folder.ServerId,
                     ParentId = folder.ParentId,
@@ -1280,7 +1280,7 @@ namespace NachoCore
                     result = NcResult.Error (NcResult.SubKindEnum.Error_ClientOwned);
                     return;
                 }
-                var pending = new McPending (Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
+                var pending = new McPending (AccountId, McAccount.AccountCapabilityEnum.EmailReaderWriter) {
                     Operation = McPending.Operations.Sync,
                     ServerId = folder.ServerId,
                 };

--- a/NachoClient.Android/NachoCore/BackEnd/NcStrategy.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/NcStrategy.cs
@@ -25,7 +25,7 @@ namespace NachoCore
                 (Power.Instance.PowerStateIsPlugged () && Power.Instance.BatteryLevel > 0.2);
         }
 
-        public virtual bool ANarrowFolderHasToClientExpected (int accountId)
+        public virtual bool ANarrowFolderHasToClientExpected ()
         {
             NcAssert.True (false);
             return true;

--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -54,12 +54,16 @@ namespace NachoCore
         protected NcStateMachine Sm;
         protected IHttpClient Client;
 
+        private int _AccountId;
         private int AccountId {
             get {
-                if ((null == Owner) || (null == Owner.Account)) {
-                    return 0;
+                if (_AccountId == 0) {
+                    if ((null == Owner) || (null == Owner.Account)) {
+                        return 0;
+                    }
+                    _AccountId = Owner.Account.Id;
                 }
-                return Owner.Account.Id;
+                return _AccountId;
             }
         }
 
@@ -1002,7 +1006,7 @@ namespace NachoCore
                 }, "PushAssistDeviceToken");
                 break;
             case NcResult.SubKindEnum.Info_FastNotificationChanged:
-                if (Owner.Account.Id == siea.Account.Id) {
+                if (AccountId == siea.Account.Id) {
                     NcTask.Run (() => {
                         if (siea.Account.FastNotificationEnabled) {
                             if (IsStartOrParked ()) {

--- a/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpCommand.cs
@@ -14,7 +14,6 @@ namespace NachoCore.SMTP
 {
     public abstract class SmtpCommand : NcCommand
     {
-        protected int AccountId { get; set; }
         public NcSmtpClient Client { get; set; }
 
         protected RedactProtocolLogFuncDel RedactProtocolLogFunc;
@@ -23,7 +22,6 @@ namespace NachoCore.SMTP
         {
             Client = smtpClient;
             RedactProtocolLogFunc = null;
-            AccountId = BEContext.Account.Id;
         }
 
         // MUST be overridden by subclass.

--- a/NachoClient.Android/NachoCore/BackEnd/SMTP/SmtpProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/SMTP/SmtpProtoControl.cs
@@ -595,7 +595,7 @@ namespace NachoCore.SMTP
             // Because we are going to stop for a while, we need to fail any
             // pending that aren't allowed to be delayed.
             SetCmd (null);
-            McPending.ResolveAllDelayNotAllowedAsFailed (ProtoControl, Account.Id);
+            McPending.ResolveAllDelayNotAllowedAsFailed (ProtoControl, AccountId);
 
             var disconnect = new SmtpDisconnectCommand (this, SmtpClient);
             disconnect.Execute (this.Sm);

--- a/Test.Android/AsAutodiscoverCommandTest.cs
+++ b/Test.Android/AsAutodiscoverCommandTest.cs
@@ -537,7 +537,7 @@ namespace Test.iOS
             autodCommand = null;
             mockContext = null;
 
-            mockContext = new MockContext ();
+            mockContext = new MockContext (null);
 
             // insert phony server to db (this allows Auto-d 'DoAcceptServerConf' to update the record later)
             var phonyServer = new McServer ();

--- a/Test.Android/AsHttpOperationTest.cs
+++ b/Test.Android/AsHttpOperationTest.cs
@@ -759,7 +759,7 @@ namespace Test.iOS
                 Capabilities = McAccount.ActiveSyncCapabilities,
                 Host = "foo.utopiasystems.net",
             };
-            Context = new MockContext ( protoControl : null, server : server);
+            Context = new MockContext (null, protoControl : null, server : server);
 
             // provides the mock owner
             BaseMockOwner owner = CreateMockOwner (CommonMockData.MockUri, CommonMockData.MockRequestXml);

--- a/Test.Android/AsStrategyTest.cs
+++ b/Test.Android/AsStrategyTest.cs
@@ -22,11 +22,11 @@ namespace Test.iOS
         public new void SetUp ()
         {
             base.SetUp ();
-            var context = new MockContext ();
             Account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             Account.Insert ();
+            var context = new MockContext (Account);
             Strategy = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
         }
 
@@ -93,17 +93,17 @@ namespace Test.iOS
             McFolder folder;
             List<McFolder> result;
             // Check missing folder scenarios.
-            result = Strategy.EmailFolderListProvider (Account.Id, AsStrategy.Scope.EmailEnum.None, true);
+            result = Strategy.EmailFolderListProvider (AsStrategy.Scope.EmailEnum.None, true);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.EmailFolderListProvider (Account.Id, AsStrategy.Scope.EmailEnum.None, false);
+            result = Strategy.EmailFolderListProvider (AsStrategy.Scope.EmailEnum.None, false);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.EmailFolderListProvider (Account.Id, AsStrategy.Scope.EmailEnum.Def2w, true);
+            result = Strategy.EmailFolderListProvider (AsStrategy.Scope.EmailEnum.Def2w, true);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.EmailFolderListProvider (Account.Id, AsStrategy.Scope.EmailEnum.Def2w, false);
+            result = Strategy.EmailFolderListProvider (AsStrategy.Scope.EmailEnum.Def2w, false);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.EmailFolderListProvider (Account.Id, AsStrategy.Scope.EmailEnum.AllInf, true);
+            result = Strategy.EmailFolderListProvider (AsStrategy.Scope.EmailEnum.AllInf, true);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.EmailFolderListProvider (Account.Id, AsStrategy.Scope.EmailEnum.AllInf, false);
+            result = Strategy.EmailFolderListProvider (AsStrategy.Scope.EmailEnum.AllInf, false);
             Assert.AreEqual (0, result.Count);
             // Normal conditions testing.
             folder = McFolder.Create (Account.Id, false, false, true, "0", "inbox", "Inbox", Xml.FolderHierarchy.TypeCode.DefaultInbox_2);
@@ -112,18 +112,18 @@ namespace Test.iOS
             folder.Insert ();
             folder = McFolder.Create (Account.Id, false, false, true, "0", "cal", "Cal", Xml.FolderHierarchy.TypeCode.DefaultCal_8);
             folder.Insert ();
-            result = Strategy.EmailFolderListProvider (Account.Id, AsStrategy.Scope.EmailEnum.None, true);
+            result = Strategy.EmailFolderListProvider (AsStrategy.Scope.EmailEnum.None, true);
             Assert.AreEqual (1, result.Count);
             Assert.AreEqual (Xml.FolderHierarchy.TypeCode.DefaultInbox_2, result [0].Type);
-            result = Strategy.EmailFolderListProvider (Account.Id, AsStrategy.Scope.EmailEnum.None, false);
+            result = Strategy.EmailFolderListProvider (AsStrategy.Scope.EmailEnum.None, false);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.EmailFolderListProvider (Account.Id, AsStrategy.Scope.EmailEnum.Def1w, false);
+            result = Strategy.EmailFolderListProvider (AsStrategy.Scope.EmailEnum.Def1w, false);
             Assert.AreEqual (1, result.Count);
             Assert.AreEqual (Xml.FolderHierarchy.TypeCode.DefaultInbox_2, result [0].Type);
-            result = Strategy.EmailFolderListProvider (Account.Id, AsStrategy.Scope.EmailEnum.AllInf, true);
+            result = Strategy.EmailFolderListProvider (AsStrategy.Scope.EmailEnum.AllInf, true);
             Assert.AreEqual (1, result.Count);
             Assert.AreEqual (Xml.FolderHierarchy.TypeCode.DefaultInbox_2, result [0].Type);
-            result = Strategy.EmailFolderListProvider (Account.Id, AsStrategy.Scope.EmailEnum.AllInf, false);
+            result = Strategy.EmailFolderListProvider (AsStrategy.Scope.EmailEnum.AllInf, false);
             Assert.AreEqual (2, result.Count);
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.DefaultInbox_2 == x.Type));
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.UserCreatedMail_12 == x.Type));
@@ -135,17 +135,17 @@ namespace Test.iOS
             McFolder folder;
             List<McFolder> result;
             // Check missing folder scenarios.
-            result = Strategy.CalFolderListProvider (Account.Id, AsStrategy.Scope.CalEnum.None, true);
+            result = Strategy.CalFolderListProvider (AsStrategy.Scope.CalEnum.None, true);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.CalFolderListProvider (Account.Id, AsStrategy.Scope.CalEnum.None, false);
+            result = Strategy.CalFolderListProvider (AsStrategy.Scope.CalEnum.None, false);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.CalFolderListProvider (Account.Id, AsStrategy.Scope.CalEnum.Def2w, true);
+            result = Strategy.CalFolderListProvider (AsStrategy.Scope.CalEnum.Def2w, true);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.CalFolderListProvider (Account.Id, AsStrategy.Scope.CalEnum.Def2w, false);
+            result = Strategy.CalFolderListProvider (AsStrategy.Scope.CalEnum.Def2w, false);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.CalFolderListProvider (Account.Id, AsStrategy.Scope.CalEnum.AllInf, true);
+            result = Strategy.CalFolderListProvider (AsStrategy.Scope.CalEnum.AllInf, true);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.CalFolderListProvider (Account.Id, AsStrategy.Scope.CalEnum.AllInf, false);
+            result = Strategy.CalFolderListProvider (AsStrategy.Scope.CalEnum.AllInf, false);
             Assert.AreEqual (0, result.Count);
             // Normal conditions testing.
             folder = McFolder.Create (Account.Id, false, false, true, "0", "inbox", "Inbox", Xml.FolderHierarchy.TypeCode.DefaultInbox_2);
@@ -154,18 +154,18 @@ namespace Test.iOS
             folder.Insert ();
             folder = McFolder.Create (Account.Id, false, false, true, "0", "cal", "Cal", Xml.FolderHierarchy.TypeCode.DefaultCal_8);
             folder.Insert ();
-            result = Strategy.CalFolderListProvider (Account.Id, AsStrategy.Scope.CalEnum.None, true);
+            result = Strategy.CalFolderListProvider (AsStrategy.Scope.CalEnum.None, true);
             Assert.AreEqual (1, result.Count);
             Assert.AreEqual (Xml.FolderHierarchy.TypeCode.DefaultCal_8, result [0].Type);
-            result = Strategy.CalFolderListProvider (Account.Id, AsStrategy.Scope.CalEnum.None, false);
+            result = Strategy.CalFolderListProvider (AsStrategy.Scope.CalEnum.None, false);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.CalFolderListProvider (Account.Id, AsStrategy.Scope.CalEnum.Def2w, false);
+            result = Strategy.CalFolderListProvider (AsStrategy.Scope.CalEnum.Def2w, false);
             Assert.AreEqual (1, result.Count);
             Assert.AreEqual (Xml.FolderHierarchy.TypeCode.DefaultCal_8, result [0].Type);
-            result = Strategy.CalFolderListProvider (Account.Id, AsStrategy.Scope.CalEnum.All3m, true);
+            result = Strategy.CalFolderListProvider (AsStrategy.Scope.CalEnum.All3m, true);
             Assert.AreEqual (1, result.Count);
             Assert.AreEqual (Xml.FolderHierarchy.TypeCode.DefaultCal_8, result [0].Type);
-            result = Strategy.CalFolderListProvider (Account.Id, AsStrategy.Scope.CalEnum.All3m, false);
+            result = Strategy.CalFolderListProvider (AsStrategy.Scope.CalEnum.All3m, false);
             Assert.AreEqual (2, result.Count);
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.DefaultCal_8 == x.Type));
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.UserCreatedCal_13 == x.Type));
@@ -177,9 +177,9 @@ namespace Test.iOS
             McFolder folder;
             List<McFolder> result;
             // Check missing folder scenarios.
-            result = Strategy.ContactFolderListProvider (Account.Id, AsStrategy.Scope.ContactEnum.DefRicInf, true);
+            result = Strategy.ContactFolderListProvider (AsStrategy.Scope.ContactEnum.DefRicInf, true);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.ContactFolderListProvider (Account.Id, AsStrategy.Scope.ContactEnum.DefRicInf, false);
+            result = Strategy.ContactFolderListProvider (AsStrategy.Scope.ContactEnum.DefRicInf, false);
             Assert.AreEqual (0, result.Count);
             // Normal conditions testing.
             folder = McFolder.Create (Account.Id, false, false, true, "0", "inbox", "Inbox", Xml.FolderHierarchy.TypeCode.DefaultInbox_2);
@@ -190,24 +190,24 @@ namespace Test.iOS
             folder.Insert ();
             folder = McFolder.Create (Account.Id, false, false, true, "0", "ric", "RIC", Xml.FolderHierarchy.TypeCode.Ric_19);
             folder.Insert ();
-            result = Strategy.ContactFolderListProvider (Account.Id, AsStrategy.Scope.ContactEnum.None, true);
+            result = Strategy.ContactFolderListProvider (AsStrategy.Scope.ContactEnum.None, true);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.ContactFolderListProvider (Account.Id, AsStrategy.Scope.ContactEnum.None, false);
+            result = Strategy.ContactFolderListProvider (AsStrategy.Scope.ContactEnum.None, false);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.ContactFolderListProvider (Account.Id, AsStrategy.Scope.ContactEnum.RicInf, true);
+            result = Strategy.ContactFolderListProvider (AsStrategy.Scope.ContactEnum.RicInf, true);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.ContactFolderListProvider (Account.Id, AsStrategy.Scope.ContactEnum.RicInf, false);
+            result = Strategy.ContactFolderListProvider (AsStrategy.Scope.ContactEnum.RicInf, false);
             Assert.AreEqual (1, result.Count);
             Assert.AreEqual (Xml.FolderHierarchy.TypeCode.Ric_19, result [0].Type);
-            result = Strategy.ContactFolderListProvider (Account.Id, AsStrategy.Scope.ContactEnum.DefRicInf, true);
+            result = Strategy.ContactFolderListProvider (AsStrategy.Scope.ContactEnum.DefRicInf, true);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.ContactFolderListProvider (Account.Id, AsStrategy.Scope.ContactEnum.DefRicInf, false);
+            result = Strategy.ContactFolderListProvider (AsStrategy.Scope.ContactEnum.DefRicInf, false);
             Assert.AreEqual (2, result.Count);
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.DefaultContacts_9 == x.Type));
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.Ric_19 == x.Type));
-            result = Strategy.ContactFolderListProvider (Account.Id, AsStrategy.Scope.ContactEnum.AllInf, true);
+            result = Strategy.ContactFolderListProvider (AsStrategy.Scope.ContactEnum.AllInf, true);
             Assert.AreEqual (0, result.Count);
-            result = Strategy.ContactFolderListProvider (Account.Id, AsStrategy.Scope.ContactEnum.AllInf, false);
+            result = Strategy.ContactFolderListProvider (AsStrategy.Scope.ContactEnum.AllInf, false);
             Assert.AreEqual (3, result.Count);
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.DefaultContacts_9 == x.Type));
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.Ric_19 == x.Type));
@@ -231,20 +231,20 @@ namespace Test.iOS
             var ricFolder = McFolder.Create (Account.Id, false, false, true, "0", "ric", "RIC", Xml.FolderHierarchy.TypeCode.Ric_19);
             ricFolder.AsSyncMetaToClientExpected = false;
             ricFolder.Insert ();
-            result = Strategy.CanAdvance (Account.Id, 5);
+            result = Strategy.CanAdvance(5);
             Assert.False (result);
             calFolder.UpdateSet_AsSyncMetaToClientExpected (false);
             conFolder.UpdateSet_AsSyncMetaToClientExpected (true);
-            result = Strategy.CanAdvance (Account.Id, 5);
+            result = Strategy.CanAdvance(5);
             Assert.False (result);
             conFolder.UpdateSet_AsSyncMetaToClientExpected (false);
-            result = Strategy.CanAdvance (Account.Id, 5);
+            result = Strategy.CanAdvance(5);
             Assert.True (result);
-            result = Strategy.CanAdvance (Account.Id, 6);
+            result = Strategy.CanAdvance(6);
             Assert.False (result);
             Account.DaysToSyncEmail = Xml.Provision.MaxAgeFilterCode.SyncAll_0;
             Account.Update ();
-            result = Strategy.CanAdvance (Account.Id, 6);
+            result = Strategy.CanAdvance(6);
             Assert.True (result);
             Account.DaysToSyncEmail = Xml.Provision.MaxAgeFilterCode.OneMonth_5;
             Account.Update ();
@@ -255,7 +255,7 @@ namespace Test.iOS
                 ServerId = "bogus",
             };   
             pending.Insert ();
-            result = Strategy.CanAdvance (Account.Id, 5);
+            result = Strategy.CanAdvance(5);
             Assert.False (result);
         }
 
@@ -286,7 +286,7 @@ namespace Test.iOS
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
-            var context = new MockContext ();
+            var context = new MockContext (account);
             context.ProtoControl = new MockProtoControl (context.Owner, account.Id);
             context.ProtocolState = context.ProtocolState.UpdateWithOCApply<McProtocolState> ((record) => {
                 var target = (McProtocolState)record;
@@ -308,11 +308,11 @@ namespace Test.iOS
             var ricFolder = McFolder.Create (account.Id, false, false, true, "0", "ric", "RIC", Xml.FolderHierarchy.TypeCode.Ric_19);
             ricFolder.AsSyncMetaToClientExpected = false;
             ricFolder.Insert ();
-            result = strat.AdvanceIfPossible (account.Id, context.ProtocolState.StrategyRung);
+            result = strat.AdvanceIfPossible (context.ProtocolState.StrategyRung);
             Assert.AreEqual (context.ProtocolState.StrategyRung, result);
             calFolder.UpdateSet_AsSyncMetaToClientExpected (false);
             var oldRung = context.ProtocolState.StrategyRung;
-            result = strat.AdvanceIfPossible (account.Id, context.ProtocolState.StrategyRung);
+            result = strat.AdvanceIfPossible (context.ProtocolState.StrategyRung);
             Assert.AreEqual (oldRung + 1, result);
             Assert.AreEqual (context.ProtocolState.StrategyRung, result);
             var verify = McProtocolState.QueryById<McProtocolState> (context.ProtocolState.Id);
@@ -324,16 +324,16 @@ namespace Test.iOS
         [Test]
         public void TestFolderListProvider ()
         {
-            var context = new MockContext ();
-            McFolder folder;
-            List<McFolder> result;
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
+            McFolder folder;
+            List<McFolder> result;
             var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             // Test folders missing scenario.
-            result = strat.FolderListProvider (account.Id, 6, true);
+            result = strat.FolderListProvider (6, true);
             Assert.AreEqual (0, result.Count);
             // Normal conditions testing.
             folder = McFolder.Create (account.Id, false, false, true, "0", "inbox", "Inbox", Xml.FolderHierarchy.TypeCode.DefaultInbox_2);
@@ -350,11 +350,11 @@ namespace Test.iOS
             folder.Insert ();
             folder = McFolder.Create (account.Id, false, false, true, "0", "ric", "RIC", Xml.FolderHierarchy.TypeCode.Ric_19);
             folder.Insert ();
-            result = strat.FolderListProvider (account.Id, 6, true);
+            result = strat.FolderListProvider (6, true);
             Assert.AreEqual (2, result.Count);
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.DefaultInbox_2 == x.Type));
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.DefaultCal_8 == x.Type));
-            result = strat.FolderListProvider (account.Id, 6, false);
+            result = strat.FolderListProvider (6, false);
             Assert.AreEqual (7, result.Count);
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.DefaultInbox_2 == x.Type));
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.DefaultCal_8 == x.Type));
@@ -368,12 +368,12 @@ namespace Test.iOS
         [Test]
         public void TestEmailParametersProvider ()
         {
-            var context = new MockContext ();
-            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
+            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var folder = McFolder.Create (account.Id, false, false, true, "0", "inbox", "Inbox", Xml.FolderHierarchy.TypeCode.DefaultInbox_2);
             folder.Insert ();
             var result = strat.EmailParametersProvider (folder, AsStrategy.Scope.EmailEnum.None, true, 50);
@@ -391,12 +391,12 @@ namespace Test.iOS
         [Test]
         public void CalEmailParametersProvider ()
         {
-            var context = new MockContext ();
-            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
+            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var folder = McFolder.Create (account.Id, false, false, true, "0", "cal", "Cal", Xml.FolderHierarchy.TypeCode.DefaultCal_8);
             folder.Insert ();
             var result = strat.CalParametersProvider (folder, AsStrategy.Scope.CalEnum.None, true, 50);
@@ -415,12 +415,12 @@ namespace Test.iOS
         public void ContactEmailParametersProvider ()
         {
 
-            var context = new MockContext ();
-            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
+            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var folder = McFolder.Create (account.Id, false, false, true, "0", "contacts", "Contacts", Xml.FolderHierarchy.TypeCode.DefaultContacts_9);
             folder.Insert ();
             var result = strat.ContactParametersProvider (folder, AsStrategy.Scope.ContactEnum.None, true, 50);
@@ -438,12 +438,12 @@ namespace Test.iOS
         [Test]
         public void ParametersProvider ()
         {
-            var context = new MockContext ();
-            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
+            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var emailFolder = McFolder.Create (account.Id, false, false, true, "0", "inbox", "Inbox", Xml.FolderHierarchy.TypeCode.DefaultInbox_2);
             emailFolder.Insert ();
             var calFolder = McFolder.Create (account.Id, false, false, true, "0", "cal", "Cal", Xml.FolderHierarchy.TypeCode.DefaultCal_8);
@@ -485,12 +485,12 @@ namespace Test.iOS
         [Test]
         public void TestAllSyncedFolders ()
         {
-            var context = new MockContext ();
-            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
+            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var emailFolder = McFolder.Create (account.Id, false, false, true, "0", "inbox", "Inbox", Xml.FolderHierarchy.TypeCode.DefaultInbox_2);
             emailFolder.AsSyncMetaToClientExpected = true;
             emailFolder.Insert ();
@@ -506,7 +506,7 @@ namespace Test.iOS
             ricFolder.Insert ();
             var jFolder = McFolder.Create (account.Id, false, false, true, "0", "journal", "J", Xml.FolderHierarchy.TypeCode.DefaultJournal_11);
             jFolder.Insert ();
-            var result = strat.AllSyncedFolders (account.Id);
+            var result = strat.AllSyncedFolders ();
             Assert.AreEqual (4, result.Count);
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.DefaultInbox_2 == x.Type));
             Assert.True (result.Any (x => Xml.FolderHierarchy.TypeCode.DefaultCal_8 == x.Type));
@@ -518,12 +518,12 @@ namespace Test.iOS
         [Test]
         public void TestGenNarrowSyncKit ()
         {
-            var context = new MockContext ();
-            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
+            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             // Test with folders missing.
             var result = strat.GenNarrowSyncKit (new List<McFolder> (), 0, 50);
             Assert.IsNull (result);
@@ -542,7 +542,7 @@ namespace Test.iOS
             folder.Insert ();
             folder = McFolder.Create (account.Id, false, false, true, "0", "ric", "RIC", Xml.FolderHierarchy.TypeCode.Ric_19);
             folder.Insert ();
-            result = strat.GenNarrowSyncKit (strat.FolderListProvider (account.Id, 0, true), 0, 50);
+            result = strat.GenNarrowSyncKit (strat.FolderListProvider (0, true), 0, 50);
             Assert.AreEqual (50, result.OverallWindowSize);
             Assert.AreEqual (2, result.PerFolders.Count);
             Assert.True (result.PerFolders.Any (x => Xml.FolderHierarchy.TypeCode.DefaultInbox_2 == x.Folder.Type));
@@ -567,44 +567,44 @@ namespace Test.iOS
         [Test]
         public void TestNarrowFoldersNoToClientExpected ()
         {
-            var context = new MockContext ();
-            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
-            var result = strat.ANarrowFolderHasToClientExpected (account.Id);
+            var context = new MockContext (account);
+            var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
+            var result = strat.ANarrowFolderHasToClientExpected ();
             Assert.IsFalse (result);
             var folder = McFolder.Create (account.Id, false, false, true, "0", "inbox", "Inbox", Xml.FolderHierarchy.TypeCode.DefaultInbox_2);
             folder.Insert ();
-            result = strat.ANarrowFolderHasToClientExpected (account.Id);
+            result = strat.ANarrowFolderHasToClientExpected ();
             Assert.IsFalse (result);
             folder = McFolder.Create (account.Id, false, false, true, "0", "cal", "Cal", Xml.FolderHierarchy.TypeCode.DefaultCal_8);
             folder.AsSyncMetaToClientExpected = true;
             folder.Insert ();
-            result = strat.ANarrowFolderHasToClientExpected (account.Id);
+            result = strat.ANarrowFolderHasToClientExpected ();
             Assert.True (result);
             folder.UpdateSet_AsSyncMetaToClientExpected (false);
-            result = strat.ANarrowFolderHasToClientExpected (account.Id);
+            result = strat.ANarrowFolderHasToClientExpected ();
             Assert.False (result);
             folder.Delete ();
-            result = strat.ANarrowFolderHasToClientExpected (account.Id);
+            result = strat.ANarrowFolderHasToClientExpected ();
             Assert.False (result);
         }
 
         [Test]
         public void TestGenPingKit ()
         {
-            var context = new MockContext ();
-            McFolder folder;
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
+            McFolder folder;
             var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
-            var result = strat.GenPingKit (account.Id, context.ProtocolState, true, false, false);
+            var result = strat.GenPingKit (context.ProtocolState, true, false, false);
             Assert.IsNull (result);
-            result = strat.GenPingKit (account.Id, context.ProtocolState, false, false, false);
+            result = strat.GenPingKit (context.ProtocolState, false, false, false);
             Assert.IsNull (result);
             var inbox = McFolder.Create (account.Id, false, false, true, "0", "inbox", "Inbox", Xml.FolderHierarchy.TypeCode.DefaultInbox_2);
             inbox.AsSyncLastPing = DateTime.UtcNow;
@@ -633,24 +633,24 @@ namespace Test.iOS
                 target.MaxFolders = 7;
                 return true;
             });
-            result = strat.GenPingKit (account.Id, context.ProtocolState, true, false, false);
+            result = strat.GenPingKit (context.ProtocolState, true, false, false);
             Assert.AreEqual (2, result.Folders.Count);
             Assert.True (result.Folders.Any (x => Xml.FolderHierarchy.TypeCode.DefaultInbox_2 == x.Type));
             Assert.True (result.Folders.Any (x => Xml.FolderHierarchy.TypeCode.DefaultCal_8 == x.Type));
             inbox.UpdateSet_AsSyncMetaToClientExpected (true);
-            result = strat.GenPingKit (account.Id, context.ProtocolState, true, false, false);
+            result = strat.GenPingKit (context.ProtocolState, true, false, false);
             Assert.IsNull (result);
-            result = strat.GenPingKit (account.Id, context.ProtocolState, false, false, false);
+            result = strat.GenPingKit (context.ProtocolState, false, false, false);
             Assert.IsNull (result);
             inbox.UpdateSet_AsSyncMetaToClientExpected (false);
-            result = strat.GenPingKit (account.Id, context.ProtocolState, false, false, false);
+            result = strat.GenPingKit (context.ProtocolState, false, false, false);
             Assert.AreEqual (7, result.Folders.Count);
             context.ProtocolState = context.ProtocolState.UpdateWithOCApply<McProtocolState> ((record) => {
                 var target = (McProtocolState)record;
                 target.MaxFolders = 3;
                 return true;
             });
-            result = strat.GenPingKit (account.Id, context.ProtocolState, false, false, false);
+            result = strat.GenPingKit (context.ProtocolState, false, false, false);
             Assert.AreEqual (3, result.Folders.Count);
             Assert.True (result.Folders.Any (x => Xml.FolderHierarchy.TypeCode.DefaultInbox_2 == x.Type));
             Assert.True (result.Folders.Any (x => Xml.FolderHierarchy.TypeCode.DefaultCal_8 == x.Type));
@@ -753,12 +753,11 @@ namespace Test.iOS
         [Test]
         public void TestGenFetchKit ()
         {
-            var context = new MockContext ();
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
-            context.Account = account;
+            var context = new MockContext (account);
             var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var result = strat.GenFetchKit ();
             Assert.IsNull (result);
@@ -793,11 +792,11 @@ namespace Test.iOS
         {
             var serverIdGen = 1; // Mock server id to make pending insert happy.
             var folders = new List<McFolder> ();
-            var context = new MockContext ();
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
             context.ProtocolState = context.ProtocolState.UpdateWithOCApply<McProtocolState> ((record) => {
                 var target = (McProtocolState)record;
                 target.StrategyRung = 6;
@@ -810,11 +809,11 @@ namespace Test.iOS
             };
             dummy.Insert ();
             var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
-            var result = strat.GenSyncKit (account.Id, context.ProtocolState, AsStrategy.SyncMode.Directed, dummy);
+            var result = strat.GenSyncKit (context.ProtocolState, AsStrategy.SyncMode.Directed, dummy);
             Assert.IsNull (result);
-            result = strat.GenSyncKit (account.Id, context.ProtocolState, AsStrategy.SyncMode.Narrow);
+            result = strat.GenSyncKit (context.ProtocolState, AsStrategy.SyncMode.Narrow);
             Assert.IsNull (result);
-            result = strat.GenSyncKit (account.Id, context.ProtocolState, AsStrategy.SyncMode.Wide);
+            result = strat.GenSyncKit (context.ProtocolState, AsStrategy.SyncMode.Wide);
             Assert.IsNull (result);
             var inbox = McFolder.Create (account.Id, false, false, true, "0", "inbox", "Inbox", Xml.FolderHierarchy.TypeCode.DefaultInbox_2);
             inbox.AsSyncKey = "1";
@@ -838,11 +837,11 @@ namespace Test.iOS
             folders.Add (folder);
 
             // Test of null result.
-            result = strat.GenSyncKit (account.Id, context.ProtocolState, AsStrategy.SyncMode.Wide);
+            result = strat.GenSyncKit (context.ProtocolState, AsStrategy.SyncMode.Wide);
             Assert.IsNull (result);
 
             // Test of narrow.
-            result = strat.GenSyncKit (account.Id, context.ProtocolState, AsStrategy.SyncMode.Narrow);
+            result = strat.GenSyncKit (context.ProtocolState, AsStrategy.SyncMode.Narrow);
             Assert.AreEqual (2, result.PerFolders.Count);
             Assert.True (result.PerFolders.Any (x => Xml.FolderHierarchy.TypeCode.DefaultInbox_2 == x.Folder.Type));
             Assert.True (result.PerFolders.Any (x => Xml.FolderHierarchy.TypeCode.DefaultCal_8 == x.Folder.Type));
@@ -852,7 +851,7 @@ namespace Test.iOS
 
             // Test simple more-available case.
             folder.UpdateSet_AsSyncMetaToClientExpected (true);
-            result = strat.GenSyncKit (account.Id, context.ProtocolState, AsStrategy.SyncMode.Wide);
+            result = strat.GenSyncKit (context.ProtocolState, AsStrategy.SyncMode.Wide);
             Assert.AreEqual (1, result.PerFolders.Count);
             Assert.True (result.PerFolders.Any (x => Xml.FolderHierarchy.TypeCode.Ric_19 == x.Folder.Type));
 
@@ -912,7 +911,7 @@ namespace Test.iOS
                 ServerId = serverIdGen++.ToString (),
             };
             pending.Insert ();
-            result = strat.GenSyncKit (account.Id, context.ProtocolState, AsStrategy.SyncMode.Wide);
+            result = strat.GenSyncKit (context.ProtocolState, AsStrategy.SyncMode.Wide);
             Assert.AreEqual (4, result.PerFolders.Count);
             var pfInbox = result.PerFolders.Single (x => "inbox" == x.Folder.ServerId);
             Assert.False (pfInbox.GetChanges);
@@ -930,7 +929,7 @@ namespace Test.iOS
             var pfContact = result.PerFolders.Single (x => "contact" == x.Folder.ServerId);
             Assert.AreEqual (0, pfContact.Commands.Count);
             contact.UpdateSet_AsSyncMetaToClientExpected (false);
-            result = strat.GenSyncKit (account.Id, context.ProtocolState, AsStrategy.SyncMode.Wide);
+            result = strat.GenSyncKit (context.ProtocolState, AsStrategy.SyncMode.Wide);
             pfContact = result.PerFolders.Single (x => "contact" == x.Folder.ServerId);
             Assert.AreEqual (1, pfContact.Commands.Count);
             Assert.AreEqual (1, pfContact.Commands.Count (
@@ -966,7 +965,7 @@ namespace Test.iOS
                 ServerId = serverIdGen++.ToString (),
             };
             pending.Insert ();
-            result = strat.GenSyncKit (account.Id, context.ProtocolState, AsStrategy.SyncMode.Wide);
+            result = strat.GenSyncKit (context.ProtocolState, AsStrategy.SyncMode.Wide);
             pfUsermail = result.PerFolders.Single (x => "useremail" == x.Folder.ServerId);
             Assert.False (pfUsermail.GetChanges);
             Assert.AreEqual (2, pfUsermail.Commands.Count);
@@ -996,7 +995,7 @@ namespace Test.iOS
                 ServerId = serverIdGen++.ToString (),
             };
             pending.Insert ();
-            result = strat.GenSyncKit (account.Id, context.ProtocolState, AsStrategy.SyncMode.Wide);
+            result = strat.GenSyncKit (context.ProtocolState, AsStrategy.SyncMode.Wide);
             pfUsermail = result.PerFolders.Single (x => "useremail" == x.Folder.ServerId);
             Assert.False (pfUsermail.GetChanges);
             Assert.AreEqual (1, pfUsermail.Commands.Count);
@@ -1021,11 +1020,11 @@ namespace Test.iOS
              *        we have conditions for spec dnlds.
              *        conditions are set to advance scope.
              */
-            var context = new MockContext ();
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
             context.ProtocolState = context.ProtocolState.UpdateWithOCApply<McProtocolState> ((record) => {
                 var target = (McProtocolState)record;
                 target.StrategyRung = 3;
@@ -1062,11 +1061,11 @@ namespace Test.iOS
         [Test]
         public void TestUploadTimeoutSecs ()
         {
-            var context = new MockContext ();
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
             var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var secs = strat.UploadTimeoutSecs (-1);
             Assert.IsTrue (secs > AsStrategy.KMinTimeout);
@@ -1082,11 +1081,11 @@ namespace Test.iOS
         [Test]
         public void TestDownloadTimeoutSecs ()
         {
-            var context = new MockContext ();
             var account = new McAccount () {
                 AccountType = McAccount.AccountTypeEnum.Exchange,
             };
             account.Insert ();
+            var context = new MockContext (account);
             var strat = new AsStrategy (context, AsStrategy.LadderChoiceEnum.Test);
             var secs = strat.UploadTimeoutSecs (-1);
             Assert.IsTrue (secs > AsStrategy.KMinTimeout);

--- a/Test.Android/Common/CommonMocks.cs
+++ b/Test.Android/Common/CommonMocks.cs
@@ -165,7 +165,7 @@ namespace Test.iOS
 
         public McCred Cred { set; get; }
 
-        public MockContext (AsProtoControl protoControl = null, McServer server = null)
+        public MockContext (McAccount account, AsProtoControl protoControl = null, McServer server = null)
         {
             Owner = new MockOwner ();
            
@@ -174,10 +174,14 @@ namespace Test.iOS
             // READ InitialProvisionCompleted
             Server = server; 
 
-            Account = new McAccount () {
-                EmailAddr = "johnd@foo.utopiasystems.net",
-            };
-            Account.Insert ();
+            if (null == account) {
+                Account = new McAccount () {
+                    EmailAddr = "johnd@foo.utopiasystems.net",
+                };
+                Account.Insert ();
+            } else {
+                Account = account;
+            }
             var protoState = McProtocolState.QueryByAccountId<McProtocolState> (Account.Id).SingleOrDefault ();
             if (null == protoState) {
                 protoState = new McProtocolState () {
@@ -343,7 +347,7 @@ namespace Test.iOS
             Folder = folder;
         }
 
-        public MoveKit GenMoveKit (int accountId)
+        public MoveKit GenMoveKit ()
         {
             return null;
         }
@@ -358,7 +362,7 @@ namespace Test.iOS
             return null;
         }
 
-        public SyncKit GenSyncKit (int accountId, McProtocolState protocolState)
+        public SyncKit GenSyncKit (McProtocolState protocolState)
         {
             return new NachoCore.ActiveSync.SyncKit () {
                 OverallWindowSize = 1,
@@ -374,7 +378,7 @@ namespace Test.iOS
             };
         }
 
-        public PingKit GenPingKit (int accountId, McProtocolState protocolState, bool isNarrow, bool stillHaveUnsyncedFolders, bool ignoreToClientExpected)
+        public PingKit GenPingKit (McProtocolState protocolState, bool isNarrow, bool stillHaveUnsyncedFolders, bool ignoreToClientExpected)
         {
             return new NachoCore.ActiveSync.PingKit () {
                 MaxHeartbeatInterval = 600,

--- a/Test.Android/ConflictResolutionTest.cs
+++ b/Test.Android/ConflictResolutionTest.cs
@@ -47,7 +47,7 @@ namespace Test.iOS
                 base.SetUp ();
 
                 var server = McServer.Create (defaultAccountId, McAccount.ActiveSyncCapabilities, CommonMockData.MockUri);
-                Context = new MockContext (null, server);
+                Context = new MockContext (null, null, server);
 
                 FolderCmd = CreateFolderSyncCmd (Context);
             }

--- a/Test.Android/SyncConfResTest.cs
+++ b/Test.Android/SyncConfResTest.cs
@@ -34,7 +34,7 @@ namespace Test.iOS
 
                 var server = McServer.Create (defaultAccountId, McAccount.ActiveSyncCapabilities, CommonMockData.MockUri);
                 server.Insert ();
-                Context = new MockContext (null, server);
+                Context = new MockContext (null, null, server);
             }
 
             public class Inbox
@@ -90,8 +90,7 @@ namespace Test.iOS
 
             public static AsSyncCommand CreateSyncCmd (MockContext context)
             {
-                var syncCmd = new AsSyncCommand (context, ((AsProtoControl)context.ProtoControl).Strategy.GenSyncKit (
-                                  defaultAccountId, context.ProtocolState));
+                var syncCmd = new AsSyncCommand (context, ((AsProtoControl)context.ProtoControl).Strategy.GenSyncKit (context.ProtocolState));
                 AsHttpOperation.HttpClientType = typeof(MockHttpClient);
                 return syncCmd;
             }


### PR DESCRIPTION
Moved AccountId getter/setter to NcCommand, so it's shared by all Commands (SMTP, IMAP, AS).
Removed passing of account ID where unnecessary
Fixed unit test MockContext to always take a McAccount (can be null), since there were plenty of places where the test code used one Account Id, and the context another.
