### PR TITLE
fixes for swiping on hot cards

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
@@ -385,9 +385,9 @@ namespace NachoClient.iOS
         {
 
             var view = cell.ContentView.ViewWithTag (SWIPE_TAG) as SwipeActionView;
-            view.DisableSwipe ();
             view.OnSwipe = null;
             view.OnClick = null;
+            view.ShouldSwipe = ShouldSwipeCell;
 
             var messageThreadIndex = indexPath.Row;
             var messageThread = messageThreads.GetEmailThread (messageThreadIndex);
@@ -408,10 +408,6 @@ namespace NachoClient.iOS
             cell.TextLabel.Text = "";
             foreach (var v in cell.ContentView.Subviews) {
                 v.Hidden = false;
-            }
-
-            if (!scrolling) {
-                view.EnableSwipe (true);
             }
 
             view.OnClick = (int tag) => {
@@ -517,6 +513,11 @@ namespace NachoClient.iOS
             var previewView = (ScrollableBodyView)view.ViewWithTag (PREVIEW_TAG);
             previewView.Frame = PreviewFrame (cell);
             previewView.SetItem (message);
+        }
+
+        public bool ShouldSwipeCell ()
+        {
+            return !scrolling;
         }
 
         public override NSIndexPath WillSelectRow (UITableView tableView, NSIndexPath indexPath)

--- a/NachoClient.iOS/NachoUI.iOS/Support/SwipeActionView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/SwipeActionView.cs
@@ -450,10 +450,13 @@ namespace NachoClient.iOS
         /// </summary>
         public delegate void SwipeCallback (SwipeActionView activeView, SwipeState state);
 
+        public delegate bool ShouldSwipeCallback ();
+
         public nfloat SnapAllShownThreshold = 0.5f;
 
         public ButtonCallback OnClick;
         public SwipeCallback OnSwipe;
+        public ShouldSwipeCallback ShouldSwipe;
 
         public SwipeActionButtonList LeftSwipeActionButtons { get; protected set; }
 
@@ -503,6 +506,9 @@ namespace NachoClient.iOS
                 return true;
             };
             swipeRecognizer.ShouldBegin = delegate(UIGestureRecognizer obj) {
+                if (ShouldSwipe != null && !ShouldSwipe()){
+                    return false;
+                }
                 var recognizer = (UIPanGestureRecognizer)obj;
                 var velocity = recognizer.VelocityInView (this);
                 return NMath.Abs (velocity.X) > NMath.Abs (velocity.Y); 


### PR DESCRIPTION
left some old enable/disable calls in that could leave cards in a bad state.
new fix for disabling swiping during scroll that doesn't require enable/disable
