### PR TITLE
On remote notification, wait for all accounts to sync

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -201,14 +201,10 @@ namespace NachoClient.iOS
             var jsonStr = (string)NSString.FromData (jsonData, NSStringEncoding.UTF8);
             var notification = JsonConvert.DeserializeObject<Notification> (jsonStr);
             if (notification.HasPingerSection ()) {
-                fetchAccounts = new List<int> ();
-                pushAccounts = McAccount.GetAllConfiguredNonDeviceAccountIds ();
                 if (!PushAssist.ProcessRemoteNotification (notification.pinger, (accountId) => {
                     if (NcApplication.Instance.IsForeground) {
                         var inbox = NcEmailManager.PriorityInbox (accountId);
                         inbox.StartSync ();
-                    } else {
-                        fetchAccounts.Add (accountId);
                     }
                 })) {
                     // Can't find any account matching those contexts. Abort immediately
@@ -741,12 +737,6 @@ namespace NachoClient.iOS
         public override void PerformFetch (UIApplication application, Action<UIBackgroundFetchResult> completionHandler)
         {
             Log.Info (Log.LOG_LIFECYCLE, "PerformFetch called.");
-            fetchAccounts = McAccount.GetAllConfiguredNonDeviceAccountIds ();
-            if (hasRegisteredForRemoteNotifications) {
-                pushAccounts = McAccount.GetAllConfiguredNonDeviceAccountIds ();
-            } else {
-                pushAccounts = new List<int> ();
-            }
             StartFetch (application, completionHandler, "PF");
         }
 
@@ -759,6 +749,12 @@ namespace NachoClient.iOS
             CompletionHandler = completionHandler;
             fetchCause = cause;
             fetchResult = UIBackgroundFetchResult.NoData;
+            fetchAccounts = McAccount.GetAllConfiguredNonDeviceAccountIds ();
+            if (hasRegisteredForRemoteNotifications) {
+                pushAccounts = McAccount.GetAllConfiguredNonDeviceAccountIds ();
+            } else {
+                pushAccounts = new List<int> ();
+            }
             // Need to set ExecutionContext before Start of BE so that strategy can see it.
             NcApplication.Instance.PlatformIndication = NcApplication.ExecutionContextEnum.QuickSync;
             NcApplication.Instance.UnmarkStartup ();


### PR DESCRIPTION
When the app was woken by a remote notification, it would start a
quick sync of all the accounts on the device.  But it wait for the
sync to complete only for those accounts listed in the notification.
When those accounts were done, the app would shut down, even if other
accounts were still in the process of synching.  This could result in
ActiveSync accounts losing messages, as described in nachocove/qa#1043

Change the code to wait for all accounts to complete their quick sync
before shutting down the app.  This doesn't resolve issue 1043, but it
should reduce the frequency with which it happens.
