### PR TITLE
Fix display of device events that repeat yearly on day of week

### DIFF
--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -382,7 +382,7 @@ namespace NachoPlatform
                             result.WeekOfMonth = week;
                         }
                         if (null == rule.MonthsOfTheYear || 0 == rule.MonthsOfTheYear.Length) {
-                            result.MonthOfYear = 1;
+                            result.MonthOfYear = localStartTime.Month;
                         } else {
                             result.MonthOfYear = (int)rule.MonthsOfTheYear [0];
                         }


### PR DESCRIPTION
Some events that came from the device calendar that repeat yearly on a
particular day of the week would incorrectly show the month of their
occurrence as January.  (This only affected the "repeats on" message
in the event detail. The actual date of the event was correct.)  That
problem is now fixed.
