### PR TITLE
Fix broken NcCalendarTest unit tests

### DIFF
--- a/Test.Android/NcCalendarTest.cs
+++ b/Test.Android/NcCalendarTest.cs
@@ -957,9 +957,9 @@ END:VCALENDAR
                   <Type>1</Type>
                   <Data> </Data>
                 </Body>
-                <DtStamp xmlns=""Calendar"">20131203T172804Z</DtStamp>
-                <StartTime xmlns=""Calendar"">20131204T120000Z</StartTime>
-                <EndTime xmlns=""Calendar"">20131204T130000Z</EndTime>
+                <DtStamp xmlns=""Calendar"">20191203T172804Z</DtStamp>
+                <StartTime xmlns=""Calendar"">20191204T120000Z</StartTime>
+                <EndTime xmlns=""Calendar"">20191204T130000Z</EndTime>
                 <Subject xmlns=""Calendar"">Re-dog</Subject>
                 <UID xmlns=""Calendar"">7j5do4kr7q8fi67ubq7bdpr01c@google.com</UID>
                 <Sensitivity xmlns=""Calendar"">0</Sensitivity>
@@ -974,13 +974,13 @@ END:VCALENDAR
                   <Type>1</Type>
                   <Interval>1</Interval>
                   <DayOfWeek>42</DayOfWeek>
-                  <Until>20140108T080000Z</Until>
+                  <Until>20200108T080000Z</Until>
                 </Recurrence>
                 <Exceptions xmlns=""Calendar"">
                   <Exception>
-                    <DtStamp>20131203T172914Z</DtStamp>
-                    <StartTime>20131204T120000Z</StartTime>
-                    <EndTime>20131204T130000Z</EndTime>
+                    <DtStamp>20191203T172914Z</DtStamp>
+                    <StartTime>20191204T120000Z</StartTime>
+                    <EndTime>20191204T130000Z</EndTime>
                     <Subject>Re-dog</Subject>
                     <Sensitivity>0</Sensitivity>
                     <BusyStatus>2</BusyStatus>
@@ -990,12 +990,12 @@ END:VCALENDAR
                       <Type>1</Type>
                       <Data> </Data>
                     </Body>
-                    <ExceptionStartTime>20131204T120000Z</ExceptionStartTime>
+                    <ExceptionStartTime>20191204T120000Z</ExceptionStartTime>
                   </Exception>
                   <Exception>
-                    <DtStamp>20131203T172843Z</DtStamp>
-                    <StartTime>20131206T120000Z</StartTime>
-                    <EndTime>20131206T130000Z</EndTime>
+                    <DtStamp>20191203T172843Z</DtStamp>
+                    <StartTime>20191206T120000Z</StartTime>
+                    <EndTime>20191206T130000Z</EndTime>
                     <Subject>Re-dog</Subject>
                     <Sensitivity>0</Sensitivity>
                     <BusyStatus>2</BusyStatus>
@@ -1006,7 +1006,7 @@ END:VCALENDAR
                       <Data> </Data>
                     </Body>
                     <Deleted>1</Deleted>
-                    <ExceptionStartTime>20131206T120000Z</ExceptionStartTime>
+                    <ExceptionStartTime>20191206T120000Z</ExceptionStartTime>
                   </Exception>
                 </Exceptions>
               </ApplicationData>
@@ -1066,14 +1066,14 @@ END:VCALENDAR
           <ServerId>5:67</ServerId>
           <ApplicationData>
             <Timezone xmlns=""Calendar"">4AEAACgAVQBUAEMALQAwADgAOgAwADAAKQAgAFAAYQBjAGkAZgBpAGMAIABUAGkAbQBlACAAKABVAFMAIAAmACAAQwAAAAsAAAABAAIAAAAAAAAAAAAAACgAVQBUAEMALQAwADgAOgAwADAAKQAgAFAAYQBjAGkAZgBpAGMAIABUAGkAbQBlACAAKABVAFMAIAAmACAAQwAAAAMAAAACAAIAAAAAAAAAxP///w==</Timezone>
-            <DtStamp xmlns=""Calendar"">20140811T141138Z</DtStamp>
-            <StartTime xmlns=""Calendar"">20140826T150000Z</StartTime>
+            <DtStamp xmlns=""Calendar"">20190811T141138Z</DtStamp>
+            <StartTime xmlns=""Calendar"">20190826T150000Z</StartTime>
             <Subject xmlns=""Calendar"">R Weekly</Subject>
             <UID xmlns=""Calendar"">040000008200E00074C5B7101A82E00800000000F08BBD2A6EB5CF010000000000000000100000006FF9F5F91D67394BAC4C77BAA41B1436</UID>
             <OrganizerName xmlns=""Calendar"">Steve Scalpone</OrganizerName>
             <OrganizerEmail xmlns=""Calendar"">steves@nachocove.com</OrganizerEmail>
             <Location xmlns=""Calendar"" />
-            <EndTime xmlns=""Calendar"">20140826T153000Z</EndTime>
+            <EndTime xmlns=""Calendar"">20190826T153000Z</EndTime>
             <Recurrence xmlns=""Calendar"">
               <Type>1</Type>
               <Interval>1</Interval>
@@ -1102,14 +1102,14 @@ END:VCALENDAR
           <ServerId>5:67</ServerId>
           <ApplicationData>
             <Timezone xmlns=""Calendar"">4AEAACgAVQBUAEMALQAwADgAOgAwADAAKQAgAFAAYQBjAGkAZgBpAGMAIABUAGkAbQBlACAAKABVAFMAIAAmACAAQwAAAAsAAAABAAIAAAAAAAAAAAAAACgAVQBUAEMALQAwADgAOgAwADAAKQAgAFAAYQBjAGkAZgBpAGMAIABUAGkAbQBlACAAKABVAFMAIAAmACAAQwAAAAMAAAACAAIAAAAAAAAAxP///w==</Timezone>
-            <DtStamp xmlns=""Calendar"">20140811T141209Z</DtStamp>
-            <StartTime xmlns=""Calendar"">20140826T150000Z</StartTime>
+            <DtStamp xmlns=""Calendar"">20190811T141209Z</DtStamp>
+            <StartTime xmlns=""Calendar"">20190826T150000Z</StartTime>
             <Subject xmlns=""Calendar"">R Weekly</Subject>
             <UID xmlns=""Calendar"">040000008200E00074C5B7101A82E00800000000F08BBD2A6EB5CF010000000000000000100000006FF9F5F91D67394BAC4C77BAA41B1436</UID>
             <OrganizerName xmlns=""Calendar"">Steve Scalpone</OrganizerName>
             <OrganizerEmail xmlns=""Calendar"">steves@nachocove.com</OrganizerEmail>
             <Location xmlns=""Calendar"" />
-            <EndTime xmlns=""Calendar"">20140826T153000Z</EndTime>
+            <EndTime xmlns=""Calendar"">20190826T153000Z</EndTime>
             <Recurrence xmlns=""Calendar"">
               <Type>1</Type>
               <Interval>1</Interval>
@@ -1127,16 +1127,16 @@ END:VCALENDAR
             <Reminder xmlns=""Calendar"">15</Reminder>
             <Exceptions xmlns=""Calendar"">
               <Exception>
-                <StartTime>20140903T190000Z</StartTime>
+                <StartTime>20190903T190000Z</StartTime>
                 <Subject>R Weekly (X)</Subject>
-                <EndTime>20140903T193000Z</EndTime>
+                <EndTime>20190903T193000Z</EndTime>
                 <Body xmlns=""AirSyncBase"">
                   <Type>4</Type>
                   <EstimatedDataSize>4223</EstimatedDataSize>
                   <Data nacho-body-id=""1"" />
                 </Body>
                 <Categories />
-                <ExceptionStartTime>20140902T150000Z</ExceptionStartTime>
+                <ExceptionStartTime>20190902T150000Z</ExceptionStartTime>
                 <OnlineMeetingConfLink />
                 <OnlineMeetingExternalLink />
               </Exception>


### PR DESCRIPTION
Change the dates on some of the test calendar items to several years
into the future, so that the exceptions are not ignored by the code
that ignores calendar item exceptions that are more than a month in
the past.
