### PR TITLE
fix login events to see successive cred waits

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/StandardCredentialsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/StandardCredentialsViewController.cs
@@ -115,6 +115,9 @@ namespace NachoClient.iOS
         {
             base.ViewWillDisappear (animated);
             if (IsMovingFromParentViewController) {
+                if (LoginEvents.Owner == this) {
+                    LoginEvents.Owner = null;
+                }
                 if (Account != null) {
                     NcAccountHandler.Instance.RemoveAccount (Account.Id);
                 }


### PR DESCRIPTION
When submitting wrong password for a second time, LoginEvents was never calling CredReq.

Steve/Jeff, is the a reason why the previous code (looking for NcResult.SubKindEnum.Info_CredReqCallback) would fail to see successive cred failures?

I changed LoginEvents to look for cred req during the backend state change event (which is what the pre-LoginEvents code used to do) and it seems to work fine.
