### PR TITLE
disable send button until there is at least one address

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageComposeViewController.cs
@@ -146,6 +146,7 @@ namespace NachoClient.iOS
                 attachment.SetDisplayName (mimePartAttachment.FileName);
                 attachmentView.Append (attachment);
             }
+
         }
 
         public void SaveDraft ()
@@ -353,6 +354,8 @@ namespace NachoClient.iOS
                 ConfigureToView (false);
                 toView.SetEditFieldAsFirstResponder ();
             }
+
+            UpdateSendEnabled ();
         }
 
         NSObject backgroundNotification;
@@ -1182,6 +1185,7 @@ namespace NachoClient.iOS
                 NcAssert.CaseError ();
                 break;
             }
+            UpdateSendEnabled ();
         }
 
         /// <summary>
@@ -1578,6 +1582,11 @@ namespace NachoClient.iOS
                     action = EmailHelper.Action.Send;
                 }
             }
+        }
+
+        private void UpdateSendEnabled ()
+        {
+            sendButton.Enabled = !toView.IsEmpty () || !ccView.IsEmpty () || !bccView.IsEmpty ();
         }
 
      


### PR DESCRIPTION
for nachocove/qa#1106, but not a complete fix.
- Only considers To/Cc/Bcc when enabling the send button
- Doesn't consider subject & body
- Keeps send button enabled if To/Cc/Bcc are cleared after having values

Not sure if it's worth getting this partial fix in, but going further requires larger changes that will conflict with the web view compose stuff I'm already working on.
