### PR TITLE
Log message when there's no sender during paste

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/NcTextView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/NcTextView.cs
@@ -4,6 +4,7 @@ using System;
 using CoreGraphics;
 using Foundation;
 using UIKit;
+using NachoCore.Utils;
 
 namespace NachoClient.iOS
 {
@@ -20,6 +21,10 @@ namespace NachoClient.iOS
 
         public override void Paste (NSObject sender)
         {
+            if (sender == null) {
+                Log.Error (Log.LOG_UI, "NcTextView.Paste got null sender, skipping paste because base.Paste will throw exception");
+                return;
+            }
             bool justText = false;
             var pasteboard = UIPasteboard.General;
 


### PR DESCRIPTION
for nachocove/qa#1172

not really a fix because we don't do the paste, but at least it prevents a crash
