### PR TITLE
Fix fresh_install = True

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
+++ b/NachoClient.Android/NachoCore/Utils/TelemetryAWS.cs
@@ -104,7 +104,7 @@ namespace NachoCore.Utils
             // If it does not exist, we save the current Cognito id into the file. After
             // the 1st time, we use the id in the file as the client id. Note that we 
             // still need to talk to Cognito in order to get the session token.
-            if (UserIdFile.SharedInstance.Exists ()) {
+            if (UserIdFile.SharedInstance.Read () != null) {
                 FreshInstall = false;
             } else {
                 // Save the current Cognito id as client id


### PR DESCRIPTION
All device_info records are coming  thru as fresh_install = True
This bug was probably introduced when we switched from file store for
user_id to keychain and deleted the file.
