### PR TITLE
Limit the number of contacts considered when searching contacts

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -1449,7 +1449,7 @@ namespace NachoCore.Model
         {
             string prefixPattern = searchFor.Replace ('%', '_') + "%";
             return NcModel.Instance.Db.Query<McContact> (
-                "SELECT * FROM McContact WHERE FirstName LIKE ? OR LastName LIKE ? OR CompanyName LIKE ?",
+                "SELECT * FROM McContact WHERE FirstName LIKE ? OR LastName LIKE ? OR CompanyName LIKE ? LIMIT 100",
                 prefixPattern, prefixPattern, prefixPattern);
         }
 
@@ -1462,7 +1462,7 @@ namespace NachoCore.Model
             string prefixPattern = searchFor.Replace ('%', '_') + "%";
             string domainPattern = "%@" + prefixPattern;
             return NcModel.Instance.Db.Query<McContactEmailAddressAttribute> (
-                "SELECT * FROM McContactEmailAddressAttribute WHERE Value LIKE ? OR Value LIKE ?",
+                "SELECT * FROM McContactEmailAddressAttribute WHERE Value LIKE ? OR Value LIKE ? LIMIT 100",
                 prefixPattern, domainPattern);
         }
 
@@ -1695,7 +1695,7 @@ namespace NachoCore.Model
                 var indexMatches = new List<MatchedItem> ();
                 foreach (var account in McAccount.GetAllAccounts ()) {
                     var index = NcBrain.SharedInstance.Index (account.Id);
-                    indexMatches.AddRange (index.SearchAllContactFields (searchFor));
+                    indexMatches.AddRange (index.SearchAllContactFields (searchFor, maxMatches: 100));
                 }
 
                 rawContacts.AddRange (McContact.QueryByIds (indexMatches.Select (x => x.Id).Distinct ().ToList ()));


### PR DESCRIPTION
When searching for a contact or for an e-mail address, configure each
subquery to return no more than 100 items.  This applies to both
database queries and index queries.  Because each search word is
looked up in multiple places, it is possible for the overall search to
still return more than 100 items.

This change improves performance when searching for a short string
that matches lots of contacts.  It comes at the cost of not always
finding the contact that the user is looking for.  But if there are
more than 100 contacts in the search results, the chance of the right
contact being near the top of the results is small anyway.
