### PR TITLE
Fix1196

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
@@ -1051,7 +1051,7 @@ namespace NachoClient.iOS
                 return;
             }
             if (!PerformAction ("tel", number)) {
-                ComplainAbout ("Could Not Dial", "We are unable to dial this phone number");
+                ComplainAbout ("Cannot Dial", "We are unable to dial this phone number");
             }
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
@@ -256,7 +256,7 @@ namespace NachoClient.iOS
                 return;
             }
             if (!Util.PerformAction ("tel", number)) {
-                Util.ComplainAbout ("Could Not Dial", "We are unable to dial this phone number");
+                Util.ComplainAbout ("Cannot Dial", "We are unable to dial this phone number");
             }
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/Util.cs
@@ -1023,13 +1023,13 @@ namespace NachoClient
                 }
             } else if (1 == contact.PhoneNumbers.Count) {
                 if (!Util.PerformAction ("tel", contact.GetPrimaryPhoneNumber ())) {
-                    ComplainAbout ("Could Not Dial", "We are unable to dial this phone number");
+                    ComplainAbout ("Cannot Dial", "We are unable to dial this phone number");
                 }
             } else {
                 foreach (var p in contact.PhoneNumbers) {
                     if (p.IsDefault) {
                         if (!Util.PerformAction ("tel", p.Value)) {
-                            ComplainAbout ("Could Not Dial", "We are unable to dial this phone number");
+                            ComplainAbout ("Cannot Dial", "We are unable to dial this phone number");
                         }
                         return; 
                     }


### PR DESCRIPTION
fixes nachocove/qa#1196 as best we can.  Even after properly escaping the tel url, we're still not allowed to dial numbers that contain \* or #.
