### PR TITLE
Fix AutoresizingMask for several subviews to fix layout issues

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -398,6 +398,7 @@ namespace NachoClient.iOS
             contentView.AddGestureRecognizer (backgroundTapGesture);
 
             scrollView.Frame = new CGRect (0, 0, View.Frame.Width, View.Frame.Height);
+            scrollView.AutoresizingMask = UIViewAutoresizing.FlexibleDimensions;
 
             doneButton = new NcUIBarButtonItem ();
             cancelButton = new NcUIBarButtonItem ();
@@ -644,6 +645,7 @@ namespace NachoClient.iOS
 
             //Content View
             contentView.Frame = new CGRect (0, 0, SCREEN_WIDTH, (LINE_OFFSET * 9) + (CELL_HEIGHT * 11));
+            contentView.AutoresizingMask = UIViewAutoresizing.None;
             contentView.BackgroundColor = A.Color_NachoNowBackground;
             contentView.AddSubviews (new UIView[] {
                 titleView,

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -176,7 +176,8 @@ namespace NachoClient.iOS
             Util.SetBackButton (NavigationController, NavigationItem, A.Color_NachoBlue);
 
             // Main view
-            scrollView.Frame = View.Frame;
+            scrollView.Frame = new CGRect(0, 0, View.Frame.Width, View.Frame.Height);
+            scrollView.AutoresizingMask = UIViewAutoresizing.FlexibleDimensions;
             scrollView.BackgroundColor = contentViewBGColor;
             scrollView.KeyboardDismissMode = UIScrollViewKeyboardDismissMode.OnDrag;
             scrollView.Scrolled += ScrollViewScrolled;
@@ -186,6 +187,7 @@ namespace NachoClient.iOS
             scrollView.ViewForZoomingInScrollView = ViewForZooming;
 
             contentView.BackgroundColor = contentViewBGColor;
+            contentView.AutoresizingMask = UIViewAutoresizing.None;
 
             nfloat yOffset = 20;
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotListTableViewSource.cs
@@ -216,7 +216,6 @@ namespace NachoClient.iOS
             view.AddSubview (reminderLabelView);
 
             var toolbar = new MessageToolbar (new CGRect (0, frame.Height - 44, frame.Width, 44));
-            toolbar.AutoresizingMask = UIViewAutoresizing.FlexibleTopMargin | UIViewAutoresizing.FlexibleWidth;
             toolbar.Tag = TOOLBAR_TAG;
             view.AddSubview (toolbar);
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageToolbar.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageToolbar.cs
@@ -70,6 +70,9 @@ namespace NachoClient.iOS
 
         public MessageToolbar (CGRect frame) : base (frame)
         {
+            // Keep the toolbar at the bottom of its parent view.
+            this.AutoresizingMask = UIViewAutoresizing.FlexibleTopMargin | UIViewAutoresizing.FlexibleWidth;
+
             Translucent = false;
             BarTintColor = UIColor.White;
 


### PR DESCRIPTION
Starting with iOS 9, the main View for a ViewController with a
navigation bar changes size and location in between ViewWillAppear()
and ViewDidAppear().  The AutoresizingMask for some subviews needs to
be set correctly so that the subviews will react correctly to this
size change.  (In the past the AutoresizingMask didn't matter, because
the main View was not resized after the views were layed out.  Now
that the main View can be resized, we need to pay more attention to
the AutoresizingMasks.)

This fixes layout issues with the toolbar in the message detail view,
and with the initial position of the event detail view and the event
editor view.

Fix nachocove/qa#1214
