### PR TITLE
close an incredibly unlikely hole.

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McEmailAddress/EmailAddressScore.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailAddress/EmailAddressScore.cs
@@ -290,7 +290,11 @@ namespace NachoCore.Model
                 int rc = 0;
                 NcModel.Instance.RunInTransaction (() => {
                     rc = base.Insert ();
-                    InsertScoreStates ();
+                    if (1 == rc) {
+                        InsertScoreStates ();
+                    } else {
+                        Log.Error (Log.LOG_BRAIN, "McEmailAddress.Insert returned {0}", rc);
+                    }
                 });
                 return rc;
             }


### PR DESCRIPTION
Ensure a dup/failed insert wont insert a EmailAddressScore.
Related to nachocove/qa#1201.
