### PR TITLE
Include the server type in the device calendar names

### DIFF
--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -66,13 +66,16 @@ namespace NachoPlatform
 
             public override string DisplayName {
                 get {
+                    if (null != Folder.Source && !string.IsNullOrEmpty (Folder.Source.Title)) {
+                        return string.Format ("{0} : {1}", Folder.Source.Title, Folder.Title);
+                    }
                     return Folder.Title;
                 }
             }
 
             public override NcResult ToMcFolder ()
             {
-                var mcFolder = McFolder.Create (McAccount.GetDeviceAccount ().Id, true, false, false, "0", Folder.CalendarIdentifier, Folder.Title,
+                var mcFolder = McFolder.Create (McAccount.GetDeviceAccount ().Id, true, false, false, "0", Folder.CalendarIdentifier, DisplayName,
                     isDefault ? Xml.FolderHierarchy.TypeCode.DefaultCal_8 : Xml.FolderHierarchy.TypeCode.UserCreatedCal_13);
                 return NcResult.OK (mcFolder);
             }


### PR DESCRIPTION
Users who configure their Calendar app to sync calendars from several
different servers tend to have calendars with similar names, such as
"Birthdays", "Holidays", or "Work".  Nacho Mail was showing only the
simple names, making it hard for the user to figure out which calendar
was linked up with which server.

Change Nacho Mail to include the server type (technically, the
EKSource.Title field) in the name of the calendar that is shown to the
user.

Fix nachocove/qa#1223
