### PR TITLE
Fix layout issue with ChooseCalendarViewController

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ChooseCalendarViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ChooseCalendarViewController.cs
@@ -66,7 +66,8 @@ namespace NachoClient.iOS
             NavigationItem.Title = "Calendars";
             Util.SetBackButton (NavigationController, NavigationItem, A.Color_NachoBlue);
 
-            tableView = new UITableView (View.Frame, UITableViewStyle.Grouped);
+            tableView = new UITableView (new CGRect (0, 0, View.Frame.Width, View.Frame.Height), UITableViewStyle.Grouped);
+            tableView.AutoresizingMask = UIViewAutoresizing.FlexibleDimensions;
             tableView.ScrollEnabled = true;
             source = new CalendarChoicesSource (this, calFolderList);
             tableView.Source = source;


### PR DESCRIPTION
When the list of calendars was too big to fit on the screen, the list
would never scroll.  But it would never scroll far enough to show the
last item on the list.  The last item would always be just off the
bottom of the screen.  Fix that.
