### PR TITLE
Handle device event without an associated device calendar

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ChooseCalendarViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ChooseCalendarViewController.cs
@@ -44,12 +44,15 @@ namespace NachoClient.iOS
 
             Log.Info (Log.LOG_UI,
                 "The selected calendar that was passed to ChooseCalendarViewController.SetCalendars is not in the set of candidate calendars.");
-            selectedAccountIndex = 0;
-            selectedFolderIndex = 0;
+            selectedAccountIndex = -1;
+            selectedFolderIndex = -1;
         }
 
         public McFolder GetSelectedCalendar ()
         {
+            if (0 > selectedAccountIndex) {
+                return null;
+            }
             return calendars [selectedAccountIndex].Item2.GetFolder (selectedFolderIndex);
         }
 
@@ -86,7 +89,9 @@ namespace NachoClient.iOS
         public override void ViewDidAppear (bool animated)
         {
             base.ViewDidAppear (animated);
-            tableView.ScrollToRow (NSIndexPath.FromRowSection (selectedFolderIndex, selectedAccountIndex), UITableViewScrollPosition.Middle, true);
+            if (0 <= selectedAccountIndex) {
+                tableView.ScrollToRow (NSIndexPath.FromRowSection (selectedFolderIndex, selectedAccountIndex), UITableViewScrollPosition.Middle, true);
+            }
         }
 
         private class CalendarChoicesSource : UITableViewSource

--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -383,10 +383,12 @@ namespace NachoClient.iOS
                 dc.SetCalendars (GetChoosableCalendars (), calendarFolder);
                 dc.ViewDisappearing += (object s, EventArgs e) => {
                     var newCalendar = dc.GetSelectedCalendar ();
-                    if (newCalendar.AccountId != calendarFolder.AccountId) {
-                        ChangeToAccount (newCalendar.AccountId);
+                    if (null != newCalendar) {
+                        if (newCalendar.AccountId != calendarFolder.AccountId) {
+                            ChangeToAccount (newCalendar.AccountId);
+                        }
+                        calendarFolder = newCalendar;
                     }
-                    calendarFolder = newCalendar;
                 };
                 return;
             }


### PR DESCRIPTION
Don't crash when synching a device event that is not associated with a
device calendar.  Such events are still synched.  They are added to
the backstop device calendar that the app keeps around for exactly
this reason.

Fix nachocove/qa#1244

Tested via crowbar: events with a certain title were treated as if the EKEvent.Calendar property was null.
