### PR TITLE
Stop discarding contact search results

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactChooserViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactChooserViewController.cs
@@ -56,16 +56,13 @@ namespace NachoClient.iOS
                         resultsTableView.ReloadData ();
                     });
                 } else {
-                    int curVersion = searcher.Version;
                     var results = McContact.SearchAllContactsForEmail (searchString);
-                    if (curVersion == searcher.Version) {
-                        InvokeOnUIThread.Instance.Invoke (() => {
-                            searchResults = results;
-                            NcAbate.HighPriority("ContactChooserUpdateAuotCompleteResults");
-                            resultsTableView.ReloadData ();
-                            NcAbate.RegularPriority("ContactChooserUpdateAuotCompleteResults");
-                        });
-                    }
+                    InvokeOnUIThread.Instance.Invoke (() => {
+                        searchResults = results;
+                        NcAbate.HighPriority ("ContactChooserUpdateAuotCompleteResults");
+                        resultsTableView.ReloadData ();
+                        NcAbate.RegularPriority ("ContactChooserUpdateAuotCompleteResults");
+                    });
                 }
             });
         }

--- a/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/ContactsTableViewSource.cs
@@ -47,14 +47,11 @@ namespace NachoClient.iOS
                         NcApplication.Instance.InvokeStatusIndEventInfo (null, NcResult.SubKindEnum.Info_ContactLocalSearchComplete);
                     });
                 } else {
-                    int curVersion = searcher.Version;
                     var results = McContact.SearchIndexAllContacts (searchString);
-                    if (curVersion == searcher.Version) {
-                        InvokeOnUIThread.Instance.Invoke (() => {
-                            SetSearchResults (results);
-                            NcApplication.Instance.InvokeStatusIndEventInfo (null, NcResult.SubKindEnum.Info_ContactLocalSearchComplete);
-                        });
-                    }
+                    InvokeOnUIThread.Instance.Invoke (() => {
+                        SetSearchResults (results);
+                        NcApplication.Instance.InvokeStatusIndEventInfo (null, NcResult.SubKindEnum.Info_ContactLocalSearchComplete);
+                    });
                 }
             });
         }


### PR DESCRIPTION
When the user is searching contacts (either the general contact search
or autocomplete for a email address), the app would throw away a set
of search results and not display them if the user had already typed
another character before the results were ready.  If the user could
type quickly, then he might not see any results until he was done
typing.

Fix the contact search code to not throw away search results.  The
results are now displayed even if the user has typed in more
characters.  This is a better user experience, because it lets the
user know that the app is searching, and it gives the user some useful
information to look at while waiting for the final results.

This change improves the situation for nachocove/qa#1232.  It may or
may not be a complete fix for the issue.
