### PR TITLE
In pinger, we were always looking for the password, even when this was a gmail account

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/PushAssist.cs
@@ -756,14 +756,7 @@ namespace NachoCore
                 IMAPUIDNEXT = parameters.IMAPUIDNEXT,
             };
             McAccount account = McAccount.QueryById<McAccount> (AccountId);
-            try {
-                string password = cred.GetPassword ();
-                account.LogHashedPassword (Log.LOG_PUSH, "PushAssist->DoStartSession", password);
-            } catch (KeychainItemNotFoundException ex) {
-                Log.Error (Log.LOG_UI, "KeychainItemNotFoundException: {0}", ex.Message);
-                PostTempFail ("KeychainItemNotFoundException");
-                return;
-            }
+            account.LogHashedPassword (Log.LOG_PUSH, "PushAssist->DoStartSession", cred);
             FillOutIdentInfo (jsonRequest);
 
             NcTask.Run (() => {

--- a/NachoClient.Android/NachoCore/Model/McAccount.cs
+++ b/NachoClient.Android/NachoCore/Model/McAccount.cs
@@ -451,6 +451,35 @@ namespace NachoCore.Model
             Log.Info (service, "LoggablePasswordSaltedHash({0}): {1} passwordHash={2}", Id, logComment, hashed);
         }
 
+        public void LogHashedPassword (ulong service, string logComment, McCred cred)
+        {
+            string credstring = null;
+            try {
+                switch (cred.CredType) {
+                case McCred.CredTypeEnum.Password:
+                    credstring = cred.GetPassword ();
+                    break;
+
+                case McCred.CredTypeEnum.OAuth2:
+                    credstring = cred.GetAccessToken ();
+                    break;
+
+                default:
+                    Log.Warn (Log.LOG_PUSH, "LogHashedPassword: Unhandled credential type {0}", cred.CredType);
+                    break;
+                }
+            } catch (KeychainItemNotFoundException ex) {
+                Log.Error (Log.LOG_UI, "LogHashedPassword({0}: {1}", logComment, ex.Message);
+            }
+            if (null != credstring) {
+                try {
+                    LogHashedPassword (service, logComment, credstring);
+                } catch (KeychainItemNotFoundException ex) {
+                    Log.Error (Log.LOG_UI, "LogHashedPassword({0}: {1}", logComment, ex.Message);
+                }
+            }
+        }
+
         public async void PopulateProfilePhotoFromURL (Uri imageUrl)
         {
             try {


### PR DESCRIPTION
Move the functionality into a new version of the LogHashedPassword
function that does appropriate checking and gets the right type of
credential.

resolves nachocove/qa#1247
