### PR TITLE
Some improvements to the Android event detail view

### DIFF
--- a/NachoClient.Android/NachoPlatform.Android/NotifAndroid.cs
+++ b/NachoClient.Android/NachoPlatform.Android/NotifAndroid.cs
@@ -33,7 +33,7 @@ namespace NachoPlatform
 
         public void ImmediateNotification (int handle, string message)
         {
-            NcAssert.True (false);
+            Log.Info (Log.LOG_CALENDAR, "ImmediateNotification not implemented for Android.");
         }
 
         public void ScheduleNotification (int handle, DateTime when, string message)
@@ -55,7 +55,7 @@ namespace NachoPlatform
 
         public void CancelNotification (int handle)
         {
-            NcAssert.True (false);
+            Log.Info (Log.LOG_CALENDAR, "CancelNotification not implemented for Android.");
         }
 
         public static void DumpNotifications ()

--- a/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
@@ -87,6 +87,17 @@ namespace NachoClient.AndroidClient
                 locationLabel.Text = location;
             }
 
+            var webview = view.FindViewById<Android.Webkit.WebView> (Resource.Id.event_description_webview);
+            var body = McBody.QueryById<McBody> (detail.SpecificItem.BodyId);
+            if (McBody.IsNontruncatedBodyComplete (body)) {
+                var bodyRenderer = new BodyRenderer ();
+                bodyRenderer.Start (webview, body, detail.SpecificItem.NativeBodyType);
+                var webClient = new NachoWebViewClient ();
+                webview.SetWebViewClient (webClient);
+            } else {
+                webview.Visibility = ViewStates.Gone;
+            }
+
             var reminderView = view.FindViewById<TextView> (Resource.Id.event_reminder_label);
             reminderView.Text = detail.ReminderString;
 
@@ -109,6 +120,14 @@ namespace NachoClient.AndroidClient
                 }
             }
 
+            var notesLabel = view.FindViewById<TextView> (Resource.Id.event_notes_label);
+            var note = McNote.QueryByTypeId (detail.SeriesItem.Id, McNote.NoteType.Event).FirstOrDefault ();
+            if (null == note) {
+                notesLabel.Text = "";
+            } else {
+                notesLabel.Text = note.noteContent;
+            }
+
             var calendarView = view.FindViewById<TextView> (Resource.Id.event_calendar_label);
             calendarView.Text = detail.CalendarNameString;
 
@@ -125,7 +144,7 @@ namespace NachoClient.AndroidClient
             var rsvpView = view.FindViewById<View> (Resource.Id.event_rsvp_view);
             var removeView = view.FindViewById<View> (Resource.Id.event_remove_view);
             var cancelledView = view.FindViewById<View> (Resource.Id.event_cancelled_view);
-            var organizerView = view.FindViewById<View> (Resource.Id.event_organizer_view);
+            var organizerView = view.FindViewById<View> (Resource.Id.event_self_organizer_view);
             var separatorView = view.FindViewById<View> (Resource.Id.event_top_separator);
 
             rsvpView.Visibility = ViewStates.Gone;
@@ -154,7 +173,6 @@ namespace NachoClient.AndroidClient
                 rsvpView.Visibility = ViewStates.Visible;
             }
         }
-
     }
 }
 

--- a/NachoClient.Android/NachoUI.Android/Activities/WaitingFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/WaitingFragment.cs
@@ -64,6 +64,7 @@ namespace NachoClient.AndroidClient
             }
             var parent = (LaunchActivity)Activity;
             parent.WaitingFinished ();
+            LoginHelpers.SetHasViewedTutorial (true);
         }
 
         public void handleStatusEnums ()

--- a/NachoClient.Android/NachoUI.Android/Support/BodyRenderer.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/BodyRenderer.cs
@@ -43,6 +43,7 @@ namespace NachoClient.AndroidClient
                 break;
             case McAbstrFileDesc.BodyTypeEnum.RTF_3:
                 // FIXME
+                RenderTextString ("[RTF body type is not yet supported.]");
                 break;
             case McAbstrFileDesc.BodyTypeEnum.MIME_4:
                 RenderMime (body, nativeBodyType);
@@ -75,13 +76,13 @@ namespace NachoClient.AndroidClient
                 var part = (MimePart)entity;
                 if (part.ContentType.Matches ("text", "html")) {
                     RenderHtmlPart (part);
-                    return;
                 } else if (part.ContentType.Matches ("text", "rtf")) {
-                    // FIXME
+                    RenderRtfPart (part);
                 } else if (part.ContentType.Matches ("text", "*")) {
                     RenderTextPart (part);
                 } else if (part.ContentType.Matches ("image", "*")) {
                     // FIXME
+                    RenderTextString ("[Image MIME part is not yet supported.]");
                 }
             }
         }
@@ -96,6 +97,11 @@ namespace NachoClient.AndroidClient
             RenderHtmlString ((part as TextPart).Text);
         }
 
+        private void RenderRtfPart (MimePart part)
+        {
+            // FIXME
+            RenderTextString ("[RTF MIME part is not yet supported.]");
+        }
     }
 
 }

--- a/NachoClient.Android/Resources/layout/EventViewFragment.axml
+++ b/NachoClient.Android/Resources/layout/EventViewFragment.axml
@@ -11,9 +11,18 @@
         android:layout_height="wrap_content"
         android:layout_weight="0"
         android:paddingBottom="4dip"
-        android:textColor="@android:color/black" />
+        android:textColor="@android:color/black"
+        android:textSize="20dp"
+        android:layout_marginLeft="30dp"
+        android:layout_marginTop="15dp"
+        android:layout_marginBottom="15dp" />
+    <View
+        android:id="@+id/event_title_separator"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/NachoGreen" />
     <LinearLayout
-        android:id="@+id/event_organizer_view"
+        android:id="@+id/event_self_organizer_view"
         android:background="@android:color/white"
         android:orientation="horizontal"
         android:layout_width="match_parent"
@@ -290,7 +299,8 @@
         android:background="@android:color/white"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:padding="10dp">
+        android:padding="10dp"
+        android:id="@+id/relativeLayout2">
         <ImageView
             android:id="@+id/image"
             android:layout_width="14dp"
@@ -311,18 +321,13 @@
             android:textStyle="normal"
             android:text="@string/event_description"
             android:paddingLeft="10dp" />
-        <TextView
-            android:id="@+id/event_location_label"
+        <android.webkit.WebView
+            android:id="@+id/event_description_webview"
             android:layout_below="@id/label"
             android:layout_toRightOf="@id/image"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@android:color/black"
-            android:textSize="17dp"
-            android:textStyle="normal"
-            android:text="@string/demo_event_description"
-            android:layout_gravity="center_vertical"
-            android:paddingLeft="10dp" />
+            android:layout_gravity="center_vertical" />
     </RelativeLayout>
     <RelativeLayout
         android:orientation="vertical"
@@ -457,7 +462,7 @@
             android:text="@string/event_notes"
             android:paddingLeft="10dp" />
         <TextView
-            android:id="@+id/event_location_label"
+            android:id="@+id/event_notes_label"
             android:layout_below="@id/label"
             android:layout_toRightOf="@id/image"
             android:layout_width="wrap_content"


### PR DESCRIPTION
Improvements to the event detail view on Android: The title looks more
like a title.  The description is displayed (if it is not in RTF,
which it often is).  The notes field is correct (except that there can
never be any notes, since there is no way to enter them).  The
organizer is displayed correctly.

Change some more local notification methods from assertion failures to
not-yet-implemented log messages.

Fix the launching process so that the user doesn't have to enter a new
account every time the app starts.
