### PR TITLE
More Android event detail view improvements

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
@@ -101,6 +101,13 @@ namespace NachoClient.AndroidClient
             var reminderView = view.FindViewById<TextView> (Resource.Id.event_reminder_label);
             reminderView.Text = detail.ReminderString;
 
+            if (0 == detail.SpecificItem.attachments.Count) {
+                view.FindViewById<View> (Resource.Id.event_attachments_view).Visibility = ViewStates.Gone;
+            } else {
+                var attachmentTextView = view.FindViewById<TextView> (Resource.Id.event_attachment_placeholder);
+                attachmentTextView.Text = string.Format ("{0} attachments. Not yet implemented.", detail.SpecificItem.attachments.Count);
+            }
+
             var organizer_view = view.FindViewById<View> (Resource.Id.event_organizer_view);
             organizer_view.Visibility = VisibleIfTrue (detail.HasNonSelfOrganizer);
             if (detail.HasNonSelfOrganizer) {
@@ -117,6 +124,25 @@ namespace NachoClient.AndroidClient
                     initialsView.Text = ContactsHelper.NameToLetters (detail.SeriesItem.OrganizerName);
                 } else {
                     initialsView.Text = ContactsHelper.NameToLetters (detail.SeriesItem.OrganizerEmail);
+                }
+            }
+
+            var attendees = detail.SpecificItem.attendees;
+            if (0 == attendees.Count) {
+                view.FindViewById<View> (Resource.Id.event_attendee_view).Visibility = ViewStates.Gone;
+            } else {
+                for (int a = 0; a < 5; ++a) {
+                    if (4 == a && 5 < attendees.Count) {
+                        AttendeeInitialsView (view, a).Text = string.Format ("+{0}", attendees.Count - a);
+                        AttendeeNameView (view, a).Text = "";
+                    } else if (a < attendees.Count) {
+                        var attendee = attendees [a];
+                        AttendeeInitialsView (view, a).Text = ContactsHelper.NameToLetters (attendee.DisplayName);
+                        AttendeeNameView (view, a).Text = GetFirstName (attendee.DisplayName);
+                    } else {
+                        AttendeeInitialsView (view, a).Visibility = ViewStates.Gone;
+                        AttendeeNameView (view, a).Visibility = ViewStates.Gone;
+                    }
                 }
             }
 
@@ -172,6 +198,70 @@ namespace NachoClient.AndroidClient
                 // Show the Attend, Maybe, and Decline buttons.
                 rsvpView.Visibility = ViewStates.Visible;
             }
+        }
+
+        private TextView AttendeeInitialsView (View parent, int attendeeIndex)
+        {
+            int id;
+            switch (attendeeIndex) {
+            case 0:
+                id = Resource.Id.event_attendee_0;
+                break;
+            case 1:
+                id = Resource.Id.event_attendee_1;
+                break;
+            case 2:
+                id = Resource.Id.event_attendee_2;
+                break;
+            case 3:
+                id = Resource.Id.event_attendee_3;
+                break;
+            case 4:
+                id = Resource.Id.event_attendee_4;
+                break;
+            default:
+                NcAssert.CaseError (string.Format ("Attendee index {0} is out of range. It must be [0..4]", attendeeIndex));
+                return null;
+            }
+            return parent.FindViewById<TextView> (id);
+        }
+
+        private TextView AttendeeNameView (View parent, int attendeeIndex)
+        {
+            int id;
+            switch (attendeeIndex) {
+            case 0:
+                id = Resource.Id.event_attendee_name_0;
+                break;
+            case 1:
+                id = Resource.Id.event_attendee_name_1;
+                break;
+            case 2:
+                id = Resource.Id.event_attendee_name_2;
+                break;
+            case 3:
+                id = Resource.Id.event_attendee_name_3;
+                break;
+            case 4:
+                id = Resource.Id.event_attendee_name_4;
+                break;
+            default:
+                NcAssert.CaseError (string.Format ("Attendee index {0} is out of range. It must be [0..4]", attendeeIndex));
+                return null;
+            }
+            return parent.FindViewById<TextView> (id);
+        }
+
+        private static string GetFirstName (string displayName)
+        {
+            string[] names = displayName.Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (names [0] == null) {
+                return "";
+            }
+            if (names [0].Length > 1) {
+                return char.ToUpper (names [0] [0]) + names [0].Substring (1);
+            }
+            return names [0].ToUpper ();
         }
     }
 }

--- a/NachoClient.Android/Resources/layout/EventViewFragment.axml
+++ b/NachoClient.Android/Resources/layout/EventViewFragment.axml
@@ -373,6 +373,43 @@
                 android:paddingLeft="10dp" />
         </RelativeLayout>
         <RelativeLayout
+            android:id="@+id/event_attachments_view"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:padding="10dp">
+            <ImageView
+                android:id="@+id/image"
+                android:layout_width="14dp"
+                android:layout_height="14dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:layout_gravity="left"
+                android:src="@drawable/inbox_icn_attachment" />
+            <TextView
+                android:id="@+id/label"
+                android:layout_toRightOf="@id/image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:textColor="@android:color/black"
+                android:textSize="14dp"
+                android:textStyle="normal"
+                android:text="@string/event_attachments"
+                android:paddingLeft="10dp" />
+            <TextView
+                android:id="@+id/event_attachment_placeholder"
+                android:layout_below="@id/label"
+                android:layout_toRightOf="@id/image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@android:color/black"
+                android:textSize="17dp"
+                android:textStyle="normal"
+                android:text="@string/demo_event_notes"
+                android:paddingLeft="10dp" />
+        </RelativeLayout>
+        <RelativeLayout
             android:id="@+id/event_organizer_view"
             android:orientation="vertical"
             android:background="@android:color/white"
@@ -438,6 +475,164 @@
                 android:text="@string/demo_event_organizer_email"
                 android:layout_gravity="center_vertical"
                 android:paddingLeft="10dp" />
+        </RelativeLayout>
+        <RelativeLayout
+            android:id="@+id/event_attendee_view"
+            android:orientation="vertical"
+            android:background="@android:color/white"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:padding="10dp">
+            <ImageView
+                android:id="@+id/image"
+                android:layout_width="14dp"
+                android:layout_height="14dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:layout_gravity="left"
+                android:src="@drawable/event_attendees" />
+            <TextView
+                android:id="@+id/label"
+                android:layout_toRightOf="@id/image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:textColor="@android:color/black"
+                android:textSize="14dp"
+                android:textStyle="normal"
+                android:text="@string/event_attendees"
+                android:paddingLeft="10dp" />
+            <TextView
+                android:layout_toRightOf="@id/image"
+                android:layout_below="@id/label"
+                android:id="@+id/event_attendee_0"
+                android:text="@string/demo_event_organizer_initials"
+                android:textSize="24dp"
+                android:textColor="@android:color/white"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:layout_marginLeft="14dp"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:background="@drawable/UserColor5" />
+            <TextView
+                android:layout_toRightOf="@id/image"
+                android:layout_below="@id/event_attendee_0"
+                android:id="@+id/event_attendee_name_0"
+                android:text="@string/demo_event_organizer"
+                android:maxLines="1"
+                android:layout_width="40dp"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="14dp"
+                android:layout_gravity="center"
+                android:gravity="center" />
+            <TextView
+                android:layout_toRightOf="@id/event_attendee_0"
+                android:layout_below="@id/label"
+                android:id="@+id/event_attendee_1"
+                android:text="@string/demo_event_organizer_initials"
+                android:textSize="24dp"
+                android:textColor="@android:color/white"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:layout_marginLeft="14dp"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:background="@drawable/UserColor10" />
+            <TextView
+                android:layout_toRightOf="@id/event_attendee_name_0"
+                android:layout_below="@id/event_attendee_1"
+                android:id="@+id/event_attendee_name_1"
+                android:text="@string/demo_event_organizer"
+                android:maxLines="1"
+                android:layout_width="40dp"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="14dp"
+                android:layout_gravity="center"
+                android:gravity="center" />
+            <TextView
+                android:layout_toRightOf="@id/event_attendee_1"
+                android:layout_below="@id/label"
+                android:id="@+id/event_attendee_2"
+                android:text="@string/demo_event_organizer_initials"
+                android:textSize="24dp"
+                android:textColor="@android:color/white"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:layout_marginLeft="14dp"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:background="@drawable/UserColor15" />
+            <TextView
+                android:layout_toRightOf="@id/event_attendee_name_1"
+                android:layout_below="@id/event_attendee_2"
+                android:id="@+id/event_attendee_name_2"
+                android:text="@string/demo_event_organizer"
+                android:maxLines="1"
+                android:layout_width="40dp"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="14dp"
+                android:layout_gravity="center"
+                android:gravity="center" />
+            <TextView
+                android:layout_toRightOf="@id/event_attendee_2"
+                android:layout_below="@id/label"
+                android:id="@+id/event_attendee_3"
+                android:text="@string/demo_event_organizer_initials"
+                android:textSize="24dp"
+                android:textColor="@android:color/white"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:layout_marginLeft="14dp"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:background="@drawable/UserColor20" />
+            <TextView
+                android:layout_toRightOf="@id/event_attendee_name_2"
+                android:layout_below="@id/event_attendee_3"
+                android:id="@+id/event_attendee_name_3"
+                android:text="@string/demo_event_organizer"
+                android:maxLines="1"
+                android:layout_width="40dp"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="14dp"
+                android:layout_gravity="center"
+                android:gravity="center" />
+            <TextView
+                android:layout_toRightOf="@id/event_attendee_3"
+                android:layout_below="@id/label"
+                android:id="@+id/event_attendee_4"
+                android:text="@string/demo_event_organizer_initials"
+                android:textSize="24dp"
+                android:textColor="@android:color/white"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:layout_marginLeft="14dp"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:background="@drawable/UserColor25" />
+            <TextView
+                android:layout_toRightOf="@id/event_attendee_name_3"
+                android:layout_below="@id/event_attendee_4"
+                android:id="@+id/event_attendee_name_4"
+                android:text="@string/demo_event_organizer"
+                android:maxLines="1"
+                android:layout_width="40dp"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="14dp"
+                android:layout_gravity="center"
+                android:gravity="center" />
         </RelativeLayout>
         <RelativeLayout
             android:orientation="vertical"

--- a/NachoClient.Android/Resources/values/strings.xml
+++ b/NachoClient.Android/Resources/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="event_location">LOCATION</string>
     <string name="event_description">DESCRIPTION</string>
     <string name="event_reminder">REMINDER</string>
+    <string name="event_attachments">ATTACHMENTS</string>
     <string name="event_attendees">ATTENDEES</string>
     <string name="event_notes">NOTES</string>
     <string name="event_calendar">CALENDAR</string>


### PR DESCRIPTION
Show the attendees summary: the initials and first name of the first
four or five attendees.  There is still no way to go to the attendees
view to see all the details about the attendees.

Show the number of attachments, but not the information about the
individual attachments.

The event detail view now has all the fields that it is supposed to
have.  But some of the fields have incomplete information (description
and attachments), and there is no way to change information or to
segue to a screen with details for a field (reminder, attendees,
notes).
