### PR TITLE
Don't crash when there are calendar items more than a month old

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NcEventsCalendarMap.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcEventsCalendarMap.cs
@@ -116,8 +116,9 @@ namespace NachoCore
 
         public void IndexToDayItem (int index, out int day, out int item)
         {
+            index += days [0];
             for (int i = 0; i < days.Length - 1; ++i) {
-                if (index <= i + days[i + 1]) {
+                if (index <= i + days [i + 1]) {
                     day = i;
                     item = index - (i + days [i] + 1);
                     return;
@@ -129,12 +130,13 @@ namespace NachoCore
 
         public int IndexFromDayItem (int day, int item)
         {
-            return day + days [day] + item + 1;
+            return day + days [day] + item + 1 - days [0];
         }
 
         public int NumberOfEvents()
         {
-            return events.Count;
+            // Events before the starting date are not counted.
+            return events.Count - days [0];
         }
 
         public DateTime GetDateUsingDayIndex (int day)


### PR DESCRIPTION
The calculations used by the Android calendar list view assumed that
there were no calendar items older than what was shown on the
calendar.  That was an incorrect assumption which resulted in a crash
when opening the calendar view.
