### PR TITLE
Correctly localize dates and times

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
@@ -1631,7 +1631,7 @@ namespace NachoCore.Utils
                     utc = utc.Subtract (adjustment.DaylightDelta);
                 }
                 return utc;
-            } catch (ArgumentException e) {
+            } catch (ArgumentException) {
                 if (timeZone.IsInvalidTime (local)) {
                     // The time is within the missing hour at the transition from standard time to daylight time.
                     // Try with a time that is an hour later.

--- a/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
@@ -261,7 +261,7 @@ namespace NachoCore.Utils
         public static string AttributionLineForMessage (McEmailMessage message)
         {
             var attribution = "";
-            attribution += message.DateReceived.ToLocalTime().ToString ("'On' MMM d, yyyy 'at' h:mm tt");
+            attribution += string.Format ("On {0} at {1}", Pretty.MediumMonthDayYear (message.DateReceived), Pretty.Time (message.DateReceived));
             if (!String.IsNullOrWhiteSpace (message.From)) {
                 if (attribution.Length > 0) {
                     attribution += ", ";
@@ -684,7 +684,7 @@ namespace NachoCore.Utils
                 result.Append ("Cc: ").Append (message.Cc).Append ("\n");
             }
             result.Append ("Subject: ").Append (message.Subject ?? "").Append ("\n");
-            result.Append ("Date: ").Append (Pretty.UniversalFullDateTimeString (message.DateReceived));
+            result.Append ("Date: ").Append (Pretty.UniversalFullDateTime (message.DateReceived));
             result.Append ("\n\n");
             return result.ToString ();
         }
@@ -697,7 +697,7 @@ namespace NachoCore.Utils
             result.Append ("Organizer: ").Append (calendar.OrganizerName ?? calendar.OrganizerEmail ?? "").Append ("\n");
             result.Append ("To: ").Append (recipient).Append ("\n");
             result.Append ("Subject: ").Append (calendar.Subject ?? "").Append ("\n");
-            result.Append ("When: ").Append (Pretty.FullDateYearString (calendar.StartTime)).Append ("\n");
+            result.Append ("When: ").Append (Pretty.UniversalFullDateTime (calendar.StartTime)).Append ("\n");
             result.Append ("Where: ").Append (calendar.Location ?? "").Append ("\n");
             result.Append ("\n\n");
             return result.ToString ();

--- a/NachoClient.Android/NachoCore/Utils/NcEventDetail.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcEventDetail.cs
@@ -180,7 +180,7 @@ namespace NachoCore.Utils
 
         public string DateString {
             get {
-                return Pretty.ExtendedDateString (StartTime);
+                return Pretty.LongFullDate (StartTime);
             }
         }
 
@@ -189,25 +189,20 @@ namespace NachoCore.Utils
                 if (specific.AllDayEvent) {
                     if ((specific.EndTime - specific.StartTime) > TimeSpan.FromDays(1)) {
                         return string.Format ("All day from {0} through {1}",
-                            Pretty.FullDateYearString (specific.StartTime),
-                            Pretty.FullDateYearString (CalendarHelper.ReturnAllDayEventEndTime (specific.EndTime)));
+                            Pretty.MediumFullDate (specific.StartTime),
+                            Pretty.MediumFullDate (CalendarHelper.ReturnAllDayEventEndTime (specific.EndTime)));
                     } else {
                         return "All day event";
                     }
                 } else {
                     DateTime start = StartTime.ToLocalTime ();
                     DateTime end = EndTime.ToLocalTime ();
-                    if (start.Year == end.Year) {
-                        if (start.DayOfYear == end.DayOfYear) {
-                            return string.Format ("from {0} until {1}",
-                                Pretty.FullTimeString (StartTime), Pretty.FullTimeString (EndTime));
-                        } else {
-                            return string.Format ("from {0} until {1}",
-                                Pretty.FullTimeString (StartTime), Pretty.FullDateTimeString (EndTime));
-                        }
+                    if (start.DayOfYear == end.DayOfYear) {
+                        return string.Format ("from {0} until {1}",
+                            Pretty.Time (StartTime), Pretty.Time (EndTime));
                     } else {
-                        return string.Format ("from {1} until {1}",
-                            Pretty.FullTimeString (StartTime), Pretty.FullDateYearTimeString (EndTime));
+                        return string.Format ("from {0} until {1}",
+                            Pretty.Time (StartTime), Pretty.MediumFullDateTime (EndTime));
                     }
                 }
             }

--- a/NachoClient.Android/NachoCore/Utils/Pretty.cs
+++ b/NachoClient.Android/NachoCore/Utils/Pretty.cs
@@ -5,6 +5,8 @@ using NachoCore;
 using NachoCore.Model;
 using MimeKit;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace NachoCore.Utils
 {
@@ -90,123 +92,6 @@ namespace NachoCore.Utils
         }
 
         /// <summary>
-        /// All day, with n days for multi-day events
-        /// </summary>
-        static public string AllDayStartToEnd (DateTime startTime, DateTime endTime)
-        {
-            var d = endTime.Date.Subtract (startTime.Date);
-            if (d.Minutes < 1) {
-                return "All day";
-            }
-            return String.Format ("All day ({0} days)", d.Days);
-        }
-
-        /// <summary>
-        /// StartTime - EndTime, on two lines.
-        /// </summary>
-        static public string EventStartToEnd (DateTime startTime, DateTime endTime)
-        {
-            NcAssert.True (DateTimeKind.Local != startTime.Kind);
-            NcAssert.True (DateTimeKind.Local != endTime.Kind);
-
-            var startString = startTime.LocalT ().ToString ("t");
-
-            if (startTime == endTime) {
-                return startString;
-            }
-            var localEndTime = endTime.LocalT ();
-            var durationString = PrettyEventDuration (startTime, endTime);
-            if (startTime.Date == endTime.Date) {
-                return String.Format ("{0} - {1} ({2})", startString, localEndTime.ToString ("t"), durationString);
-            } else {
-                return String.Format ("{0} -\n{1} ({2})", startString, FullDateTimeString (endTime), durationString);
-            }
-        }
-
-        /// <summary>
-        /// Day, date and time string: Saturday, March 1 - 12:01 pm
-        /// </summary>
-        static public string FullDateTimeString (DateTime d)
-        {
-            NcAssert.True (DateTimeKind.Local != d.Kind);
-            return d.LocalT ().ToString ("ddd, MMM d - h:mm ") + d.LocalT ().ToString ("tt").ToLower ();
-
-        }
-
-        static public string FullDateYearTimeString (DateTime d)
-        {
-            NcAssert.True (DateTimeKind.Local != d.Kind);
-            return d.LocalT ().ToString ("ddd, MMM d, yyyy - h:mm ") + d.LocalT ().ToString ("tt").ToLower ();
-        }
-
-        static public string UniversalFullDateTimeString (DateTime d)
-        {
-            return d.LocalT ().ToString ("U");
-        }
-
-        /// <summary>
-        /// Day and date: Sat, Mar 1
-        /// </summary>
-        static public string FullDateString (DateTime d)
-        {
-            NcAssert.True (DateTimeKind.Local != d.Kind);
-            return d.LocalT ().ToString ("ddd, MMM d");
-        }
-
-        /// <summary>
-        /// Day and date: Sat, Mar 1
-        /// </summary>
-        static public string FullDateSpelledOutString (DateTime d)
-        {
-            NcAssert.True (DateTimeKind.Local != d.Kind);
-            return d.LocalT ().ToString ("dddd, MMMM d");
-        }
-
-        /// <summary>
-        /// Day, date and year: Sat, Mar 1, 2014
-        /// </summary>
-        static public string FullDateYearString (DateTime d)
-        {
-            NcAssert.True (DateTimeKind.Local != d.Kind);
-            return d.LocalT ().ToString ("ddd, MMM d, yyyy");
-        }
-
-        /// <summary>
-        /// Short date: 3/1/14
-        /// </summary>
-        static public string ShortDateString (DateTime d)
-        {
-            NcAssert.True (DateTimeKind.Local != d.Kind);
-            return d.LocalT ().ToString ("M/d/yy");
-        }
-
-        /// <summary>
-        /// Full day and date string: Saturday, March 1
-        /// </summary>
-        static public string ExtendedDateString (DateTime d)
-        {
-            NcAssert.True (DateTimeKind.Local != d.Kind);
-            return d.LocalT ().ToString ("dddd, MMMM d");
-        }
-
-        /// <summary>
-        /// Time: 3:00 pm
-        /// </summary>
-        static public string FullTimeString (DateTime d)
-        {
-            NcAssert.True (DateTimeKind.Local != d.Kind);
-            return d.LocalT ().ToString ("t").ToLower ();
-        }
-
-        /// <summary>
-        /// Month: March or March 2016
-        /// </summary>
-        static public string PrettyMonthLabel (DateTime d)
-        {
-            return (d.Year == DateTime.UtcNow.Year) ? d.ToString ("MMMM") : d.ToString ("Y");
-        }
-
-        /// <summary>
         /// Display a date that may or may not have a year associated with it, and for which the
         /// day of the week is not important. For example, "August 27" or "August 27, 2000".
         /// iOS uses a date in 1604 when the year doesn't matter, so leave off the year when the
@@ -215,10 +100,180 @@ namespace NachoCore.Utils
         static public string BirthdayOrAnniversary (DateTime d)
         {
             if (d.Year < 1700) {
-                return d.ToString ("MMMM d");
+                return d.ToString ("M");
             } else {
-                return d.ToString ("MMMM d, yyyy");
+                return d.ToString (CollapseSpaces (DTFormat.LongDatePattern.Replace ("dddd", "")));
             }
+        }
+
+        /// <summary>
+        /// "October" or "October 2015"
+        /// </summary>
+        static public string LongMonthYear (DateTime date)
+        {
+            date = date.ToLocalTime ();
+            if (date.Year == DateTime.Now.Year) {
+                return date.ToString ("MMMM");
+            } else {
+                return date.ToString ("Y");
+            }
+        }
+
+        /// <summary>
+        /// "October 2015"
+        /// </summary>
+        static public string LongMonthForceYear (DateTime date)
+        {
+            return date.ToLocalTime ().ToString ("Y");
+        }
+
+        /// <summary>
+        /// "Wednesday, October 21" or "Wednesday, October 21, 2015"
+        /// </summary>
+        static public string LongFullDate (DateTime date)
+        {
+            date = date.ToLocalTime ();
+            string format = DTFormat.LongDatePattern;
+            // We want "October 7" instead of "October 07".
+            format = format.Replace ("MMMM dd", "MMMM d");
+            if (date.Year == DateTime.Now.Year) {
+                // Remove the year
+                format = CollapseSpaces (format.Replace ("yyyy", ""));
+            }
+            return date.ToString (format);
+        }
+
+        /// <summary>
+        /// "October 21"
+        /// </summary>
+        static public string LongMonthDay (DateTime date)
+        {
+            return date.ToLocalTime ().ToString (DTFormat.MonthDayPattern.Replace ("MMMM dd", "MMMM d"));
+        }
+
+        /// <summary>
+        /// "October 21, 2015"
+        /// </summary>
+        static public string LongMonthDayYear (DateTime date)
+        {
+            return date.ToLocalTime ().ToString (CollapseSpaces (DTFormat.LongDatePattern.Replace ("MMMM dd", "MMMM d").Replace ("dddd", "")));
+        }
+
+        /// <summary>
+        /// "October 21" or "October 21, 2015"
+        /// </summary>
+        static public string LongDate (DateTime date)
+        {
+            if (date.ToLocalTime ().Year == DateTime.Now.Year) {
+                return LongMonthDay (date);
+            } else {
+                return LongMonthDayYear (date);
+            }
+        }
+
+        /// <summary>
+        /// "Wed, Oct 21" or "Wed, Oct 21, 2015"
+        /// </summary>
+        static public string MediumFullDate (DateTime date)
+        {
+            date = date.ToLocalTime ();
+            string format = DTFormat.LongDatePattern;
+            // We want "October 7" instead of "October 07".
+            format = format.Replace ("MMMM dd", "MMMM d");
+            if (date.Year == DateTime.Now.Year) {
+                // Remove the year
+                format = CollapseSpaces (format.Replace ("yyyy", ""));
+            }
+            format = format.Replace ("dddd", "ddd").Replace ("MMMM", "MMM");
+            return date.ToString (format);
+        }
+
+        /// <summary>
+        /// "Oct 21"
+        /// </summary>
+        static public string MediumMonthDay (DateTime date)
+        {
+            return date.ToLocalTime ().ToString (DTFormat.MonthDayPattern.Replace ("MMMM dd", "MMMM d").Replace ("MMMM", "MMM"));
+        }
+
+        /// <summary>
+        /// "Oct 21, 2015"
+        /// </summary>
+        static public string MediumMonthDayYear (DateTime date)
+        {
+            return date.ToLocalTime ().ToString (CollapseSpaces (DTFormat.LongDatePattern.Replace ("MMMM dd", "MMMM d").Replace ("dddd", "").Replace ("MMMM", "MMM")));
+        }
+
+        /// <summary>
+        /// "Oct 21" or "Oct 21, 2015"
+        /// </summary>
+        static public string MediumDate (DateTime date)
+        {
+            if (date.ToLocalTime ().Year == DateTime.Now.Year) {
+                return MediumMonthDay (date);
+            } else {
+                return MediumMonthDayYear (date);
+            }
+        }
+
+        /// <summary>
+        /// "10/21/15"
+        /// </summary>
+        static public string ShortDate (DateTime date)
+        {
+            return date.ToLocalTime ().ToString (DTFormat.ShortDatePattern.Replace ("yyyy", "yy"));
+        }
+
+        /// <summary>
+        /// "4:28 pm" or "16:28"
+        /// </summary>
+        static public string Time (DateTime time)
+        {
+            time = time.ToLocalTime ();
+            string result = time.ToString ("t");
+            if ("AM" == DTFormat.AMDesignator && "PM" == DTFormat.PMDesignator) {
+                result = result.Replace ("AM", "am").Replace ("PM", "pm");
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// "Wed, Oct 21 - 4:28 pm" or "Wed, Oct 21, 2015 - 4:28 pm"
+        /// </summary>
+        static public string MediumFullDateTime (DateTime dateTime)
+        {
+            return string.Format ("{0} - {1}", MediumFullDate (dateTime), Time (dateTime));
+        }
+
+        /// <summary>
+        /// "Wednesday 4:28 pm"
+        /// </summary>
+        static public string LongDayTime (DateTime dateTime)
+        {
+            return string.Format ("{0} {1}", dateTime.ToLocalTime ().ToString ("dddd"), Time (dateTime));
+        }
+
+        static public string UniversalFullDateTime (DateTime d)
+        {
+            return d.ToLocalTime ().ToString ("U");
+        }
+
+        static private DateTimeFormatInfo DTFormat {
+            get {
+                return CultureInfo.CurrentCulture.DateTimeFormat;
+            }
+        }
+
+        static private string CollapseSpaces (string format)
+        {
+            string result = Regex.Replace (format.Trim (), @"\s+", " ");
+            if (result.EndsWith (",")) {
+                result = result.Substring (0, result.Length - 1).Trim ();
+            }
+            if (result.StartsWith(",")) {
+                result = result.Substring (1).Trim ();
+            }
+            return result;
         }
 
         /// <summary>
@@ -331,7 +386,7 @@ namespace NachoCore.Utils
         /// </summary>
         static public string CompactDateString (DateTime Date)
         {
-            var local = Date.LocalT ();
+            var local = Date.ToLocalTime ();
             var diff = DateTime.Now - local;
             if (diff < TimeSpan.FromMinutes (60)) {
                 return String.Format ("{0:n0}m", diff.TotalMinutes);
@@ -346,16 +401,6 @@ namespace NachoCore.Utils
                 return local.ToString ("dddd");
             }
             return local.ToShortDateString ();
-        }
-
-        static public string ShortTimeString (DateTime Date)
-        {
-            return Date.LocalT ().ToString ("t");
-        }
-
-        static public string ShortDayTimeString (DateTime Date)
-        {
-            return Date.LocalT ().ToString ("dddd") + " " + Date.LocalT ().ToString ("t");
         }
 
         // The display name of the account is a nickname for
@@ -379,12 +424,11 @@ namespace NachoCore.Utils
 
         static public string ReminderDate (DateTime utcDueDate)
         {
-            var local = utcDueDate.LocalT ();
             var duration = System.DateTime.UtcNow - utcDueDate;
-            if (365 < Math.Abs (duration.Days)) {
-                return local.ToString ("MMM dd, yyyy"); // FIXME: Localize
+            if (180 < Math.Abs (duration.Days)) {
+                return MediumMonthDayYear (utcDueDate);
             } else {
-                return local.ToString ("MMM dd, h:mm tt"); // FIXME: Localize
+                return string.Format ("{0} - {1}", MediumMonthDay (utcDueDate), Time (utcDueDate));
             }
         }
 
@@ -487,44 +531,55 @@ namespace NachoCore.Utils
 
         protected static string DayOfWeekAsString (NcDayOfWeek dow)
         {
+            var fullNames = DTFormat.DayNames;
+
             switch (dow) {
+
             case NcDayOfWeek.Sunday:
-                return "Sunday";
+                return fullNames [(int)DayOfWeek.Sunday];
+            
             case NcDayOfWeek.Monday:
-                return "Monday";
+                return fullNames [(int)DayOfWeek.Monday];
+            
             case NcDayOfWeek.Tuesday:
-                return "Tuesday";
+                return fullNames [(int)DayOfWeek.Tuesday];
+            
             case NcDayOfWeek.Wednesday:
-                return "Wednesday";
+                return fullNames [(int)DayOfWeek.Wednesday];
+            
             case NcDayOfWeek.Thursday:
-                return "Thursday";
+                return fullNames [(int)DayOfWeek.Thursday];
+            
             case NcDayOfWeek.Friday:
-                return "Friday";
+                return fullNames [(int)DayOfWeek.Friday];
+            
             case NcDayOfWeek.Saturday:
-                return "Saturday";
+                return fullNames [(int)DayOfWeek.Saturday];
+            
             default:
                 // A combination of days.
+                var shortNames = DTFormat.AbbreviatedDayNames;
                 var dayList = new List<string> ();
                 if (0 != (dow & NcDayOfWeek.Sunday)) {
-                    dayList.Add ("Sun");
+                    dayList.Add (shortNames [(int)DayOfWeek.Sunday]);
                 }
                 if (0 != (dow & NcDayOfWeek.Monday)) {
-                    dayList.Add ("Mon");
+                    dayList.Add (shortNames [(int)DayOfWeek.Monday]);
                 }
                 if (0 != (dow & NcDayOfWeek.Tuesday)) {
-                    dayList.Add ("Tue");
+                    dayList.Add (shortNames [(int)DayOfWeek.Tuesday]);
                 }
                 if (0 != (dow & NcDayOfWeek.Wednesday)) {
-                    dayList.Add ("Wed");
+                    dayList.Add (shortNames [(int)DayOfWeek.Wednesday]);
                 }
                 if (0 != (dow & NcDayOfWeek.Thursday)) {
-                    dayList.Add ("Thu");
+                    dayList.Add (shortNames [(int)DayOfWeek.Thursday]);
                 }
                 if (0 != (dow & NcDayOfWeek.Friday)) {
-                    dayList.Add ("Fri");
+                    dayList.Add (shortNames [(int)DayOfWeek.Friday]);
                 }
                 if (0 != (dow & NcDayOfWeek.Saturday)) {
-                    dayList.Add ("Sat");
+                    dayList.Add (shortNames [(int)DayOfWeek.Saturday]);
                 }
                 return MakeCommaSeparatedList (dayList);
             }
@@ -597,7 +652,7 @@ namespace NachoCore.Utils
             case NcRecurrenceType.Yearly:
                 string dateString;
                 try {
-                    dateString = new DateTime (2004, r.MonthOfYear, r.DayOfMonth).ToString ("MMM d");
+                    dateString = LongMonthDay (new DateTime (2004, r.MonthOfYear, r.DayOfMonth, 0, 0, 0, DateTimeKind.Local));
                 } catch (ArgumentOutOfRangeException) {
                     dateString = string.Format ("{0}/{1}", r.MonthOfYear, r.DayOfMonth);
                 }

--- a/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
@@ -258,24 +258,13 @@ namespace NachoClient.AndroidClient
 
         private void ConfigureStartEndFields ()
         {
-            DateTime now = DateTime.Now;
-            bool differentYear = now.Year != startTime.Year || now.Year != endTime.Year;
-            string format;
             if (allDayField.Checked) {
-                if (differentYear) {
-                    format = "ddd, MMM d, yyyy";
-                } else {
-                    format = "ddd, MMM d";
-                }
+                startField.Text = Pretty.MediumFullDate (startTime);
+                endField.Text = Pretty.MediumFullDate (endTime);
             } else {
-                if (differentYear) {
-                    format = "ddd, MMM d, yyyy - h:mm tt";
-                } else {
-                    format = "ddd, MMM d - h:mm tt";
-                }
+                startField.Text = Pretty.MediumFullDateTime (startTime);
+                endField.Text = Pretty.MediumFullDateTime (endTime);
             }
-            startField.Text = startTime.ToString (format);
-            endField.Text = endTime.ToString (format);
 
             if (ValidStartEndTimes ()) {
                 endField.SetTextColor (titleField.TextColors);

--- a/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
@@ -103,7 +103,7 @@ namespace NachoClient.AndroidClient
             detail.Refresh ();
 
             var buttonBarTitleView = view.FindViewById<TextView> (Resource.Id.title);
-            buttonBarTitleView.Text = detail.StartTime.ToLocalTime ().ToString ("MMMMM yyyy");
+            buttonBarTitleView.Text = Pretty.LongMonthForceYear (detail.StartTime);
             buttonBarTitleView.Visibility = ViewStates.Visible;
 
             var editButton = view.FindViewById<ImageView> (Resource.Id.right_button1);

--- a/NachoClient.Android/NachoUI.Android/Support/Bind.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/Bind.cs
@@ -81,7 +81,7 @@ namespace NachoClient.AndroidClient
             subjectView.Text = Pretty.SubjectString (message.Subject);
             subjectView.Visibility = ViewStates.Visible;
 
-            dateView.Text = Pretty.FullDateTimeString (message.DateReceived);
+            dateView.Text = Pretty.MediumFullDateTime (message.DateReceived);
             dateView.Visibility = ViewStates.Visible;
 
             if (message.cachedHasAttachments) {
@@ -187,7 +187,7 @@ namespace NachoClient.AndroidClient
             if (detailView.SpecificItem.AllDayEvent) {
                 startAndDuration = "ALL DAY";
             } else {
-                var start = Pretty.ShortTimeString (detailView.SpecificItem.StartTime);
+                var start = Pretty.Time (detailView.SpecificItem.StartTime);
                 if (detailView.SpecificItem.EndTime > detailView.SpecificItem.StartTime) {
                     var duration = Pretty.CompactDuration (detailView.SpecificItem.StartTime, detailView.SpecificItem.EndTime);
                     startAndDuration = String.Join (" - ", new string[] { start, duration });
@@ -217,7 +217,7 @@ namespace NachoClient.AndroidClient
             dayOfWeekView.Text = date.ToString ("dddd");
 
             var monthDayView = view.FindViewById<TextView> (Resource.Id.event_date_month_day);
-            monthDayView.Text = date.ToString ("MMMM d, yyyy");
+            monthDayView.Text = Pretty.LongMonthDayYear (date);
 
             var addButton = view.FindViewById<ImageView> (Resource.Id.event_date_add);
             addButton.SetTag (Resource.Id.event_date_add, new JavaObjectWrapper<DateTime> () { Item = date });
@@ -244,12 +244,12 @@ namespace NachoClient.AndroidClient
 
             var startString = "";
             if (c.AllDayEvent) {
-                startString = "ALL DAY " + Pretty.FullDateSpelledOutString (currentEvent.GetStartTimeUtc ());
+                startString = "ALL DAY " + Pretty.LongFullDate (currentEvent.GetStartTimeUtc ());
             } else {
                 if ((currentEvent.GetStartTimeUtc () - DateTime.UtcNow).TotalHours < 12) {
-                    startString = Pretty.ShortTimeString (currentEvent.GetStartTimeUtc ());
+                    startString = Pretty.Time (currentEvent.GetStartTimeUtc ());
                 } else {
-                    startString = Pretty.ShortDayTimeString (currentEvent.GetStartTimeUtc ());
+                    startString = Pretty.LongDayTime (currentEvent.GetStartTimeUtc ());
                 }
             }
 

--- a/NachoClient.Android/NachoUI.Android/Support/DateTimePicker.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/DateTimePicker.cs
@@ -6,6 +6,7 @@ using Android.Content;
 using Android.Views;
 using Android.Widget;
 using NachoCore.Utils;
+using System.Globalization;
 
 namespace NachoClient.AndroidClient
 {
@@ -46,6 +47,7 @@ namespace NachoClient.AndroidClient
             var timePicker = view.FindViewById<TimePicker> (Resource.Id.time_picker);
             timePicker.CurrentHour = (Java.Lang.Integer)startDate.Hour;
             timePicker.CurrentMinute = (Java.Lang.Integer)startDate.Minute;
+            timePicker.SetIs24HourView (new Java.Lang.Boolean (!CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern.Contains ("tt")));
             timePicker.Visibility = showTimePicker ? ViewStates.Visible : ViewStates.Gone;
 
             var setButton = view.FindViewById<Button> (Resource.Id.date_time_set);

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -859,7 +859,7 @@ namespace NachoClient.iOS
                                 } else {
                                     subject = "Event at ";
                                 }
-                                var msg = subject + Pretty.FullDateTimeString (eventItem.GetStartTimeUtc ());
+                                var msg = subject + Pretty.MediumFullDateTime (eventItem.GetStartTimeUtc ());
                                 UIAlertView alert = new UIAlertView ("Reminder", msg, null, "OK", null);
 
                                 alert.Show ();

--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -776,9 +776,9 @@ namespace NachoClient.iOS
 
             //start date
             if (c.AllDayEvent) {
-                startDateLabel.Text = Pretty.FullDateString (c.StartTime);
+                startDateLabel.Text = Pretty.MediumFullDate (c.StartTime);
             } else {
-                startDateLabel.Text = Pretty.FullDateTimeString (c.StartTime);
+                startDateLabel.Text = Pretty.MediumFullDateTime (c.StartTime);
             }
             startDate = c.StartTime;
             startDateLabel.SizeToFit ();
@@ -787,10 +787,10 @@ namespace NachoClient.iOS
             //end date
             if (c.AllDayEvent) {
                 var endDay = CalendarHelper.ReturnAllDayEventEndTime (c.EndTime);
-                endDateLabel.Text = Pretty.FullDateString (endDay);
+                endDateLabel.Text = Pretty.MediumFullDate (endDay);
                 endDate = endDay;
             } else {
-                endDateLabel.Text = Pretty.FullDateTimeString (c.EndTime);
+                endDateLabel.Text = Pretty.MediumFullDateTime (c.EndTime);
                 endDate = c.EndTime;
             }
             endDateLabel.SizeToFit ();
@@ -1450,9 +1450,9 @@ namespace NachoClient.iOS
             eventEditStarted = true;
             DateTime date = startDatePicker.Date.ToDateTime ();
             if (allDaySwitch.On) {
-                startDateLabel.Text = Pretty.FullDateString (date);
+                startDateLabel.Text = Pretty.MediumFullDate (date);
             } else {
-                startDateLabel.Text = Pretty.FullDateTimeString (date);
+                startDateLabel.Text = Pretty.MediumFullDateTime (date);
             }
             startDate = date;
             if (!endChanged && !allDaySwitch.On) {
@@ -1460,7 +1460,7 @@ namespace NachoClient.iOS
                 if (null != endDatePicker) {
                     endDatePicker.Date = endDate.ToNSDate ();
                 }
-                endDateLabel.Text = Pretty.FullTimeString (endDate);
+                endDateLabel.Text = Pretty.Time (endDate);
                 endDateLabel.SizeToFit ();
                 endDateLabel.Frame = new CGRect (SCREEN_WIDTH - endDateLabel.Frame.Width - 15, 12.438f, endDateLabel.Frame.Width, TEXT_LINE_HEIGHT);
                 endDateLabel.TextColor = A.Color_NachoTeal;
@@ -1484,9 +1484,9 @@ namespace NachoClient.iOS
             endChanged = true;
             DateTime date = endDatePicker.Date.ToDateTime ();
             if (allDaySwitch.On) {
-                endDateLabel.Text = Pretty.FullDateString (date);
+                endDateLabel.Text = Pretty.MediumFullDate (date);
             } else {
-                endDateLabel.Text = Pretty.FullDateTimeString (date);
+                endDateLabel.Text = Pretty.MediumFullDateTime (date);
             }
             endDate = date;
             endDateLabel.SizeToFit ();
@@ -1505,10 +1505,10 @@ namespace NachoClient.iOS
         {
             eventEditStarted = true;
             if (allDaySwitch.On) {
-                startDateLabel.Text = Pretty.FullDateString (startDate);
+                startDateLabel.Text = Pretty.MediumFullDate (startDate);
                 startDateLabel.SizeToFit ();
                 startDateLabel.Frame = new CGRect (SCREEN_WIDTH - startDateLabel.Frame.Width - 15, 12.438f, startDateLabel.Frame.Width, TEXT_LINE_HEIGHT);
-                endDateLabel.Text = Pretty.FullDateString (endDate);
+                endDateLabel.Text = Pretty.MediumFullDate (endDate);
                 endDateLabel.SizeToFit ();
                 endDateLabel.Frame = new CGRect (SCREEN_WIDTH - endDateLabel.Frame.Width - 15, 12.438f, endDateLabel.Frame.Width, TEXT_LINE_HEIGHT);
                 strikethrough.Frame = new CGRect (SCREEN_WIDTH - endDateLabel.Frame.Width - 15, CELL_HEIGHT / 2, endDateLabel.Frame.Width, 1);
@@ -1530,14 +1530,14 @@ namespace NachoClient.iOS
                     startDatePicker.Date = startDate.ToNSDate ();
                     startDatePicker.Mode = UIDatePickerMode.DateAndTime;
                 }
-                startDateLabel.Text = Pretty.FullDateTimeString (startDate);
+                startDateLabel.Text = Pretty.MediumFullDateTime (startDate);
                 startDateLabel.SizeToFit ();
                 startDateLabel.Frame = new CGRect (SCREEN_WIDTH - startDateLabel.Frame.Width - 15, 12.438f, startDateLabel.Frame.Width, TEXT_LINE_HEIGHT);
                 if (null != endDatePicker) {
                     endDatePicker.Date = endDate.ToNSDate ();
                     endDatePicker.Mode = UIDatePickerMode.DateAndTime;
                 }
-                endDateLabel.Text = Pretty.FullDateTimeString (endDate);
+                endDateLabel.Text = Pretty.MediumFullDateTime (endDate);
                 endDateLabel.SizeToFit ();
                 endDateLabel.Frame = new CGRect (SCREEN_WIDTH - endDateLabel.Frame.Width - 15, 12.438f, endDateLabel.Frame.Width, TEXT_LINE_HEIGHT);
 

--- a/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventViewController.cs
@@ -500,7 +500,7 @@ namespace NachoClient.iOS
 
             ConfigureRsvpBar ();
 
-            NavigationItem.Title = detail.StartTime.ToLocalTime ().ToString ("Y");
+            NavigationItem.Title = Pretty.LongMonthForceYear (detail.StartTime);
 
             var titleLabel = View.ViewWithTag ((int)TagType.EVENT_TITLE_LABEL_TAG) as UILabel;
             titleLabel.Text = detail.SpecificItem.GetSubject ();
@@ -1264,7 +1264,7 @@ namespace NachoClient.iOS
             if (null == Note) {
                 Note = new McNote ();
                 Note.AccountId = detail.Account.Id;
-                Note.DisplayName = (detail.SpecificItem.GetSubject () + " - " + Pretty.ShortDateString (DateTime.UtcNow));
+                Note.DisplayName = (detail.SpecificItem.GetSubject () + " - " + Pretty.ShortDate (DateTime.UtcNow));
                 Note.TypeId = detail.SeriesItem.Id;
                 Note.noteType = McNote.NoteType.Event;
                 Note.noteContent = noteText;

--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -467,7 +467,7 @@ namespace NachoClient.iOS
             cursor.LayoutView (subjectLabelView);
 
             var receivedLabelView = View.ViewWithTag ((int)TagType.RECEIVED_DATE_TAG) as UILabel;
-            receivedLabelView.Text = Pretty.FullDateTimeString (message.DateReceived);
+            receivedLabelView.Text = Pretty.MediumFullDateTime (message.DateReceived);
             cursor.LayoutView (receivedLabelView);
 
             // Reminder image view and label

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyCalendarView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyCalendarView.cs
@@ -187,20 +187,20 @@ namespace NachoClient.iOS
             DateTime end = meetingInfo.EndTime;
             string location = meetingInfo.Location;
             // When label, image, and detail
-            whenLabel.Text = Pretty.ExtendedDateString (start);
+            whenLabel.Text = Pretty.LongFullDate (start);
             if (meetingInfo.AllDayEvent) {
                 durationLabel.Text = "all day event";
                 if ((start.LocalT ().DayOfYear) + 1 != end.LocalT ().DayOfYear) {
                     durationLabel.Text = string.Format ("All day from {0} \nuntil {1}",
-                        Pretty.FullDateYearString (start), Pretty.FullDateYearString (end));
+                        Pretty.MediumFullDate (start), Pretty.MediumFullDate (end));
                 }
             } else {
                 if (start.LocalT ().DayOfYear == end.LocalT ().DayOfYear) {
                     durationLabel.Text = string.Format ("from {0} until {1}",
-                        Pretty.FullTimeString (start), Pretty.FullTimeString (end));
+                        Pretty.Time (start), Pretty.Time (end));
                 } else {
                     durationLabel.Text = string.Format ("from {0} until {1}",
-                        Pretty.FullTimeString (start), Pretty.FullDateTimeString (end));
+                        Pretty.Time (start), Pretty.MediumFullDateTime (end));
                 }
             }
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/BodyWebView.cs
@@ -230,12 +230,9 @@ namespace NachoClient.iOS
     /// </summary>
     public class BodyPlainWebView : BodyHtmlWebView
     {
-        private string text;
-
         public BodyPlainWebView (nfloat Y, nfloat preferredWidth, nfloat initialHeight, Action sizeChangedCallback, string text, NSUrl baseUrl, BodyWebView.LinkSelectedCallback onLinkSelected)
             : base (Y, preferredWidth, initialHeight, sizeChangedCallback, baseUrl, onLinkSelected)
         {
-            this.text = text;
             var serializer = new HtmlTextDeserializer ();
             var doc = serializer.Deserialize (text);
             string html = "";

--- a/NachoClient.iOS/NachoUI.iOS/Support/CalendarTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/CalendarTableViewSource.cs
@@ -284,7 +284,7 @@ namespace NachoClient.iOS
             if (c.AllDayEvent) {
                 startAndDuration = "ALL DAY";
             } else {
-                var start = Pretty.ShortTimeString (e.GetStartTimeUtc ());
+                var start = Pretty.Time (e.GetStartTimeUtc ());
                 if (e.EndTime > e.StartTime) {
                     var duration = Pretty.CompactDuration (e.GetStartTimeUtc (), e.GetEndTimeUtc ());
                     startAndDuration = String.Join (" - ", new string[] { start, duration });
@@ -428,7 +428,7 @@ namespace NachoClient.iOS
             view.AddSubview (addButton);
 
             dayLabelView.Text = date.ToString ("dddd");
-            dateLabelView.Text = date.ToString ("MMMMM d, yyyy");
+            dateLabelView.Text = Pretty.LongMonthDayYear (date);
             bigNumberView.Text = date.Day.ToString ();
 
             return view;

--- a/NachoClient.iOS/NachoUI.iOS/Support/DateBarView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/DateBarView.cs
@@ -191,7 +191,7 @@ namespace NachoClient.iOS
 
         public void UpdateMonthLabel ()
         {
-            monthLabelView.Text = Pretty.PrettyMonthLabel (this.ViewDate);
+            monthLabelView.Text = Pretty.LongMonthYear (this.ViewDate);
         }
 
         public DateTime GetFirstDay (DateTime date)

--- a/NachoClient.iOS/NachoUI.iOS/Support/FilesTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/FilesTableViewSource.cs
@@ -550,7 +550,7 @@ namespace NachoClient.iOS
         {
             string dateText = "Date unknown";
             if (date != DateTime.MinValue) {
-                dateText = Pretty.FullDateTimeString (date);
+                dateText = Pretty.MediumFullDateTime (date);
             }
             return dateText;
         }

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
@@ -231,12 +231,12 @@ namespace NachoClient.iOS
 
             var startString = "";
             if (c.AllDayEvent) {
-                startString = "ALL DAY " + Pretty.FullDateSpelledOutString (currentEvent.GetStartTimeUtc ());
+                startString = "ALL DAY " + Pretty.LongFullDate (currentEvent.GetStartTimeUtc ());
             } else {
                 if ((currentEvent.GetStartTimeUtc () - DateTime.UtcNow).TotalHours < 12) {
-                    startString = Pretty.ShortTimeString (currentEvent.GetStartTimeUtc ());
+                    startString = Pretty.Time (currentEvent.GetStartTimeUtc ());
                 } else {
-                    startString = Pretty.ShortDayTimeString (currentEvent.GetStartTimeUtc ());
+                    startString = Pretty.LongDayTime (currentEvent.GetStartTimeUtc ());
                 }
             }
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageHeaderView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageHeaderView.cs
@@ -149,7 +149,7 @@ namespace NachoClient.iOS
 
             // Received label view
             var receivedLabelView = this.ViewWithTag (RECEIVED_DATE_TAG) as UILabel;
-            receivedLabelView.Text = Pretty.FullDateTimeString (message.DateReceived);
+            receivedLabelView.Text = Pretty.MediumFullDateTime (message.DateReceived);
             receivedLabelView.SizeToFit ();
             receivedLabelView.Hidden = false;
 
@@ -196,7 +196,7 @@ namespace NachoClient.iOS
 
             // Received label view
             var receivedLabelView = this.ViewWithTag (RECEIVED_DATE_TAG) as UILabel;
-            receivedLabelView.Text = Pretty.FullDateTimeString (message.DateReceived);
+            receivedLabelView.Text = Pretty.MediumFullDateTime (message.DateReceived);
             receivedLabelView.SizeToFit ();
             receivedLabelView.Hidden = false;
 


### PR DESCRIPTION
Localization of dates and times within the app was inconsistent.  When
using the app in a locale with 24-hour time, the app would sometimes
display the time correctly as "16:28", but other times would show it
as "4:28 pm".  There were similar problems displaying dates.

Clean up the code that displays dates and times to always localize
them correctly.  The methods in class Pretty for displaying dates are
times were rewritten to have more consistent names and more correct
behavior.  All uses of DateTime.ToString(string format) in the app
were changed to use the methods in class Pretty if the result was
displayed to the user.

(A couple of other compiler warnings unrelated to date/time were
fixed.)

Fix nachocove/qa#415
