### PR TITLE
Cleanup event related activities and fragments

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -562,6 +562,7 @@
     <Compile Include="NachoUI.Android\Activities\ContactsListFragment.cs" />
     <Compile Include="NachoUI.Android\Activities\SettingsActivity.cs" />
     <Compile Include="NachoUI.Android\Activities\SettingsFragment.cs" />
+    <Compile Include="NachoUI.Android\Activities\EventViewActivity.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\AboutAssets.txt" />
@@ -1364,5 +1365,6 @@
     <AndroidResource Include="Resources\layout\NoteActivity.axml" />
     <AndroidResource Include="Resources\layout\SettingsActivity.axml" />
     <AndroidResource Include="Resources\layout\SettingsFragment.axml" />
+    <AndroidResource Include="Resources\layout\EventViewActivity.axml" />
   </ItemGroup>
 </Project>

--- a/NachoClient.Android/NachoUI.Android/Activities/CalendarActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/CalendarActivity.cs
@@ -19,42 +19,11 @@ namespace NachoClient.AndroidClient
     [Activity (Label = "CalendarActivity")]            
     public class CalendarActivity : NcTabBarActivity
     {
-        EventViewFragment eventViewFragment;
-        EventListFragment eventListFragment;
-
+        // All of the work happens in NcTabBarActivity and in EventListFragment.  The only thing that
+        // happens in this class is to specify the layout to use.
         protected override void OnCreate (Bundle bundle)
         {
             base.OnCreate (bundle, Resource.Layout.CalendarActivity);
-
-            eventListFragment = EventListFragment.newInstance ();
-            eventListFragment.onEventClick += EventListFragment_onEventClick;
-            FragmentManager.BeginTransaction ().Add (Resource.Id.content, eventListFragment).AddToBackStack ("Events").Commit ();
-        }
-
-        void EventListFragment_onEventClick (object sender, McEvent ev)
-        {
-            Log.Info (Log.LOG_UI, "EventListFragment_onEventClick: {0}", ev);
-            eventViewFragment = EventViewFragment.newInstance (ev);
-            // Switch the view from the event list to the event detail.
-            this.FragmentManager.BeginTransaction ()
-                .Add (Resource.Id.content, eventViewFragment)
-                .Remove (eventListFragment)
-                .AddToBackStack ("View")
-                .Commit ();
-        }
-
-        public override void OnBackPressed ()
-        {
-            base.OnBackPressed ();
-            var f = FragmentManager.FindFragmentById (Resource.Id.content);
-            if (f is EventViewFragment) {
-                this.FragmentManager.PopBackStack ();
-            }
-        }
-
-        protected override void OnSaveInstanceState (Bundle outState)
-        {
-            base.OnSaveInstanceState (outState);
         }
     }
 }

--- a/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
@@ -43,16 +43,6 @@ namespace NachoClient.AndroidClient
         ImageView addButton;
         ImageView todayButton;
 
-        private bool firstTime = true;
-
-        public event EventHandler<McEvent> onEventClick;
-
-        public static EventListFragment newInstance ()
-        {
-            var fragment = new EventListFragment ();
-            return fragment;
-        }
-
         public override void OnCreate (Bundle savedInstanceState)
         {
             base.OnCreate (savedInstanceState);
@@ -129,12 +119,9 @@ namespace NachoClient.AndroidClient
                 return false;
             });
 
-            if (firstTime) {
-                firstTime = false;
-                eventListAdapter.Refresh (() => {
-                    listView.SetSelection (eventListAdapter.PositionForToday);
-                });
-            }
+            eventListAdapter.Refresh (() => {
+                listView.SetSelection (eventListAdapter.PositionForToday);
+            });
 
             return view;
         }
@@ -146,9 +133,7 @@ namespace NachoClient.AndroidClient
 
         void ListView_ItemClick (object sender, Android.Widget.AdapterView.ItemClickEventArgs e)
         {
-            if (null != onEventClick) {
-                onEventClick (this, eventListAdapter [e.Position]);
-            }
+            StartActivity (EventViewActivity.ShowEventIntent (Activity, eventListAdapter [e.Position]));
         }
 
         void AddButton_Click (object sender, EventArgs e)

--- a/NachoClient.Android/NachoUI.Android/Activities/EventViewActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventViewActivity.cs
@@ -1,0 +1,49 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using NachoCore.Model;
+using NachoCore.Utils;
+
+namespace NachoClient.AndroidClient
+{
+    [Activity (Label = "EventViewActivity")]            
+    public class EventViewActivity : NcActivity, IEventViewFragmentOwner
+    {
+        private const string EXTRA_EVENT = "com.nachocove.nachomail.EXTRA_EVENT";
+
+        private McEvent ev;
+
+        protected override void OnCreate (Bundle bundle)
+        {
+            base.OnCreate (bundle);
+            this.ev = IntentHelper.RetreiveValue<McEvent> (Intent.GetStringExtra (EXTRA_EVENT));
+            SetContentView (Resource.Layout.EventViewActivity);
+        }
+
+        McEvent IEventViewFragmentOwner.EventToView {
+            get {
+                return this.ev;
+            }
+        }
+
+        public static Intent ShowEventIntent (Context context, McEvent ev)
+        {
+            var intent = new Intent (context, typeof(EventViewActivity));
+            intent.SetAction (Intent.ActionView);
+            intent.PutExtra (EXTRA_EVENT, IntentHelper.StoreValue (ev));
+            return intent;
+        }
+    }
+}
+

--- a/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
@@ -17,6 +17,11 @@ using NachoCore;
 
 namespace NachoClient.AndroidClient
 {
+    public interface IEventViewFragmentOwner
+    {
+        McEvent EventToView { get; }
+    }
+
     public class EventViewFragment : Fragment
     {
         private const int EDIT_REQUEST_CODE = 1;
@@ -27,25 +32,19 @@ namespace NachoClient.AndroidClient
 
         private View view;
 
-        public static EventViewFragment newInstance (McEvent ev)
-        {
-            var fragment = new EventViewFragment ();
-            fragment.ev = ev;
-            fragment.detail = new NcEventDetail (ev);
-            return fragment;
-        }
-
-        public override void OnCreate (Bundle savedInstanceState)
-        {
-            base.OnCreate (savedInstanceState);
-        }
-
         public override View OnCreateView (LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             view = inflater.Inflate (Resource.Layout.EventViewFragment, container, false);
             BindListeners ();
-            BindEventView ();
             return view;
+        }
+
+        public override void OnActivityCreated (Bundle savedInstanceState)
+        {
+            base.OnActivityCreated (savedInstanceState);
+            this.ev = ((IEventViewFragmentOwner)Activity).EventToView;
+            this.detail = new NcEventDetail (ev);
+            BindEventView ();
         }
 
         public override void OnActivityResult (int requestCode, Result resultCode, Intent data)

--- a/NachoClient.Android/NachoUI.Android/Activities/NcMessageListActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/NcMessageListActivity.cs
@@ -63,12 +63,7 @@ namespace NachoClient.AndroidClient
 
         void MessageListFragment_onEventClick (object sender, McEvent ev)
         {
-            Log.Info (Log.LOG_UI, "MessageListFragment_onEventClick: {0}", ev);
-            var eventViewFragment = EventViewFragment.newInstance (ev);
-            this.FragmentManager.BeginTransaction ()
-                .Add (Resource.Id.content, eventViewFragment)
-                .AddToBackStack ("View")
-                .Commit ();
+            StartActivity (EventViewActivity.ShowEventIntent (this, ev));
         }
 
         void onMessageClick (object sender, McEmailMessageThread thread)
@@ -107,9 +102,6 @@ namespace NachoClient.AndroidClient
                 if (1 < this.FragmentManager.BackStackEntryCount) {
                     this.FragmentManager.PopBackStack ();
                 }
-            }
-            if (f is EventViewFragment) {
-                this.FragmentManager.PopBackStack ();
             }
         }
 

--- a/NachoClient.Android/Resources/layout/CalendarActivity.axml
+++ b/NachoClient.Android/Resources/layout/CalendarActivity.axml
@@ -4,11 +4,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
-<!-- Real content goes here -->
-    <FrameLayout
-        android:id="@+id/content"
+    <fragment
+        android:name="NachoClient.AndroidClient.EventListFragment"
+        android:id="@+id/event_list_fragment"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
-<!-- your content layout -->
+        android:layout_height="match_parent" />
 </LinearLayout>

--- a/NachoClient.Android/Resources/layout/EventViewActivity.axml
+++ b/NachoClient.Android/Resources/layout/EventViewActivity.axml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent">
+    <fragment
+        android:name="NachoClient.AndroidClient.EventViewFragment"
+        android:id="@+id/event_view_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>


### PR DESCRIPTION
Make the event detail view its own Activity rather than just a
fragment that is added to another activity's view.  EventViewFragment
still exists, in case we want to reuse that UI somewhere else.  But it
is not wrapped in EventViewActivity.

Change CalendarActivity so that EventListFragment is hard coded in its
layout, as opposed to adding EventListFragment to the view hierarchy
dynamically.
