### PR TITLE
Hook up the "I'm late" and "Forward" swipe actions for calendar items

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
@@ -108,10 +108,20 @@ namespace NachoClient.AndroidClient
             });
 
             listView.setOnMenuItemClickListener (( position, menu, index) => {
+                var cal = CalendarHelper.GetMcCalendarRootForEvent (eventListAdapter [position].Id);
                 switch (index) {
                 case LATE_TAG:
+                    if (null != cal) {
+                        var outgoingMessage = McEmailMessage.MessageWithSubject (NcApplication.Instance.Account, "Re: " + cal.GetSubject ());
+                        outgoingMessage.To = cal.OrganizerEmail;
+                        StartActivity (MessageComposeActivity.InitialTextIntent (this.Activity, outgoingMessage, "Running late."));
+                    }
                     break;
                 case FORWARD_TAG:
+                    if (null != cal) {
+                        StartActivity (MessageComposeActivity.ForwardCalendarIntent (
+                            this.Activity, cal.Id, McEmailMessage.MessageWithSubject (NcApplication.Instance.Account, "Fwd: " + cal.GetSubject ())));
+                    }
                     break;
                 default:
                     throw new NcAssert.NachoDefaultCaseFailure (String.Format ("Unknown action index {0}", index));

--- a/NachoClient.Android/NachoUI.Android/Activities/HotMessageFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/HotMessageFragment.cs
@@ -193,11 +193,7 @@ namespace NachoClient.AndroidClient
 
         void StartComposeActivity (EmailHelper.Action action)
         {
-            var intent = new Intent ();
-            intent.SetClass (this.Activity, typeof(MessageComposeActivity));
-            intent.PutExtra (MessageComposeActivity.EXTRA_ACTION, (int)action);
-            intent.PutExtra (MessageComposeActivity.EXTRA_RELATED_MESSAGE_ID, thread.FirstMessageId);
-            StartActivity (intent);
+            StartActivity (MessageComposeActivity.RespondIntent (this.Activity, action, thread.FirstMessageId));
         }
 
         void View_Click (object sender, EventArgs e)

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageComposeActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageComposeActivity.cs
@@ -10,6 +10,8 @@ using Android.Support.V7.App;
 using Android.Support.Design.Widget;
 
 using NachoCore.Model;
+using NachoCore.Utils;
+using NachoCore;
 
 namespace NachoClient.AndroidClient
 {
@@ -20,7 +22,7 @@ namespace NachoClient.AndroidClient
         public static readonly string EXTRA_ACTION = "com.nachocove.nachomail.action";
         public static readonly string EXTRA_RELATED_MESSAGE_ID = "com.nachocove.nachomail.relatedMessageId";
         public static readonly string EXTRA_RELATED_CALENDAR_ID = "com.nachocove.nachomail.relatedCalendarId";
-        public static readonly string EXTRA_MESSAGE_ID = "com.nachocove.nachomail.messageId";
+        public static readonly string EXTRA_MESSAGE = "com.nachocove.nachomail.message";
         public static readonly string EXTRA_INITIAL_TEXT = "com.nachocove.nachomail.initialText";
 
         protected override void OnCreate (Bundle bundle)
@@ -43,9 +45,8 @@ namespace NachoClient.AndroidClient
                 var relatedCalendarItem = McCalendar.QueryById<McCalendar> (Intent.GetIntExtra (EXTRA_RELATED_CALENDAR_ID, 0));
                 composeFragment.Composer.RelatedCalendarItem = relatedCalendarItem;
             }
-            if (Intent.HasExtra (EXTRA_RELATED_MESSAGE_ID)) {
-                var message = McEmailMessage.QueryById<McEmailMessage> (Intent.GetIntExtra (EXTRA_MESSAGE_ID, 0));
-                composeFragment.Composer.Message = message;
+            if (Intent.HasExtra(EXTRA_MESSAGE)) {
+                composeFragment.Composer.Message = IntentHelper.RetreiveValue<McEmailMessage> (Intent.GetStringExtra (EXTRA_MESSAGE));
             }
             if (Intent.HasExtra (EXTRA_INITIAL_TEXT)) {
                 var text = Intent.GetStringExtra (EXTRA_INITIAL_TEXT);
@@ -54,6 +55,41 @@ namespace NachoClient.AndroidClient
 
             FragmentManager.BeginTransaction ().Replace (Resource.Id.content, composeFragment).AddToBackStack("Now").Commit ();
            
+        }
+
+        public static Intent NewMessageIntent (Context context)
+        {
+            var intent = new Intent (context, typeof(MessageComposeActivity));
+            intent.SetAction (Intent.ActionSend);
+            return intent;
+        }
+
+        public static Intent RespondIntent (Context context, EmailHelper.Action action, int relatedMessageId)
+        {
+            var intent = new Intent (context, typeof(MessageComposeActivity));
+            intent.SetAction (Intent.ActionSend);
+            intent.PutExtra (EXTRA_ACTION, (int)action);
+            intent.PutExtra (EXTRA_RELATED_MESSAGE_ID, relatedMessageId);
+            return intent;
+        }
+
+        public static Intent InitialTextIntent (Context context, McEmailMessage message, string text)
+        {
+            var intent = new Intent (context, typeof(MessageComposeActivity));
+            intent.SetAction (Intent.ActionSend);
+            intent.PutExtra (EXTRA_MESSAGE, IntentHelper.StoreValue (message));
+            intent.PutExtra (EXTRA_INITIAL_TEXT, text);
+            return intent;
+        }
+
+        public static Intent ForwardCalendarIntent (Context context, int calendarId, McEmailMessage message)
+        {
+            var intent = new Intent (context, typeof(MessageComposeActivity));
+            intent.SetAction (Intent.ActionSend);
+            intent.PutExtra (EXTRA_ACTION, (int)EmailHelper.Action.Forward);
+            intent.PutExtra (EXTRA_RELATED_CALENDAR_ID, calendarId);
+            intent.PutExtra (EXTRA_MESSAGE, IntentHelper.StoreValue (message));
+            return intent;
         }
     }
 }

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageViewFragment.cs
@@ -230,11 +230,7 @@ namespace NachoClient.AndroidClient
 
         void StartComposeActivity (EmailHelper.Action action)
         {
-            var intent = new Intent ();
-            intent.SetClass (this.Activity, typeof(MessageComposeActivity));
-            intent.PutExtra (MessageComposeActivity.EXTRA_ACTION, (int)action);
-            intent.PutExtra (MessageComposeActivity.EXTRA_RELATED_MESSAGE_ID, message.Id);
-            StartActivity (intent);
+            StartActivity (MessageComposeActivity.RespondIntent (this.Activity, action, message.Id));
         }
 
         void View_Click (object sender, EventArgs e)

--- a/NachoClient.Android/NachoUI.Android/Activities/NowFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/NowFragment.cs
@@ -92,9 +92,7 @@ namespace NachoClient.AndroidClient
 
         void ComposeButton_Click (object sender, EventArgs e)
         {
-            var intent = new Intent ();
-            intent.SetClass (this.Activity, typeof(MessageComposeActivity));
-            StartActivity (intent);
+            StartActivity (MessageComposeActivity.NewMessageIntent (this.Activity));
         }
 
         public override void SwitchAccount ()


### PR DESCRIPTION
The UI for the calendar item swipe actions was done, but those choices
didn't actually do anything.  This update fixes the app so the choices
actually do what they are supposed to do.
