### PR TITLE
Fix the account switch action when on the calendar tab

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/CalendarActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/CalendarActivity.cs
@@ -20,10 +20,13 @@ namespace NachoClient.AndroidClient
     public class CalendarActivity : NcTabBarActivity
     {
         // All of the work happens in NcTabBarActivity and in EventListFragment.  The only thing that
-        // happens in this class is to specify the layout to use.
+        // happens in this class is hooking up the correct base fragment
         protected override void OnCreate (Bundle bundle)
         {
             base.OnCreate (bundle, Resource.Layout.CalendarActivity);
+
+            var eventListFragment = new EventListFragment ();
+            FragmentManager.BeginTransaction ().Add (Resource.Id.content, eventListFragment).Commit ();
         }
     }
 }

--- a/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
@@ -43,6 +43,8 @@ namespace NachoClient.AndroidClient
         ImageView addButton;
         ImageView todayButton;
 
+        private bool firstTime = true;
+
         public override void OnCreate (Bundle savedInstanceState)
         {
             base.OnCreate (savedInstanceState);
@@ -129,9 +131,12 @@ namespace NachoClient.AndroidClient
                 return false;
             });
 
-            eventListAdapter.Refresh (() => {
-                listView.SetSelection (eventListAdapter.PositionForToday);
-            });
+            if (firstTime) {
+                firstTime = false;
+                eventListAdapter.Refresh (() => {
+                    listView.SetSelection (eventListAdapter.PositionForToday);
+                });
+            }
 
             return view;
         }

--- a/NachoClient.Android/Resources/layout/CalendarActivity.axml
+++ b/NachoClient.Android/Resources/layout/CalendarActivity.axml
@@ -4,9 +4,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
-    <fragment
-        android:name="NachoClient.AndroidClient.EventListFragment"
-        android:id="@+id/event_list_fragment"
+<!-- Real content goes here -->
+    <FrameLayout
+        android:id="@+id/content"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+<!-- your content layout -->
 </LinearLayout>


### PR DESCRIPTION
An earlier update of mine to clean up some of the activity/fragment
code broke the account switcher when the app was on the calendar tab,
causing the app to crash when the account switch button was tapped.
This change undoes some (but not all) of my previous update so that
the account switcher is again working correctly on the calendar tab.
