### PR TITLE
Disable the swipe-to-refresh pull when a slidy is open. 

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/ContactsListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/ContactsListFragment.cs
@@ -146,6 +146,14 @@ namespace NachoClient.AndroidClient
                 return false;
             });
 
+            listView.setOnSwipeStartListener ((position) => {
+                mSwipeRefreshLayout.Enabled = false;
+            });
+
+            listView.setOnSwipeEndListener ((position) => {
+                mSwipeRefreshLayout.Enabled = true;
+            });
+
             return view;
         }
 

--- a/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
@@ -131,6 +131,14 @@ namespace NachoClient.AndroidClient
                 return false;
             });
 
+            listView.setOnSwipeStartListener ((position) => {
+                mSwipeRefreshLayout.Enabled = false;
+            });
+
+            listView.setOnSwipeEndListener ((position) => {
+                mSwipeRefreshLayout.Enabled = true;
+            });
+
             if (firstTime) {
                 firstTime = false;
                 eventListAdapter.Refresh (() => {

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageListFragment.cs
@@ -29,8 +29,9 @@ namespace NachoClient.AndroidClient
 {
     public interface MessageListDelegate
     {
-        bool ShowHotEvent();
-        void SetActiveImage(View view);
+        bool ShowHotEvent ();
+
+        void SetActiveImage (View view);
     }
 
     public class MessageListFragment : Fragment
@@ -169,6 +170,14 @@ namespace NachoClient.AndroidClient
                     throw new NcAssert.NachoDefaultCaseFailure (String.Format ("Unknown action index {0}", index));
                 }
                 return false;
+            });
+
+            listView.setOnSwipeStartListener ((position) => {
+                mSwipeRefreshLayout.Enabled = false;
+            });
+
+            listView.setOnSwipeEndListener ((position) => {
+                mSwipeRefreshLayout.Enabled = true;
             });
 
             var parent = (MessageListDelegate)Activity;


### PR DESCRIPTION
The swipe control was intercepting & canceling the slidy drag as soon as it
detected a slightly upward or downward pull.
