### PR TITLE
Don't crash when hot event is deleted while hot event view is loading

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Support/Bind.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/Bind.cs
@@ -250,6 +250,17 @@ namespace NachoClient.AndroidClient
             var c = currentEvent.GetCalendarItemforEvent ();
             var cRoot = CalendarHelper.GetMcCalendarRootForEvent (currentEvent.Id);
 
+            if (null == c || null == cRoot) {
+                eventTitle.Text = "This event has been deleted.";
+                calendarColor.Visibility = ViewStates.Invisible;
+                eventSummary.Visibility = ViewStates.Invisible;
+                eventIcon.Visibility = ViewStates.Invisible;
+                return;
+            }
+
+            calendarColor.Visibility = ViewStates.Visible;
+            eventSummary.Visibility = ViewStates.Visible;
+
             eventTitle.Text = Pretty.SubjectString (c.GetSubject ());
 
             int colorIndex = 0;


### PR DESCRIPTION
When a calendar item deletion arrives from the server, the McCalendar
and McEvent objects are deleted from the database before the UI is
notified of the change.  If the hot event view is loading while the
deletion is happening, the view might find itself with an in-memory
McEvent for which there is no McCalendar.  Don't crash in this case.
Instead show a message in the hot event view explaining the situation.
The user should see this message for a very short time (probably not
even long enough to read it), since the UI should be notified of the
calendar change very shortly.
