### PR TITLE
hack to make android exchange work with empty responses

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Operations/AsHttpOperation.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Operations/AsHttpOperation.cs
@@ -715,10 +715,15 @@ namespace NachoCore.ActiveSync
                         } catch (OperationCanceledException) {
                             Owner.ResolveAllDeferred ();
                             return Final ((uint)SmEvt.E.HardFail, "WBXCANCEL");
-                        } catch (WBXMLReadPastEndException) {
-                            // We are deferring because we think that an invalid WBXML string is likely transient.
-                            Owner.ResolveAllDeferred ();
-                            return Event.Create ((uint)SmEvt.E.TempFail, "HTTPOPRDPEND");
+                        } catch (WBXMLReadPastEndException ex) {
+                            if (ex.BytesRead == 0) {
+                                // nothing was read, i.e. HasBody was wrong.
+                                return Final (Owner.ProcessResponse (this, response, cToken));
+                            } else {
+                                // We are deferring because we think that an invalid WBXML string is likely transient.
+                                Owner.ResolveAllDeferred ();
+                                return Event.Create ((uint)SmEvt.E.TempFail, "HTTPOPRDPEND");
+                            }
                         } catch (InvalidDataException) {
                             Owner.ResolveAllDeferred ();
                             return Event.Create ((uint)SmEvt.E.TempFail, "HTTPOPRDPEND2");

--- a/NachoClient.Android/NachoCore/Utils/ASWBXMLByteQueue.cs
+++ b/NachoClient.Android/NachoCore/Utils/ASWBXMLByteQueue.cs
@@ -10,6 +10,11 @@ namespace NachoCore.Wbxml
 {
     class WBXMLReadPastEndException : Exception
     {
+        public long BytesRead;
+        public WBXMLReadPastEndException (long bytesRead)
+        {
+            BytesRead = bytesRead;
+        }
     }
 
     class ASWBXMLByteQueue
@@ -17,6 +22,7 @@ namespace NachoCore.Wbxml
         private Stream ByteStream;
         private int? PeekHolder;
         private GatedMemoryStream RedactedCopy;
+        private long BytesRead;
 
         public ASWBXMLByteQueue (Stream bytes, GatedMemoryStream redactedCopy = null)
         {
@@ -44,7 +50,9 @@ namespace NachoCore.Wbxml
                 PeekHolder = null;
             }
             if (-1 == value) {
-                throw new WBXMLReadPastEndException ();
+                throw new WBXMLReadPastEndException (BytesRead);
+            } else {
+                BytesRead++;
             }
             byte aByte = Convert.ToByte (value);
             if (null != RedactedCopy) {


### PR DESCRIPTION
The issue is that for android we can't tell if a body has data or not, and ModernHttpClient (MHC) is worse than useless: It lies.

So instead of relying on MHC, we try to read what we can, and enhance the exception throw during WBXML processing to tell us how many bytes were actually read. If 0 were read, there was no body, and we can safely call Final().

resolves nachocove/qa#1333
