### PR TITLE
Avoid crash during email autocomplete due to orphaned DB records

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -1569,7 +1569,12 @@ namespace NachoCore.Model
             // Convert the matched e-mail addresses into SearchMatch objects, avoiding duplicates.
             foreach (var emailMatch in emailMatches) {
                 if (matchedAttributeIds.Add (emailMatch.Id)) {
-                    allMatches.Add (new SearchMatch (McContact.QueryById<McContact> ((int)emailMatch.ContactId), emailMatch));
+                    // An old bug resulted in some databases that have orphaned McContactEmailAddressAttribute records.
+                    // Don't crash if one of those orphaned objects is found during the search.
+                    var contact = McContact.QueryById<McContact> ((int)emailMatch.ContactId);
+                    if (null != contact) {
+                        allMatches.Add (new SearchMatch (contact, emailMatch));
+                    }
                 }
             }
 


### PR DESCRIPTION
An old bug resulted in some databases that have orphaned
McContactEmailAddressAttribute records.  Don't crash if one of those
orphaned objects is found by a search during email address
autocomplete.

This bug only affects McContact.SearchAllContactsForEmail(), which is
used for email autocomplete.  McContact.SearchIndexAllContacts(),
which is used by the generic contact search, has slightly different
code that avoids this crash.

Fix nachocove/qa#1338
