### PR TITLE
allow for scenario where IMAP and SMTP server host names are the same

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapCommand.cs
@@ -478,7 +478,7 @@ namespace NachoCore.IMAP
         protected void ReportCommResult (string host, bool didFailGenerally)
         {
             if (!DontReportCommResult) {
-                NcCommStatusSingleton.ReportCommResult (BEContext.Account.Id, host, didFailGenerally);
+                NcCommStatusSingleton.ReportCommResult (BEContext.Account.Id, McAccount.AccountCapabilityEnum.EmailReaderWriter, didFailGenerally);
             }
         }
 

--- a/NachoClient.Android/NachoCore/BackEnd/NcCommStatus/INcCommStatus.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/NcCommStatus/INcCommStatus.cs
@@ -1,6 +1,7 @@
 //  Copyright (C) 2014 Nacho Cove, Inc. All rights reserved.
 //
 using System;
+using NachoCore.Model;
 using NachoPlatform;
 
 namespace NachoCore.Utils
@@ -18,6 +19,8 @@ namespace NachoCore.Utils
         void ReportCommResult (int serverId, bool didFailGenerally);
 
         void ReportCommResult (int serverId, DateTime delayUntil);
+
+        void ReportCommResult (int accountId, McAccount.AccountCapabilityEnum capabilities, bool didFailGenerally);
 
         void ReportCommResult (int accountId, string host, bool didFailGenerally);
 

--- a/NachoClient.Android/NachoCore/BackEnd/NcCommStatus/NcCommStatus.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/NcCommStatus/NcCommStatus.cs
@@ -122,6 +122,13 @@ namespace NachoCore.Utils
             }
         }
 
+        public void ReportCommResult (int accountId, McAccount.AccountCapabilityEnum capabilities, bool didFailGenerally)
+        {
+            lock (syncRoot) {
+                ReportCommResult (GetServerId (accountId, capabilities), didFailGenerally);
+            }
+        }
+
         public void ReportCommResult (int accountId, string host, bool didFailGenerally)
         {
             lock (syncRoot) {
@@ -134,6 +141,13 @@ namespace NachoCore.Utils
             lock (syncRoot) {
                 ReportCommResult (GetServerId (accountId, host), delayUntil);
             }
+        }
+
+        private int GetServerId (int accountId, McAccount.AccountCapabilityEnum capabilities)
+        {
+            var server = McServer.QueryByAccountIdAndCapabilities (accountId, capabilities);
+            // Allow 0 for scenario when we don't yet have a McServer record in DB (ex: auto-d).
+            return (null == server) ? 0 : server.Id;
         }
 
         private int GetServerId (int accountId, string host)

--- a/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/SMTP/Commands/SmtpCommand.cs
@@ -176,7 +176,7 @@ namespace NachoCore.SMTP
         protected void ReportCommResult (string host, bool didFailGenerally)
         {
             if (!DontReportCommResult) {
-                NcCommStatusSingleton.ReportCommResult (BEContext.Account.Id, host, didFailGenerally);
+                NcCommStatusSingleton.ReportCommResult (BEContext.Account.Id, McAccount.AccountCapabilityEnum.EmailSender, didFailGenerally);
             }
         }
 

--- a/Test.Android/Common/CommonMocks.cs
+++ b/Test.Android/Common/CommonMocks.cs
@@ -313,6 +313,13 @@ namespace Test.iOS
         {
         }
 
+        public void ReportCommResult (int accountId, McAccount.AccountCapabilityEnum capabilities, bool didFailGenerally)
+        {
+            AccountId = accountId;
+            Capabilities = capabilities;
+            DidFailGenerally = didFailGenerally;
+        }
+
         public void ReportCommResult (int accountId, string host, bool didFailGenerally)
         {
             AccountId = accountId;
@@ -323,6 +330,8 @@ namespace Test.iOS
         public int AccountId { get; set; }
 
         public string Host { get; set; }
+
+        public McAccount.AccountCapabilityEnum Capabilities { get; set; }
 
         public bool DidFailGenerally { get; set; }
 

--- a/Test.Android/LoginEventsTest.cs
+++ b/Test.Android/LoginEventsTest.cs
@@ -772,6 +772,9 @@ namespace Test.iOS
         public void ReportCommResult (int serverId, DateTime delayUntil)
         {
         }
+        public void ReportCommResult (int accountId, McAccount.AccountCapabilityEnum capabilities, bool didFailGenerally)
+        {
+        }
         public void ReportCommResult (int accountId, string host, bool didFailGenerally)
         {
         }


### PR DESCRIPTION
find the McServer using capabilities rather than host name.

Intended to fix nachocove/qa#1343
