### PR TITLE
Tweak email autocomplete, always showing email address in choices

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Support/MessageComposeHeaderView.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/MessageComposeHeaderView.cs
@@ -196,7 +196,7 @@ namespace NachoClient.AndroidClient
                 var searchString = constraint == null ? "" : constraint.ToString ();
                 List<McContactEmailAddressAttribute> contacts;
                 if (!String.IsNullOrWhiteSpace (searchString)) {
-                    contacts = McContact.SearchIndexAllContacts (searchString);
+                    contacts = McContact.SearchAllContactsForEmail (searchString);
                 } else {
                     contacts = new List<McContactEmailAddressAttribute> ();
                 }
@@ -256,8 +256,16 @@ namespace NachoClient.AndroidClient
             if (convertView == null) {
                 view = new TextView (Context);
             }
-            var contact = SearchResults [position].GetContact ();
-            view.Text = contact.GetDisplayNameOrEmailAddress ();
+
+            string email = SearchResults [position].Value;
+            string displayName = SearchResults [position].GetContact ().GetDisplayName ();
+
+            string viewText = email;
+            if (!string.IsNullOrEmpty(displayName) && displayName != email) {
+                viewText = string.Format ("{0} <{1}>", displayName, email);
+            }
+            view.Text = viewText;
+
             return view;
         }
 


### PR DESCRIPTION
Two tweaks to the email autocomplete in the message compose view.
1. Use the correct search McContact search method, namely the one that
   limits the results to contacts with email addresses.
2. Always show the email address in the set of choices, not just the
   name.  This allows the user to correctly choose among different email
   addresses that have the same name.
