### PR TITLE
eliminate use of BufferedStream to see if LoadBytes lock-up goes away

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcXmlFilter.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcXmlFilter.cs
@@ -571,8 +571,7 @@ namespace NachoCore.Wbxml
             // Cheating!! Use ASWBXL class to decode. This is less efficient
             // because it walks the tree twice.
             ASWBXML wbxml = new ASWBXML (new CancellationToken (false));
-            MemoryStream byteStream = new MemoryStream (Wbxml.ToArray (), false);
-            wbxml.LoadBytes (0, byteStream);
+            wbxml.LoadBytes (0, Wbxml.ToArray ());
             return new XDocument (wbxml.XmlDoc);
         }
     }

--- a/NachoClient.Android/NachoCore/Utils/WBXML.cs
+++ b/NachoClient.Android/NachoCore/Utils/WBXML.cs
@@ -46,7 +46,7 @@ namespace NachoCore.Wbxml
             return XmlDoc.ToString (SaveOptions.DisableFormatting);
         }
 
-        public void LoadBytes (int accountId, Stream byteWBXML, Boolean? doFiltering = null)
+        public void LoadBytes (int accountId, byte[] rawBytes, Boolean? doFiltering = null)
         {
             XmlDoc = new XDocument (new XDeclaration ("1.0", "utf-8", "yes"));
             int level = 0;
@@ -59,7 +59,7 @@ namespace NachoCore.Wbxml
             }
             filter.Start ();
 
-            ASWBXMLByteQueue bytes = new ASWBXMLByteQueue (byteWBXML, filter.WbxmlBuffer);
+            ASWBXMLByteQueue bytes = new ASWBXMLByteQueue (new MemoryStream (rawBytes), filter.WbxmlBuffer);
 
             // Version is ignored
             byte version = bytes.Dequeue ();


### PR DESCRIPTION
We had lockup problems with BufferedStream a loooooong time ago. Use a byte[] instead and see if the LoadBytes lock-ups go away.

Besides the hundreds of such lock-ups per-day in the alpha pool causing retries, delays and lost threads, eliminating this lock up would mean we could stop using NcTask to Run AttemptHttp (revert), eliminating ~15% of NcTask.Run calls.
