### PR TITLE
Make the Android date/time picker dialog scrollable

### DIFF
--- a/NachoClient.Android/Resources/layout/DateTimePicker.axml
+++ b/NachoClient.Android/Resources/layout/DateTimePicker.axml
@@ -1,26 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:padding="8dp"
-    android:background="@color/NachoLightGrayBackground"
     android:layout_height="match_parent">
-    <DatePicker
-        android:id="@+id/date_picker"
+    <LinearLayout
+        android:orientation="vertical"
         android:layout_width="match_parent"
-        android:calendarViewShown="true"
-        android:spinnersShown="false"
-        android:layout_weight="4"
-        android:layout_height="0dp" />
-    <TimePicker
-        android:id="@+id/time_picker"
-        android:layout_weight="4"
-        android:layout_width="match_parent"
-        android:layout_height="0dp" />
-    <Button
-        android:id="@+id/date_time_set"
-        android:layout_weight="1"
-        android:layout_width="match_parent"
-        android:text="Set"
-        android:layout_height="0dp" />
-</LinearLayout>
+        android:layout_height="match_parent"
+        android:padding="8dp"
+        android:background="@color/NachoLightGrayBackground">
+        <DatePicker
+            android:id="@+id/date_picker"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="4"
+            android:calendarViewShown="true"
+            android:spinnersShown="false" />
+        <TimePicker
+            android:id="@+id/time_picker"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="4" />
+        <Button
+            android:id="@+id/date_time_set"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:text="Set" />
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
On some devices, the date/time picker dialog is more than one screen
tall, which makes the "Set" button unreachable, which makes the dialog
unusable.  Fix this problem by making the dialog scrollable.
