### PR TITLE
Show the full subject of the message in the message detail view

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/MessageViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageViewFragment.cs
@@ -169,6 +169,10 @@ namespace NachoClient.AndroidClient
         void BindValues (View view)
         {
             Bind.BindMessageHeader (null, message, view);
+            // The header view is shared between the message list view and the message detail view.
+            // In the list view, the subject should be truncated to a single line.  In the detail
+            // view, the full subject needs to be shown.
+            view.FindViewById<TextView> (Resource.Id.subject).SetMaxLines (100);
 
             var body = McBody.QueryById<McBody> (message.BodyId);
 


### PR DESCRIPTION
Change the message detail view to show the full subject, even if it is
more than one line long.  The message list view still truncates the
subject to one line.
