### PR TITLE
Change the back button to save changes in notes and attendees views

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/AttendeeEditActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/AttendeeEditActivity.cs
@@ -30,6 +30,13 @@ namespace NachoClient.AndroidClient
             fragment.Attendees = AttendeesFromIntent (Intent);
         }
 
+        public override void OnBackPressed ()
+        {
+            var fragment = FragmentManager.FindFragmentById<AttendeeListEditFragment> (Resource.Id.attendee_edit_fragment);
+            SetResult (Result.Ok, ResultIntent (fragment.Attendees));
+            Finish ();
+        }
+
         public static Intent AttendeeEditIntent (Context context, int accountId, IList<McAttendee> attendees)
         {
             return AttendeesIntent (context, typeof(AttendeeEditActivity), Intent.ActionEdit, accountId, attendees);

--- a/NachoClient.Android/NachoUI.Android/Activities/AttendeeListEditFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/AttendeeListEditFragment.cs
@@ -42,8 +42,8 @@ namespace NachoClient.AndroidClient
             listView.setMenuCreator (SwipeMenu_Create);
             listView.setOnMenuItemClickListener (SwipeMenu_Click);
 
-            buttonBar.SetTextButton (ButtonBar.Button.Right1, Resource.String.save, SaveButton_Click);
-            buttonBar.SetIconButton (ButtonBar.Button.Right2, Resource.Drawable.calendar_add_attendee, AddButton_Click);
+            buttonBar.SetIconButton (ButtonBar.Button.Right1, Resource.Drawable.calendar_add_attendee, AddButton_Click);
+            buttonBar.SetIconButton (ButtonBar.Button.Left1, Resource.Drawable.gen_close, CancelButton_Click);
 
             return view;
         }
@@ -146,15 +146,15 @@ namespace NachoClient.AndroidClient
             return false;
         }
 
-        private void SaveButton_Click (object sender, EventArgs e)
-        {
-            this.Activity.SetResult (Result.Ok, AttendeeEditActivity.ResultIntent (Attendees));
-            this.Activity.Finish ();
-        }
-
         private void AddButton_Click (object sender, EventArgs e)
         {
             StartActivityForResult (ContactEmailChooserActivity.EmptySearchIntent (this.Activity, accountId), CONTACT_CHOOSER_REQUEST);
+        }
+
+        private void CancelButton_Click (object sender, EventArgs e)
+        {
+            this.Activity.SetResult (Result.Canceled);
+            this.Activity.Finish ();
         }
     }
 }

--- a/NachoClient.Android/NachoUI.Android/Activities/NoteActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/NoteActivity.cs
@@ -38,6 +38,8 @@ namespace NachoClient.AndroidClient
 
             buttonBar.SetTextButton (ButtonBar.Button.Right1, "Done", DoneButton_Click);
 
+            buttonBar.SetIconButton (ButtonBar.Button.Left1, Resource.Drawable.gen_close, CancelButton_Click);
+
             instructions = FindViewById<TextView> (Resource.Id.note_instructions);
 
             textField = FindViewById<EditText> (Resource.Id.note_text);
@@ -64,6 +66,23 @@ namespace NachoClient.AndroidClient
             }
 
             textField.Text = unmodifiedText;
+        }
+
+        public override void OnBackPressed ()
+        {
+            SaveChanges ();
+        }
+
+        private void SaveChanges ()
+        {
+            if (textField.Text == unmodifiedText) {
+                SetResult (Result.Canceled);
+            } else {
+                var resultIntent = new Intent ();
+                resultIntent.PutExtra (EXTRA_NOTE_TEXT, textField.Text);
+                SetResult (Result.Ok, resultIntent);
+            }
+            Finish ();
         }
 
         public static Intent EditNoteIntent (Context context, string title, string instructions, string text, bool insertDate)
@@ -95,13 +114,12 @@ namespace NachoClient.AndroidClient
 
         private void DoneButton_Click (object sender, EventArgs e)
         {
-            if (textField.Text == unmodifiedText) {
-                SetResult (Result.Canceled);
-            } else {
-                var resultIntent = new Intent ();
-                resultIntent.PutExtra (EXTRA_NOTE_TEXT, textField.Text);
-                SetResult (Result.Ok, resultIntent);
-            }
+            SaveChanges ();
+        }
+
+        private void CancelButton_Click (object sender, EventArgs e)
+        {
+            SetResult (Result.Canceled);
             Finish ();
         }
     }


### PR DESCRIPTION
In the notes view and the attendees view, change the behavior of the
back button to save changes.  Add a cancel button so that users can
discard their changes.

The notes view still has a "Done" button, which behaves the same as
the back button, because the back button is normally hidden by the
dismiss keyboard button.  The attendees view does not show a keyboard,
so the "Save" button was removed entirely and the back button is the
only way to save changes.
