### PR TITLE
dont use task.run for attempthttp at all

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcTask.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcTask.cs
@@ -65,7 +65,6 @@ namespace NachoCore.Utils
         }
 
         static string[] LoginRunningTasks = new string[] {
-            "AttemptHttp",
             "Brain",
             "CheckNotified",
             "DeviceProtoControl:DeviceDbChange",


### PR DESCRIPTION
`// Using response.Content.ReadAsStreamAsync causes lock-ups sometimes.
                // These lock-ups would cause loss of a thread.
                // We switched back to ReadAsByteArrayAsync to avoid lock-ups. 
                // This will have the side-effect of big responses being memory-resident
                // until NachoHttp comes in.`
