### PR TITLE
Fix many of the crashes when rotating the device

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/AboutActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/AboutActivity.cs
@@ -24,8 +24,6 @@ namespace NachoClient.AndroidClient
         {
             base.OnCreate (bundle, Resource.Layout.AboutActivity);
 
-            this.RequestedOrientation = Android.Content.PM.ScreenOrientation.Nosensor;
-
             var aboutFragment = AboutFragment.newInstance ();
             FragmentManager.BeginTransaction ().Replace (Resource.Id.content, aboutFragment).Commit ();
         }

--- a/NachoClient.Android/NachoUI.Android/Activities/AttendeeBaseActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/AttendeeBaseActivity.cs
@@ -16,7 +16,7 @@ using NachoCore.Model;
 
 namespace NachoClient.AndroidClient
 {
-    public class AttendeeBaseActivity : NcActivity
+    public class AttendeeBaseActivity : NcActivityWithData<IList<McAttendee>>
     {
         private const string EXTRA_ACCOUNT = "com.nachocove.nachomail.EXTRA_ACCOUNT";
         private const string EXTRA_ATTENDEES = "com.nachocove.nachomail.EXTRA_ATTENDEES";

--- a/NachoClient.Android/NachoUI.Android/Activities/AttendeeEditActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/AttendeeEditActivity.cs
@@ -27,7 +27,12 @@ namespace NachoClient.AndroidClient
 
             var fragment = FragmentManager.FindFragmentById<AttendeeListEditFragment> (Resource.Id.attendee_edit_fragment);
             fragment.AccountId = AccountIdFromIntent (Intent);
-            fragment.Attendees = AttendeesFromIntent (Intent);
+            var attendees = RetainedData;
+            if (null == attendees) {
+                attendees = AttendeesFromIntent (Intent);
+                RetainedData = attendees;
+            }
+            fragment.Attendees = attendees;
         }
 
         public override void OnBackPressed ()

--- a/NachoClient.Android/NachoUI.Android/Activities/AttendeeViewActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/AttendeeViewActivity.cs
@@ -27,7 +27,12 @@ namespace NachoClient.AndroidClient
 
             var fragment = FragmentManager.FindFragmentById<AttendeeListViewFragment> (Resource.Id.attendee_view_fragment);
             fragment.AccountId = AccountIdFromIntent (Intent);
-            fragment.Attendees = AttendeesFromIntent (Intent);
+            var attendees = RetainedData;
+            if (null == attendees) {
+                attendees = AttendeesFromIntent (Intent);
+                RetainedData = attendees;
+            }
+            fragment.Attendees = attendees;
         }
 
         public static Intent AttendeeViewIntent (Context context, int accountId, IList<McAttendee> attendees)

--- a/NachoClient.Android/NachoUI.Android/Activities/ContactViewActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/ContactViewActivity.cs
@@ -17,7 +17,7 @@ using NachoCore.Model;
 namespace NachoClient.AndroidClient
 {
     [Activity (Label = "ContactViewActivity")]
-    public class ContactViewActivity : NcActivity, IContactViewFragmentOwner
+    public class ContactViewActivity : NcActivityWithData<McContact>, IContactViewFragmentOwner
     {
         private const string EXTRA_CONTACT = "com.nachocove.nachomail.EXTRA_CONTACT";
 
@@ -26,7 +26,12 @@ namespace NachoClient.AndroidClient
         protected override void OnCreate (Bundle bundle)
         {
             base.OnCreate (bundle);
-            this.contact = IntentHelper.RetrieveValue<McContact> (Intent.GetStringExtra (EXTRA_CONTACT));
+            var contact = RetainedData;
+            if (null == contact) {
+                contact = IntentHelper.RetrieveValue<McContact> (Intent.GetStringExtra (EXTRA_CONTACT));
+                RetainedData = contact;
+            }
+            this.contact = contact;
             SetContentView (Resource.Layout.ContactViewActivity);
         }
 

--- a/NachoClient.Android/NachoUI.Android/Activities/ContactsActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/ContactsActivity.cs
@@ -25,8 +25,6 @@ namespace NachoClient.AndroidClient
         {
             base.OnCreate (bundle, Resource.Layout.ContactsActivity);
 
-            this.RequestedOrientation = Android.Content.PM.ScreenOrientation.Nosensor;
-
             contactsListFragment = ContactsListFragment.newInstance ();
             contactsListFragment.onContactClick += ContactsListFragment_onContactClick;
             FragmentManager.BeginTransaction ().Add (Resource.Id.content, contactsListFragment).AddToBackStack ("Contacts").Commit ();

--- a/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
@@ -20,8 +20,14 @@ using NachoCore.ActiveSync;
 
 namespace NachoClient.AndroidClient
 {
+    public class EventEditActivityData
+    {
+        public McEvent Event;
+        public McEmailMessage EmailMessage;
+    }
+
     [Activity (Label = "EventEditActivity")]            
-    public class EventEditActivity : NcActivity
+    public class EventEditActivity : NcActivityWithData<EventEditActivityData>
     {
         public const Result DELETE_EVENT_RESULT_CODE = Result.FirstUser;
 
@@ -59,6 +65,18 @@ namespace NachoClient.AndroidClient
 
             SetContentView (Resource.Layout.EventEditActivity);
 
+            var dataFromIntent = RetainedData;
+            if (null == dataFromIntent) {
+                dataFromIntent = new EventEditActivityData ();
+                if (Intent.HasExtra(EXTRA_EVENT_TO_EDIT)) {
+                    dataFromIntent.Event = IntentHelper.RetrieveValue<McEvent> (Intent.GetStringExtra (EXTRA_EVENT_TO_EDIT));
+                }
+                if (Intent.HasExtra(EXTRA_MESSAGE_FOR_MEETING)) {
+                    dataFromIntent.EmailMessage = IntentHelper.RetrieveValue<McEmailMessage> (Intent.GetStringExtra (EXTRA_MESSAGE_FOR_MEETING));
+                }
+                RetainedData = dataFromIntent;
+            }
+
             buttonBar = new ButtonBar (FindViewById<View> (Resource.Id.button_bar));
 
             buttonBar.SetTextButton (ButtonBar.Button.Right1, Resource.String.save, SaveButton_Click);
@@ -92,7 +110,6 @@ namespace NachoClient.AndroidClient
                 if (Intent.HasExtra (EXTRA_MESSAGE_FOR_MEETING)) {
                     // Create a meeting based on the recipients and the body of an email message.
                     // TODO Not yet implemented
-                    IntentHelper.RetrieveValue<McEmailMessage> (Intent.GetStringExtra (EXTRA_MESSAGE_FOR_MEETING));
                 }
 
                 // Figure out the correct account for the new event.
@@ -138,7 +155,7 @@ namespace NachoClient.AndroidClient
 
                 buttonBar.SetTitle ("Edit Event");
 
-                ev = IntentHelper.RetrieveValue<McEvent> (Intent.GetStringExtra (EXTRA_EVENT_TO_EDIT));
+                ev = dataFromIntent.Event;
                 cal = McCalendar.QueryById<McCalendar> (ev.CalendarId);
 
                 if (cal.AllDayEvent) {

--- a/NachoClient.Android/NachoUI.Android/Activities/EventViewActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventViewActivity.cs
@@ -18,7 +18,7 @@ using NachoCore.Utils;
 namespace NachoClient.AndroidClient
 {
     [Activity (Label = "EventViewActivity")]            
-    public class EventViewActivity : NcActivity, IEventViewFragmentOwner
+    public class EventViewActivity : NcActivityWithData<McEvent>, IEventViewFragmentOwner
     {
         private const string EXTRA_EVENT = "com.nachocove.nachomail.EXTRA_EVENT";
 
@@ -27,7 +27,13 @@ namespace NachoClient.AndroidClient
         protected override void OnCreate (Bundle bundle)
         {
             base.OnCreate (bundle);
-            this.ev = IntentHelper.RetrieveValue<McEvent> (Intent.GetStringExtra (EXTRA_EVENT));
+            var savedEvent = RetainedData;
+            if (null == savedEvent) {
+                this.ev = IntentHelper.RetrieveValue<McEvent> (Intent.GetStringExtra (EXTRA_EVENT));
+                RetainedData = this.ev;
+            } else {
+                this.ev = savedEvent;
+            }
             SetContentView (Resource.Layout.EventViewActivity);
         }
 

--- a/NachoClient.Android/NachoUI.Android/Activities/FoldersActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/FoldersActivity.cs
@@ -28,6 +28,8 @@ namespace NachoClient.AndroidClient
         {
             base.OnCreate (bundle, Resource.Layout.FoldersActivity);
 
+            this.RequestedOrientation = Android.Content.PM.ScreenOrientation.Nosensor;
+
             folderListFragment = FolderListFragment.newInstance ();
             folderListFragment.onFolderSelected += onFolderSelected;
             FragmentManager.BeginTransaction ().Add (Resource.Id.content, folderListFragment).AddToBackStack ("Folders").Commit ();

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageComposeActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageComposeActivity.cs
@@ -16,7 +16,7 @@ using NachoCore;
 namespace NachoClient.AndroidClient
 {
     [Activity (Label = "MessageComposeActivity")]            
-    public class MessageComposeActivity : NcActivity
+    public class MessageComposeActivity : NcActivityWithData<McEmailMessage>
     {
 
         public static readonly string EXTRA_ACTION = "com.nachocove.nachomail.action";
@@ -46,7 +46,12 @@ namespace NachoClient.AndroidClient
                 composeFragment.Composer.RelatedCalendarItem = relatedCalendarItem;
             }
             if (Intent.HasExtra(EXTRA_MESSAGE)) {
-                composeFragment.Composer.Message = IntentHelper.RetrieveValue<McEmailMessage> (Intent.GetStringExtra (EXTRA_MESSAGE));
+                var message = RetainedData;
+                if (null == message) {
+                    message = IntentHelper.RetrieveValue<McEmailMessage> (Intent.GetStringExtra (EXTRA_MESSAGE));
+                    RetainedData = message;
+                }
+                composeFragment.Composer.Message = message;
             }
             if (Intent.HasExtra (EXTRA_INITIAL_TEXT)) {
                 var text = Intent.GetStringExtra (EXTRA_INITIAL_TEXT);

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageViewActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageViewActivity.cs
@@ -16,8 +16,14 @@ using NachoCore.Model;
 
 namespace NachoClient.AndroidClient
 {
+    public class MessageViewActivityData
+    {
+        public McEmailMessageThread Thread;
+        public McEmailMessage Message;
+    }
+
     [Activity (Label = "MessageViewActivity")]
-    public class MessageViewActivity : NcActivity, IMessageViewFragmentOwner
+    public class MessageViewActivity : NcActivityWithData<MessageViewActivityData>, IMessageViewFragmentOwner
     {
         private const string EXTRA_THREAD = "com.nachocove.nachomail.EXTRA_THREAD";
         private const string EXTRA_MESSAGE = "com.nachocove.nachomail.EXTRA_MESSAGE";
@@ -28,8 +34,15 @@ namespace NachoClient.AndroidClient
         protected override void OnCreate (Bundle bundle)
         {
             base.OnCreate (bundle);
-            this.thread = IntentHelper.RetrieveValue<McEmailMessageThread> (Intent.GetStringExtra (EXTRA_THREAD));
-            this.message = IntentHelper.RetrieveValue<McEmailMessage> (Intent.GetStringExtra (EXTRA_MESSAGE));
+            var dataFromIntent = RetainedData;
+            if (null == dataFromIntent) {
+                dataFromIntent = new MessageViewActivityData ();
+                dataFromIntent.Thread = IntentHelper.RetrieveValue<McEmailMessageThread> (Intent.GetStringExtra (EXTRA_THREAD));
+                dataFromIntent.Message = IntentHelper.RetrieveValue<McEmailMessage> (Intent.GetStringExtra (EXTRA_MESSAGE));
+                RetainedData = dataFromIntent;
+            }
+            this.thread = dataFromIntent.Thread;
+            this.message = dataFromIntent.Message;
 
             SetContentView (Resource.Layout.MessageViewActivity);
         }

--- a/NachoClient.Android/NachoUI.Android/Activities/NcActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/NcActivity.cs
@@ -1,13 +1,16 @@
 ﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
 //
 using System;
-using Android.Support.V7.App;
 using Android.OS;
-using NachoCore.Utils;
+using Android.Support.V7.App;
 using NachoClient.Build;
+using NachoCore.Utils;
 
 namespace NachoClient.AndroidClient
 {
+    /// <summary>
+    /// Activity base class that (1) logs state transitions, and (2) checks with HockeyApp for updates.
+    /// </summary>
     public class NcActivity : AppCompatActivity
     {
         private string ClassName;
@@ -96,7 +99,48 @@ namespace NachoClient.AndroidClient
                 base.OnNoUpdateAvailable ();
             }
         }
+    }
 
+    /// <summary>
+    /// Activity base class on top of NcActivity that provides a way for activities to save data
+    /// that must survive across a configuration change such as rotating the device.  Preserving
+    /// the data is not automatic.  Derived classes must call RetainedData at the appropriate time.
+    /// </summary>
+    public class NcActivityWithData<T> : NcActivity
+    {
+        private class DataFragment : Android.App.Fragment
+        {
+            public T Data {
+                get;
+                set;
+            }
+
+            public override void OnCreate (Bundle savedInstanceState)
+            {
+                base.OnCreate (savedInstanceState);
+                this.RetainInstance = true;
+            }
+        }
+
+        private const string DATA_FRAGMENT_TAG = "DataFragment";
+
+        public T RetainedData {
+            get {
+                var fragment = FragmentManager.FindFragmentByTag<DataFragment> (DATA_FRAGMENT_TAG);
+                if (null == fragment) {
+                    return default(T);
+                }
+                return fragment.Data;
+            }
+            set {
+                var fragment = FragmentManager.FindFragmentByTag<DataFragment> (DATA_FRAGMENT_TAG);
+                if (null == fragment) {
+                    fragment = new DataFragment ();
+                    FragmentManager.BeginTransaction ().Add (fragment, DATA_FRAGMENT_TAG).Commit ();
+                }
+                fragment.Data = value;
+            }
+        }
     }
 }
 

--- a/NachoClient.Android/NachoUI.Android/Activities/NowActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/NowActivity.cs
@@ -27,6 +27,8 @@ namespace NachoClient.AndroidClient
         {
             Log.Info (Log.LOG_UI, "NowActivity OnCreate");
 
+            this.RequestedOrientation = Android.Content.PM.ScreenOrientation.Nosensor;
+
             base.OnCreate (bundle, Resource.Layout.NowActivity);
 
             nowFragment = new NowFragment ();

--- a/NachoClient.Android/NachoUI.Android/Activities/SettingsActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/SettingsActivity.cs
@@ -24,8 +24,6 @@ namespace NachoClient.AndroidClient
         {
             base.OnCreate (bundle, Resource.Layout.SettingsActivity);
 
-            this.RequestedOrientation = Android.Content.PM.ScreenOrientation.Nosensor;
-
             var settingsFragment = SettingsFragment.newInstance ();
             FragmentManager.BeginTransaction ().Replace (Resource.Id.content, settingsFragment).Commit ();
         }

--- a/NachoClient.Android/NachoUI.Android/Activities/SupportActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/SupportActivity.cs
@@ -24,8 +24,6 @@ namespace NachoClient.AndroidClient
         {
             base.OnCreate (bundle, Resource.Layout.SupportActivity);
 
-            this.RequestedOrientation = Android.Content.PM.ScreenOrientation.Nosensor;
-
             var supportFragment = SupportFragment.newInstance ();
             FragmentManager.BeginTransaction ().Replace (Resource.Id.content, supportFragment).Commit ();
         }


### PR DESCRIPTION
Create class NcActivityWithData<T> to be used by activities that need
to preserve data across the OnDestroy()/OnCreate() calls that happen
upon configuration changes such as rotating the device.  Change
existing activities to use this for data that is stored in
IntentHelper.  For some activities that can now support rotation,
remove the code that disabled rotation.  For other activities that
still crash on rotation for other reasons, add the code that disables
rotation.

With these changes, most views in the app will not crash when the
device is rotated.  I tested most of the views other than the login
and new account views.  The app will still crash when launched in
landscape mode.  The behavior is not always correct when the device is
rotated.

Improves the situation for nachocove/qa#1360, but is not a complete
solution.
