### PR TITLE
Don't create duplicate EventListFragments when rotating the device

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/CalendarActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/CalendarActivity.cs
@@ -19,14 +19,23 @@ namespace NachoClient.AndroidClient
     [Activity (Label = "CalendarActivity")]            
     public class CalendarActivity : NcTabBarActivity
     {
+        private const string EVENT_LIST_FRAGMENT_TAG = "EventList";
+
         // All of the work happens in NcTabBarActivity and in EventListFragment.  The only thing that
         // happens in this class is hooking up the correct base fragment
         protected override void OnCreate (Bundle bundle)
         {
             base.OnCreate (bundle, Resource.Layout.CalendarActivity);
 
-            var eventListFragment = new EventListFragment ();
-            FragmentManager.BeginTransaction ().Add (Resource.Id.content, eventListFragment).Commit ();
+            EventListFragment fragment = null;
+            if (null != bundle) {
+                fragment = FragmentManager.FindFragmentByTag<EventListFragment> (EVENT_LIST_FRAGMENT_TAG);
+            }
+            if (null == fragment) {
+                fragment = new EventListFragment ();
+                fragment.StartAtToday ();
+                FragmentManager.BeginTransaction ().Add (Resource.Id.content, fragment, EVENT_LIST_FRAGMENT_TAG).Commit ();
+            }
         }
     }
 }

--- a/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
@@ -43,7 +43,7 @@ namespace NachoClient.AndroidClient
         ImageView addButton;
         ImageView todayButton;
 
-        private bool firstTime = true;
+        private bool jumpToToday = false;
 
         public override void OnCreate (Bundle savedInstanceState)
         {
@@ -139,14 +139,19 @@ namespace NachoClient.AndroidClient
                 mSwipeRefreshLayout.Enabled = true;
             });
 
-            if (firstTime) {
-                firstTime = false;
+            if (jumpToToday) {
+                jumpToToday = false;
                 eventListAdapter.Refresh (() => {
                     listView.SetSelection (eventListAdapter.PositionForToday);
                 });
             }
 
             return view;
+        }
+
+        public void StartAtToday ()
+        {
+            jumpToToday = true;
         }
 
         void TodayButton_Click (object sender, EventArgs e)


### PR DESCRIPTION
When the device was rotated while the calendar view was showing,
duplicate EventListFragments were created.  Android was restoring one,
while CalendarActivity was creating a second one.
