### PR TITLE
More fixes for fragment lifecycle when rotating the device

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/AboutActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/AboutActivity.cs
@@ -16,16 +16,19 @@ using NachoCore.Utils;
 
 namespace NachoClient.AndroidClient
 {
-    [Activity (Label = "AboutActivity")]            
+    [Activity (Label = "AboutActivity")]
     public class AboutActivity : NcTabBarActivity
     {
+        private const string ABOUT_FRAGMENT_TAG = "AboutFragment";
 
         protected override void OnCreate (Bundle bundle)
         {
             base.OnCreate (bundle, Resource.Layout.AboutActivity);
 
-            var aboutFragment = AboutFragment.newInstance ();
-            FragmentManager.BeginTransaction ().Replace (Resource.Id.content, aboutFragment).Commit ();
+            if (null == bundle || null == FragmentManager.FindFragmentByTag<AboutFragment> (ABOUT_FRAGMENT_TAG)) {
+                var aboutFragment = AboutFragment.newInstance ();
+                FragmentManager.BeginTransaction ().Replace (Resource.Id.content, aboutFragment, ABOUT_FRAGMENT_TAG).Commit ();
+            }
         }
 
         public override void OnBackPressed ()

--- a/NachoClient.Android/NachoUI.Android/Activities/ContactsActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/ContactsActivity.cs
@@ -16,18 +16,24 @@ using NachoCore.Utils;
 
 namespace NachoClient.AndroidClient
 {
-    [Activity (Label = "ContactsActivity", WindowSoftInputMode = Android.Views.SoftInput.AdjustResize)]            
+    [Activity (Label = "ContactsActivity", WindowSoftInputMode = Android.Views.SoftInput.AdjustResize)]
     public class ContactsActivity : NcTabBarActivity
     {
-        ContactsListFragment contactsListFragment;
+        private const string CONTACTS_LIST_FRAGMENT_TAG = "ContactsListFragment";
 
         protected override void OnCreate (Bundle bundle)
         {
             base.OnCreate (bundle, Resource.Layout.ContactsActivity);
 
-            contactsListFragment = ContactsListFragment.newInstance ();
-            contactsListFragment.onContactClick += ContactsListFragment_onContactClick;
-            FragmentManager.BeginTransaction ().Add (Resource.Id.content, contactsListFragment).AddToBackStack ("Contacts").Commit ();
+            ContactsListFragment fragment = null;
+            if (null != bundle) {
+                fragment = FragmentManager.FindFragmentByTag<ContactsListFragment> (CONTACTS_LIST_FRAGMENT_TAG);
+            }
+            if (null == fragment) {
+                fragment = ContactsListFragment.newInstance ();
+                FragmentManager.BeginTransaction ().Add (Resource.Id.content, fragment, CONTACTS_LIST_FRAGMENT_TAG).Commit ();
+            }
+            fragment.onContactClick += ContactsListFragment_onContactClick;
         }
 
         void ContactsListFragment_onContactClick (object sender, McContact contact)
@@ -37,11 +43,11 @@ namespace NachoClient.AndroidClient
 
         public override void OnBackPressed ()
         {
-            base.OnBackPressed ();
             var f = FragmentManager.FindFragmentById (Resource.Id.content);
             if (f is ContactsListFragment) {
                 ((ContactsListFragment)f).OnBackPressed ();
             }
+            base.OnBackPressed ();
         }
 
         protected override void OnSaveInstanceState (Bundle outState)

--- a/NachoClient.Android/NachoUI.Android/Activities/ContactsListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/ContactsListFragment.cs
@@ -32,6 +32,8 @@ namespace NachoClient.AndroidClient
         private const int CALL_TAG = 1;
         private const int EMAIL_TAG = 2;
 
+        private const string SAVED_SEARCHING_KEY = "ContactsListFragment.searching";
+
         bool searching;
         Android.Widget.EditText searchEditText;
         View letterBar;
@@ -157,6 +159,18 @@ namespace NachoClient.AndroidClient
             return view;
         }
 
+        public override void OnActivityCreated (Bundle savedInstanceState)
+        {
+            base.OnActivityCreated (savedInstanceState);
+            if (null != savedInstanceState) {
+                searching = savedInstanceState.GetBoolean (SAVED_SEARCHING_KEY, false);
+                if (searching) {
+                    StartSearching ();
+                    contactsListAdapter.Search (searchEditText.Text);
+                }
+            }
+        }
+
         public override void OnResume ()
         {
             base.OnResume ();
@@ -167,6 +181,12 @@ namespace NachoClient.AndroidClient
         {
             base.OnPause ();
             NcApplication.Instance.StatusIndEvent -= StatusIndicatorCallback;
+        }
+
+        public override void OnSaveInstanceState (Bundle outState)
+        {
+            base.OnSaveInstanceState (outState);
+            outState.PutBoolean (SAVED_SEARCHING_KEY, searching);
         }
 
         void Letterbox_Click (object sender, EventArgs e)

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageFolderActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageFolderActivity.cs
@@ -21,7 +21,24 @@ namespace NachoClient.AndroidClient
     {
         private const string EXTRA_FOLDER = "com.nachocove.nachomail.EXTRA_FOLDER";
 
-        McFolder folder;
+        private const string DATA_FRAGMENT_TAG = "FolderDataFragment";
+
+        McFolder folder = null;
+
+        private McFolder Folder {
+            get {
+                if (null == folder) {
+                    var data = FragmentManager.FindFragmentByTag<DataFragment> (DATA_FRAGMENT_TAG);
+                    if (null == data) {
+                        data = new DataFragment ();
+                        data.Folder = IntentHelper.RetrieveValue<McFolder> (Intent.GetStringExtra (EXTRA_FOLDER));
+                        FragmentManager.BeginTransaction ().Add (data, DATA_FRAGMENT_TAG).Commit ();
+                    }
+                    folder = data.Folder;
+                }
+                return folder;
+            }
+        }
 
         public static Intent ShowFolderIntent (Context context, McFolder folder)
         {
@@ -33,8 +50,7 @@ namespace NachoClient.AndroidClient
 
         protected override INachoEmailMessages GetMessages (out List<int> adds, out List<int> deletes)
         {
-            folder = IntentHelper.RetrieveValue<McFolder> (Intent.GetStringExtra (EXTRA_FOLDER));
-            var messages = new NachoEmailMessages (folder);
+            var messages = new NachoEmailMessages (Folder);
             messages.Refresh (out adds, out deletes);
             return messages;
         }
@@ -48,8 +64,19 @@ namespace NachoClient.AndroidClient
             view.FindViewById<View> (Resource.Id.account).Visibility = ViewStates.Gone;
 
             var title = view.FindViewById<TextView> (Resource.Id.title);
-            title.Text = folder.DisplayName;
+            title.Text = Folder.DisplayName;
             title.Visibility = ViewStates.Visible;
+        }
+
+        private class DataFragment : Fragment
+        {
+            public McFolder Folder { get; set; }
+
+            public override void OnCreate (Bundle savedInstanceState)
+            {
+                base.OnCreate (savedInstanceState);
+                this.RetainInstance = true;
+            }
         }
     }
 }

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageListFragment.cs
@@ -73,12 +73,23 @@ namespace NachoClient.AndroidClient
         public event EventHandler<INachoEmailMessages> onThreadClick;
         public event EventHandler<McEmailMessageThread> onMessageClick;
 
-        public static MessageListFragment newInstance (INachoEmailMessages messages)
+        public void Initialize (INachoEmailMessages messages, EventHandler<McEvent> eventClickHandler, EventHandler<INachoEmailMessages> threadClickHandler, EventHandler<McEmailMessageThread> messageClickHandler)
         {
-            var fragment = new MessageListFragment ();
-            fragment.messages = messages;
-            fragment.ClearCache ();
-            return fragment;
+            this.messages = messages;
+            if (null != eventClickHandler) {
+                onEventClick += eventClickHandler;
+            }
+            if (null != threadClickHandler) {
+                onThreadClick += threadClickHandler;
+            }
+            if (null != messageClickHandler) {
+                onMessageClick += messageClickHandler;
+            }
+        }
+
+        public void Initialize (INachoEmailMessages messages, EventHandler<McEmailMessageThread> messageClickHandler)
+        {
+            Initialize (messages, null, null, messageClickHandler);
         }
 
         public override void OnCreate (Bundle savedInstanceState)

--- a/NachoClient.Android/NachoUI.Android/Activities/MoreActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MoreActivity.cs
@@ -19,17 +19,19 @@ using NachoCore.Utils;
 
 namespace NachoClient.AndroidClient
 {
-    [Activity (Label = "MoreActivity")]            
+    [Activity (Label = "MoreActivity")]
     public class MoreActivity : NcTabBarActivity
     {
+        private const string MORE_FRAGMENT_TAG = "MoreFragment";
 
         protected override void OnCreate (Bundle bundle)
         {
             base.OnCreate (bundle, Resource.Layout.MoreActivity);
 
-            var moreFragment = MoreFragment.newInstance ();
-            FragmentManager.BeginTransaction ().Replace (Resource.Id.content, moreFragment).Commit ();
+            if (null == bundle || null == FragmentManager.FindFragmentByTag<MoreFragment> (MORE_FRAGMENT_TAG)) {
+                var moreFragment = MoreFragment.newInstance ();
+                FragmentManager.BeginTransaction ().Replace (Resource.Id.content, moreFragment, MORE_FRAGMENT_TAG).Commit ();
+            }
         }
-
     }
 }

--- a/NachoClient.Android/NachoUI.Android/Activities/NcMessageListActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/NcMessageListActivity.cs
@@ -16,7 +16,7 @@ using NachoCore.Utils;
 
 namespace NachoClient.AndroidClient
 {
-    [Activity (Label = "NcMessageListActivity", ScreenOrientation = Android.Content.PM.ScreenOrientation.Portrait)]            
+    [Activity (Label = "NcMessageListActivity")]
     public class NcMessageListActivity : NcTabBarActivity, MessageListDelegate
     {
         protected McAccount account;
@@ -24,6 +24,8 @@ namespace NachoClient.AndroidClient
 
         private const string EXTRA_THREAD = "com.nachocove.nachomail.EXTRA_THREAD";
         private const string EXTRA_MESSAGE = "com.nachocove.nachomail.EXTRA_MESSAGE";
+
+        private const string MESSAGE_LIST_FRAGMENT_TAG = "MessageList";
 
         protected virtual INachoEmailMessages GetMessages (out List<int> adds, out List<int> deletes)
         {
@@ -49,19 +51,21 @@ namespace NachoClient.AndroidClient
         {
             base.OnCreate (bundle, Resource.Layout.NcMessageListActivity);
 
-            this.RequestedOrientation = Android.Content.PM.ScreenOrientation.Nosensor;
-
             account = NcApplication.Instance.Account;
 
             List<int> adds;
             List<int> deletes;
             var messages = GetMessages (out adds, out deletes);
 
-            messageListFragment = MessageListFragment.newInstance (messages);
-            messageListFragment.onEventClick += MessageListFragment_onEventClick;
-            messageListFragment.onThreadClick += MessageListFragment_onThreadClick;
-            messageListFragment.onMessageClick += MessageListFragment_onMessageClick;
-            FragmentManager.BeginTransaction ().Replace (Resource.Id.content, messageListFragment).Commit ();
+            messageListFragment = null;
+            if (null != bundle) {
+                messageListFragment = FragmentManager.FindFragmentByTag<MessageListFragment> (MESSAGE_LIST_FRAGMENT_TAG);
+            }
+            if (null == messageListFragment) {
+                messageListFragment = new MessageListFragment ();
+                FragmentManager.BeginTransaction ().Replace (Resource.Id.content, messageListFragment, MESSAGE_LIST_FRAGMENT_TAG).Commit ();
+            }
+            messageListFragment.Initialize (messages, MessageListFragment_onEventClick, MessageListFragment_onThreadClick, MessageListFragment_onMessageClick);
         }
 
         protected override void OnResume ()

--- a/NachoClient.Android/NachoUI.Android/Activities/NowActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/NowActivity.cs
@@ -16,12 +16,12 @@ using NachoCore.Utils;
 
 namespace NachoClient.AndroidClient
 {
-    [Activity (Label = "NowActivity")]            
+    [Activity (Label = "NowActivity")]
     public class NowActivity : NcTabBarActivity, MessageListDelegate
     {
+        private const string NOW_FRAGMENT_TAG = "NowFragment";
 
         NowFragment nowFragment;
-        MessageListFragment messageListFragment;
 
         protected override void OnCreate (Bundle bundle)
         {
@@ -31,11 +31,17 @@ namespace NachoClient.AndroidClient
 
             base.OnCreate (bundle, Resource.Layout.NowActivity);
 
-            nowFragment = new NowFragment ();
+            nowFragment = null;
+            if (null != bundle) {
+                nowFragment = FragmentManager.FindFragmentByTag<NowFragment> (NOW_FRAGMENT_TAG);
+            }
+            if (null == nowFragment) {
+                nowFragment = new NowFragment ();
+                FragmentManager.BeginTransaction ().Replace (Resource.Id.content, nowFragment, NOW_FRAGMENT_TAG).AddToBackStack ("Now").Commit ();
+            }
             nowFragment.onEventClick += NowFragment_onEventClick;
             nowFragment.onThreadClick += NowFragment_onThreadClick;
             nowFragment.onMessageClick += NowFragment_onMessageClick;
-            FragmentManager.BeginTransaction ().Replace (Resource.Id.content, nowFragment).AddToBackStack ("Now").Commit ();
         }
 
         public void ListIsEmpty()


### PR DESCRIPTION
More fixes for handling fragments, avoiding the creating of duplicate
fragments when rotating the device.  This update fixes most of the
activities that have a single non-dialog fragment.  Message list views
can now be rotated.  If the contacts view has a search in progress,
that search will be preserved when the device is rotated.

nachocove/qa#1360
