### PR TITLE
Fix quirky behavior when creating an all-day event late in the evening

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
@@ -502,6 +502,15 @@ namespace NachoClient.AndroidClient
 
         private void AllDayField_CheckedChange (object sender, CompoundButton.CheckedChangeEventArgs e)
         {
+            if (allDayField.Checked && !endTimeChanged && startTime.Date != endTime.Date && TimeSpan.FromHours (1) >= endTime - startTime) {
+                // The user changed the event be an all-day event.  The event is no more than
+                // an hour long, its start and end times are on different days, and the user
+                // hasn't explicitly changed the end time.  It is more likely that the user
+                // wants the event to be a single day rather than an multi-day all-day event.
+                // If the app is guessing incorrectly, the user can still correct the times
+                // before saving the event.
+                endTime = startTime;
+            }
             ConfigureStartEndFields ();
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -1505,6 +1505,15 @@ namespace NachoClient.iOS
         {
             eventEditStarted = true;
             if (allDaySwitch.On) {
+                if (!endChanged && startDate.ToLocalTime ().Date != endDate.ToLocalTime ().Date && TimeSpan.FromHours (1) >= endDate - startDate) {
+                    // The user changed the event be an all-day event.  The event is no more than
+                    // an hour long, its start and end times are on different days, and the user
+                    // hasn't explicitly changed the end time.  It is more likely that the user
+                    // wants the event to be a single day rather than an multi-day all-day event.
+                    // If the app is guessing incorrectly, the user can still correct the times
+                    // before saving the event.
+                    endDate = startDate;
+                }
                 startDateLabel.Text = Pretty.MediumFullDate (startDate);
                 startDateLabel.SizeToFit ();
                 startDateLabel.Frame = new CGRect (SCREEN_WIDTH - startDateLabel.Frame.Width - 15, 12.438f, startDateLabel.Frame.Width, TEXT_LINE_HEIGHT);


### PR DESCRIPTION
When the user creates an all-day event when the current local time is
between 10:30pm and 11:30pm, and the user doesn't make any other
adjustments to the start or end times, then the event will be two days
long.  It is more likely that the user wanted it to be only one day
long.  Fix the code (on both iOS and Android) to recognize this
unusual situation and make the event be only one day long.

Fix nachocove/qa#1370
