### PR TITLE
Better handling of fragments in support and settings views

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/AccountSettingsFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/AccountSettingsFragment.cs
@@ -26,6 +26,8 @@ namespace NachoClient.AndroidClient
         private const int DESCRIPTION_REQUEST_CODE = 2;
         private const int PASSWORD_REQUEST_CODE = 4;
 
+        private const string SAVED_ACCOUNT_ID_KEY = "AccountSettingsFragment.accountId";
+
         ButtonBar buttonBar;
 
         ImageView accountIcon;
@@ -69,6 +71,17 @@ namespace NachoClient.AndroidClient
             var fragment = new AccountSettingsFragment ();
             fragment.account = account;
             return fragment;
+        }
+
+        public override void OnCreate (Bundle savedInstanceState)
+        {
+            base.OnCreate (savedInstanceState);
+            if (null == account && null != savedInstanceState) {
+                int accountId = savedInstanceState.GetInt (SAVED_ACCOUNT_ID_KEY, 0);
+                if (0 != accountId) {
+                    account = McAccount.QueryById<McAccount> (accountId);
+                }
+            }
         }
 
         public override View OnCreateView (LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
@@ -209,6 +222,12 @@ namespace NachoClient.AndroidClient
             } else {
                 accountIssuesSeparator.Visibility = ViewStates.Gone;
             }
+        }
+
+        public override void OnSaveInstanceState (Bundle outState)
+        {
+            base.OnSaveInstanceState (outState);
+            outState.PutInt (SAVED_ACCOUNT_ID_KEY, account.Id);
         }
 
         public override void OnActivityResult (int requestCode, Result resultCode, Intent data)

--- a/NachoClient.Android/NachoUI.Android/Activities/SettingsActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/SettingsActivity.cs
@@ -19,16 +19,19 @@ namespace NachoClient.AndroidClient
     [Activity (Label = "SettingsActivity", WindowSoftInputMode = Android.Views.SoftInput.AdjustResize)]            
     public class SettingsActivity : NcTabBarActivity
     {
+        private const string SETTINGS_FRAGMENT_TAG = "SettingsFragment";
 
         protected override void OnCreate (Bundle bundle)
         {
             base.OnCreate (bundle, Resource.Layout.SettingsActivity);
 
-            var settingsFragment = SettingsFragment.newInstance ();
-            FragmentManager.BeginTransaction ().Replace (Resource.Id.content, settingsFragment).Commit ();
+            if (null == bundle || null == FragmentManager.FindFragmentByTag<SettingsFragment> (SETTINGS_FRAGMENT_TAG)) {
+                var settingsFragment = SettingsFragment.newInstance ();
+                FragmentManager.BeginTransaction ().Replace (Resource.Id.content, settingsFragment, SETTINGS_FRAGMENT_TAG).Commit ();
+            }
         }
 
-        public void AccountSettingsSelected(McAccount account)
+        public void AccountSettingsSelected (McAccount account)
         {
             var accountSettingsFragment = AccountSettingsFragment.newInstance (account);
             this.FragmentManager.BeginTransaction ().Add (Resource.Id.content, accountSettingsFragment).AddToBackStack ("AccountSettings").Commit ();
@@ -36,12 +39,11 @@ namespace NachoClient.AndroidClient
             
         public override void OnBackPressed ()
         {
-            var f = FragmentManager.FindFragmentById (Resource.Id.content);
-            if(f is AccountSettingsFragment) {
-                this.FragmentManager.PopBackStack ();
-                return;
+            if (0 < FragmentManager.BackStackEntryCount) {
+                FragmentManager.PopBackStack ();
+            } else {
+                base.OnBackPressed ();
             }
-            base.OnBackPressed ();
         }
 
         protected override void OnSaveInstanceState (Bundle outState)

--- a/NachoClient.Android/NachoUI.Android/Activities/SupportActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/SupportActivity.cs
@@ -16,26 +16,28 @@ using NachoCore.Utils;
 
 namespace NachoClient.AndroidClient
 {
-    [Activity (Label = "SupportActivity", WindowSoftInputMode = Android.Views.SoftInput.AdjustResize)]            
+    [Activity (Label = "SupportActivity", WindowSoftInputMode = Android.Views.SoftInput.AdjustResize)]
     public class SupportActivity : NcTabBarActivity
     {
+        private const string SUPPORT_FRAGMENT_TAG = "SupportFragment";
 
         protected override void OnCreate (Bundle bundle)
         {
             base.OnCreate (bundle, Resource.Layout.SupportActivity);
 
-            var supportFragment = SupportFragment.newInstance ();
-            FragmentManager.BeginTransaction ().Replace (Resource.Id.content, supportFragment).Commit ();
+            if (null == bundle || null == FragmentManager.FindFragmentByTag<SupportFragment> (SUPPORT_FRAGMENT_TAG)) {
+                var supportFragment = SupportFragment.newInstance ();
+                FragmentManager.BeginTransaction ().Replace (Resource.Id.content, supportFragment, SUPPORT_FRAGMENT_TAG).Commit ();
+            }
         }
 
         public override void OnBackPressed ()
         {
-            var f = FragmentManager.FindFragmentById (Resource.Id.content);
-            if (f is SupportMessageFragment) {
-                this.FragmentManager.PopBackStack ();
-                return;
+            if (0 < FragmentManager.BackStackEntryCount) {
+                FragmentManager.PopBackStack ();
+            } else {
+                base.OnBackPressed ();
             }
-            base.OnBackPressed ();
         }
 
         protected override void OnSaveInstanceState (Bundle outState)


### PR DESCRIPTION
Clean up the lifecycle of non-dialog fragments in SupportActivity and
SettingsActivity.  Those views now behave correctly when the device is
rotated.
