### PR TITLE
Proper handling of fragments in the new account views

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NcEmailSingleton.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcEmailSingleton.cs
@@ -99,10 +99,7 @@ namespace NachoClient.AndroidClient
             {
                 var s = (StatusIndEventArgs)e;
 
-                if (null == s.Account) {
-                    return;
-                }
-                if (NcApplication.Instance.Account.Id != s.Account.Id) {
+                if (null == s.Account || null == NcApplication.Instance.Account || NcApplication.Instance.Account.Id != s.Account.Id) {
                     return;
                 }
 

--- a/NachoClient.Android/NachoUI.Android/Activities/GettingStartedFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/GettingStartedFragment.cs
@@ -24,6 +24,8 @@ namespace NachoClient.AndroidClient
 
     public class GettingStartedFragment : Fragment
     {
+        private const string WELCOME_KEY = "GettingStarted.welcomeId";
+
         int welcomeId;
 
         // Just shows "Welcome to NachoMail"
@@ -37,6 +39,9 @@ namespace NachoClient.AndroidClient
         public override void OnCreate (Bundle savedInstanceState)
         {
             base.OnCreate (savedInstanceState);
+            if (null != savedInstanceState) {
+                welcomeId = savedInstanceState.GetInt (WELCOME_KEY, Resource.String.gettingstarted);
+            }
         }
 
         public override View OnCreateView (LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
@@ -49,6 +54,12 @@ namespace NachoClient.AndroidClient
             var submitButton = view.FindViewById<Button> (Resource.Id.submit);
             submitButton.Click += SubmitButton_Click;
             return view;
+        }
+
+        public override void OnSaveInstanceState (Bundle outState)
+        {
+            base.OnSaveInstanceState (outState);
+            outState.PutInt (WELCOME_KEY, welcomeId);
         }
 
         void SubmitButton_Click (object sender, EventArgs e)

--- a/NachoClient.Android/NachoUI.Android/Activities/GoogleSignInFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/GoogleSignInFragment.cs
@@ -20,6 +20,9 @@ namespace NachoClient.AndroidClient
 {
     public class GoogleSignInFragment : Fragment
     {
+        private const string ACCOUNT_ID_KEY = "accountId";
+        private const string SERVICE_KEY = "service";
+
         McAccount Account;
         McAccount.AccountServiceEnum Service;
 
@@ -36,6 +39,13 @@ namespace NachoClient.AndroidClient
         public override void OnCreate (Bundle savedInstanceState)
         {
             base.OnCreate (savedInstanceState);
+            if (null != savedInstanceState) {
+                int accountId = savedInstanceState.GetInt (ACCOUNT_ID_KEY, 0);
+                if (0 != accountId) {
+                    Account = McAccount.QueryById<McAccount> (accountId);
+                }
+                Service = (McAccount.AccountServiceEnum)savedInstanceState.GetInt (SERVICE_KEY, (int)McAccount.AccountServiceEnum.None);
+            }
         }
 
         public override View OnCreateView (LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
@@ -60,10 +70,13 @@ namespace NachoClient.AndroidClient
             }
         }
 
-        public override void OnResume ()
+        public override void OnSaveInstanceState (Bundle outState)
         {
-            base.OnResume ();
-
+            base.OnSaveInstanceState (outState);
+            if (null != Account) {
+                outState.PutInt (ACCOUNT_ID_KEY, Account.Id);
+            }
+            outState.PutInt (SERVICE_KEY, (int)Service);
         }
 
         void RestartAuthenticator ()

--- a/NachoClient.Android/NachoUI.Android/Activities/LaunchActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/LaunchActivity.cs
@@ -15,9 +15,11 @@ using NachoCore.Utils;
 
 namespace NachoClient.AndroidClient
 {
-    [Activity (Label = "LaunchActivity", WindowSoftInputMode = Android.Views.SoftInput.AdjustResize)]            
+    [Activity (Label = "LaunchActivity", WindowSoftInputMode = Android.Views.SoftInput.AdjustResize)]
     public class LaunchActivity : NcActivity, GettingStartedDelegate, ChooseProviderDelegate, CredentialsFragmentDelegate, WaitingFragmentDelegate
     {
+        private const string GETTING_STARTED_FRAGMENT_TAG = "GettingStarted";
+
         McAccount account;
 
         protected override void OnCreate (Bundle bundle)
@@ -28,8 +30,10 @@ namespace NachoClient.AndroidClient
 
             account = McAccount.GetAccountBeingConfigured ();
 
-            var gettingStartedFragment = GettingStartedFragment.newInstance (account);
-            FragmentManager.BeginTransaction ().Replace (Resource.Id.content, gettingStartedFragment).Commit ();
+            if (null == bundle || null == FragmentManager.FindFragmentByTag<GettingStartedFragment> (GETTING_STARTED_FRAGMENT_TAG)) {
+                var gettingStartedFragment = GettingStartedFragment.newInstance (account);
+                FragmentManager.BeginTransaction ().Replace (Resource.Id.content, gettingStartedFragment, GETTING_STARTED_FRAGMENT_TAG).Commit ();
+            }
         }
 
         protected override void OnResume ()
@@ -94,19 +98,12 @@ namespace NachoClient.AndroidClient
 
         public override void OnBackPressed ()
         {
-            var f = FragmentManager.FindFragmentById (Resource.Id.content);
-            if (f is GettingStartedFragment) {
-                this.FragmentManager.PopBackStack (); // Let me go!
-            }
-            if (f is ChooseProviderFragment) {
-                this.FragmentManager.PopBackStack (); // Let me go!
-            }
-            if (f is CredentialsFragment) {
-                ((CredentialsFragment)f).OnBackPressed ();
-                this.FragmentManager.PopBackStack (); // Let me go!
-            }
-            if (f is GoogleSignInFragment) {
-                this.FragmentManager.PopBackStack (); // Let me go!
+            if (0 < FragmentManager.BackStackEntryCount) {
+                var topFragment = FragmentManager.FindFragmentById (Resource.Id.content);
+                if (topFragment is CredentialsFragment) {
+                    ((CredentialsFragment)topFragment).OnBackPressed ();
+                }
+                FragmentManager.PopBackStack ();
             }
         }
 

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageListFragment.cs
@@ -94,8 +94,6 @@ namespace NachoClient.AndroidClient
 
         public override View OnCreateView (LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
-            // Use this to return your custom view for this Fragment
-            // return inflater.Inflate(Resource.Layout.YourFragment, container, false);
             var view = inflater.Inflate (Resource.Layout.MessageListFragment, container, false);
 
             if (Activity is NcTabBarActivity) {
@@ -674,8 +672,10 @@ namespace NachoClient.AndroidClient
         {
             ClearCache ();
             messages = newMessages;
-            messageListAdapter = new MessageListAdapter (this);
-            listView.Adapter = messageListAdapter;
+            if (null != listView) {
+                messageListAdapter = new MessageListAdapter (this);
+                listView.Adapter = messageListAdapter;
+            }
         }
 
         void RefreshVisibleMessageCells ()

--- a/NachoClient.Android/NachoUI.Android/Activities/WaitingFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/WaitingFragment.cs
@@ -25,6 +25,8 @@ namespace NachoClient.AndroidClient
 
     public class WaitingFragment : Fragment, ILoginEvents
     {
+        private const string ACCOUNT_ID_KEY = "accountId";
+
         TextView statusLabel;
         ProgressBar activityIndicatorView;
 
@@ -67,6 +69,9 @@ namespace NachoClient.AndroidClient
         public override void OnCreate (Bundle savedInstanceState)
         {
             base.OnCreate (savedInstanceState);
+            if (null != savedInstanceState) {
+                account = McAccount.QueryById<McAccount> (savedInstanceState.GetInt (ACCOUNT_ID_KEY));
+            }
         }
 
         public override View OnCreateView (LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
@@ -127,6 +132,12 @@ namespace NachoClient.AndroidClient
             }
         }
 
+        public override void OnSaveInstanceState (Bundle outState)
+        {
+            base.OnSaveInstanceState (outState);
+            outState.PutInt (ACCOUNT_ID_KEY, account.Id);
+        }
+
         void Update ()
         {
             statusLabel.Text = Message.Details;
@@ -166,8 +177,12 @@ namespace NachoClient.AndroidClient
                         DismissTimer.Dispose ();
                         DismissTimer = null;
                     }
-                    var parent = (WaitingFragmentDelegate)Activity;
-                    parent.WaitingFinished (account);
+                    if (null != this.Activity) {
+                        // The activity can be null if there was a configuration change while waiting for
+                        // the timer to fire.
+                        var parent = (WaitingFragmentDelegate)Activity;
+                        parent.WaitingFinished (account);
+                    }
                 });
             }, null, TimeSpan.FromSeconds (2), TimeSpan.Zero);
         }


### PR DESCRIPTION
Clean up the management of the fragments that are used when creating a
new account.  The app's behavior should now be correct when the device
is rotated any time during the account creation process.

Fix nachocove/qa#1360
