### PR TITLE
Enable the dial action in the attendee swipe menu

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/AttendeeListViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/AttendeeListViewFragment.cs
@@ -91,15 +91,16 @@ namespace NachoClient.AndroidClient
 
         private bool SwipeMenu_Click (int position, SwipeMenu menu, int index)
         {
+            var attendee = adapter [position];
             switch (index) {
             case EMAIL_SWIPE_TAG:
-                var attendee = adapter [position];
-                var message = McEmailMessage.MessageWithSubject (McAccount.QueryById<McAccount> (accountId), "");
-                message.To = attendee.Email;
-                StartActivity (MessageComposeActivity.InitialTextIntent (this.Activity, message, ""));
+                StartActivity (MessageComposeActivity.NewMessageIntent (this.Activity, attendee.Email));
                 break;
             case DIAL_SWIPE_TAG:
-                NcAlertView.ShowMessage (this.Activity, "Not yet implemented", "Calling an attendee is not yet implemented. Please try again later.");
+                var contact = McContact.QueryByEmailAddress (accountId, attendee.Email).FirstOrDefault ();
+                if (null != contact) {
+                    Util.CallNumber (this.Activity, contact, null);
+                }
                 break;
             }
             return false;

--- a/NachoClient.Android/NachoUI.Android/Support/Util.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/Util.cs
@@ -106,22 +106,26 @@ namespace NachoClient.AndroidClient
 
         public static void CallNumber(Context context, McContact contact, string alternatePhoneNumber)
         {
-            if (null != alternatePhoneNumber) {
-                var number = Android.Net.Uri.Parse (String.Format ("tel:{0}", alternatePhoneNumber));
-                context.StartActivity(new Intent(Intent.ActionDial, number));
-                return;
+            try {
+                if (null != alternatePhoneNumber) {
+                    var number = Android.Net.Uri.Parse (String.Format ("tel:{0}", alternatePhoneNumber));
+                    context.StartActivity (new Intent (Intent.ActionDial, number));
+                    return;
+                }
+                if (0 == contact.PhoneNumbers.Count) {
+                    NcAlertView.ShowMessage (context, "Cannot Call Contact", "This contact does not have a phone number.");
+                    return;
+                }
+                var phoneNumber = contact.GetDefaultOrSinglePhoneNumber ();
+                if (null == phoneNumber) {
+                    NcAlertView.ShowMessage (context, "Contact has multiple numbers", "Please select a number to call.");
+                    return;
+                }
+                var phoneUri = Android.Net.Uri.Parse (String.Format ("tel:{0}", phoneNumber));
+                context.StartActivity (new Intent (Intent.ActionDial, phoneUri));
+            } catch (ActivityNotFoundException) {
+                NcAlertView.ShowMessage (context, "Cannot Call", "This device does not support making phone calls.");
             }
-            if (0 == contact.PhoneNumbers.Count) {
-                NcAlertView.ShowMessage (context, "Cannot Call Contact", "This contact does not have a phone number.");
-                return;
-            }
-            var  phoneNumber = contact.GetDefaultOrSinglePhoneNumber ();
-            if (null == phoneNumber) {
-                NcAlertView.ShowMessage (context, "Contact has multiple numbers", "Please select a number to call.");
-                return;
-            }
-            var phoneUri = Android.Net.Uri.Parse (String.Format ("tel:{0}", alternatePhoneNumber));
-            context.StartActivity(new Intent(Intent.ActionDial, phoneUri));
         }
     }
 


### PR DESCRIPTION
Don't crash when the user tries to dial on a device with no phone app
(such as the simulator).
