### PR TITLE
make fetch print out less garbage, and better garbage if an update fails

### DIFF
--- a/scripts/fetch.py
+++ b/scripts/fetch.py
@@ -6,68 +6,92 @@ import os
 import threading
 import subprocess
 import time
+from argparse import ArgumentParser
+
 import repos_cfg
 
-
 class FetchThread(threading.Thread):
-    def __init__(self, repo, parent_dir):
+    def __init__(self, repo, parent_dir, options):
         super(FetchThread, self).__init__()
         self.repo = repo
         self.parent_dir = parent_dir
-        self._return = None
+        self.stderr = []
+        self.stdout = []
+        self.repo_dir = os.path.join(self.parent_dir, self.repo)
+        self.returncode = None
+        self.options = options
 
     def join(self, *args, **kwargs):
         super(FetchThread, self).join(*args, **kwargs)
-        return self._return
+        return self.returncode
 
     def run(self):
-        self._return = self.nacho_run()
+        self.nacho_run()
+
+    def clone (self):
+        cmd = ['git', 'clone', '-q', 'git@github.com:nachocove/%s.git' % self.repo]
+        return self.run_cmd(self.parent_dir, cmd, "fetching")
+
+    def update (self):
+        cmd = ['git', 'pull']
+        return self.run_cmd(self.repo_dir, cmd, "updating")
+
+    def submodule (self):
+        cmd = ['git', 'submodule', 'update', '--init', '--recursive']
+        return self.run_cmd(self.repo_dir, cmd, "updating submodules")
+
+    def run_cmd (self, dir, cmd, verb):
+        if not self.options.quiet or self.options.debug:
+            print '%s %s...' % (verb.capitalize(), self.repo)
+        start = time.time()
+        os.chdir(dir)
+        self.stdout.append("Running: %s" % cmd)
+        repo_update = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (error, output) = repo_update.communicate()
+        if error:
+            self.stderr.append(error)
+        if output:
+            self.stdout.append(output)
+        self.returncode = repo_update.returncode
+        if repo_update.returncode != 0:
+            if self.options.debug:
+                print 'ERROR: failed to fetch %s!' % self.repo
+                print output
+                print error
+        etime = time.time() - start
+        if not self.options.quiet or self.options.debug:
+            print 'Done %s %s (%.2f sec)!' % (verb, self.repo, etime)
+        return True if repo_update.returncode == 0 else False
 
     def nacho_run(self):
-        start = time.time()
-        repo_dir = os.path.join(self.parent_dir, self.repo)
-        if not os.path.exists(repo_dir):
+        if not os.path.exists(self.repo_dir):
             # git clone
-            print 'Fetching %s...' % self.repo
-            # os.mkdir(repo_dir)
-            os.chdir(self.parent_dir)
-            try:
-                rc = subprocess.check_call(['git', 'clone', '-q', 'git@github.com:nachocove/%s.git' % self.repo])
-            except subprocess.CalledProcessError as e:
-                print 'ERROR: failed to fetch %s!' % self.repo
-                return 1
-            etime = time.time() - start
-            print 'Done fetching %s (%.2f sec)!' % (self.repo, etime)
+            if not self.clone():
+                return
         else:
             # git pull
-            print 'Updating %s...' % self.repo
-            os.chdir(repo_dir)
-            try:
-                rc = subprocess.check_call(['git', 'pull'])
-            except subprocess.CalledProcessError as e:
-                print 'ERROR: failed to pull %s!' % self.repo
-                return 1
-            etime = time.time() - start
-            print 'Done pulling %s (%.2f sec)!' % (self.repo, etime)
-        try:
-            print 'Start submodule fetching %s' % (self.repo)
-            os.chdir(repo_dir)
-            rc = subprocess.check_call(['git', 'submodule', 'update', '--init', '--recursive'])
-        except subprocess.CalledProcessError as e:
-            print 'ERROR: failed to update submodule  %s!' % self.repo
-            return 1
+            if not self.update():
+                return
 
-        return 0
+        if not self.submodule():
+            return
 
 def main():
-    if 1 == len(sys.argv):
+    parser = ArgumentParser()
+    parser.add_argument("-q", "--quiet", action="store_true", help="Less verbose output", default=False)
+    parser.add_argument("-d", "--debug", action="store_true", help="More verbose output", default=False)
+    parser.add_argument("repo", nargs="*", type=str, default=[])
+    options = parser.parse_args()
+
+    if not options.repo:
         # If no repo is given, use the default list
         repo_list = repos_cfg.repos
     else:
-        repo_list = sys.argv[1:]
+        repo_list = options.repo
+
     start = time.time()
     repos_dir = os.path.abspath('..')
-    threads = [FetchThread(repo=repo, parent_dir=repos_dir) for repo in repo_list]
+    threads = [FetchThread(repo=repo, parent_dir=repos_dir, options=options) for repo in repo_list]
     for thread in threads:
         thread.start()
 
@@ -78,9 +102,14 @@ def main():
             failed_repos.append(thread)
 
     if failed_repos:
-        print
+        print # empty line
         for failed in failed_repos:
-            print "ERROR: Update/fetch failed for: %s" % failed.repo
+            print "ERROR: Update/fetch failed for: %s (ret %s)" % (failed.repo, failed.returncode)
+            print "\n".join(failed.stdout)
+            print "\n".join(failed.stderr)
+    else:
+        print "Good news, everyone! All Repos updated successfully!"
+
     print 'Total runtime: %.2f sec' % (time.time() - start)
     sys.exit(0 if not failed_repos else 1)
 


### PR DESCRIPTION
added options -d (debug) and -q (quiet)

Examples:
Success:

```
NachoPro:NachoClientX jan_vilhuber$ python scripts/fetch.py -q
Good news, everyone! All Repos updated successfully!
Total runtime: 4.89 sec
```

Error:

```
NachoPro:NachoClientX jan_vilhuber$ python scripts/fetch.py -q

ERROR: Update/fetch failed for: DnDns (ret 1)
Running: ['git', 'pull']
Your configuration specifies to merge with the ref 'more-ipv6-fixes'
from the remote, but no such ref was fetched.


Total runtime: 4.49 sec
```
