### PR TITLE
Make event notifications high priority

### DIFF
--- a/NachoClient.Android/NachoPlatform.Android/NotifAndroid.cs
+++ b/NachoClient.Android/NachoPlatform.Android/NotifAndroid.cs
@@ -124,6 +124,8 @@ namespace NachoClient.AndroidClient
             builder.SetLargeIcon (largeIcon);
 
             builder.SetSmallIcon (Resource.Drawable.Loginscreen_2);
+            builder.SetPriority (NotificationCompat.PriorityHigh);
+            builder.SetCategory (NotificationCompat.CategoryEvent);
             builder.SetContentTitle ("Nacho Mail");
             builder.SetContentText (message);
             builder.SetAutoCancel (true);


### PR DESCRIPTION
Event notification are given the correct category and are marked as
high priority.  (High priority is supposed to trigger a heads-up
notification, but I can't get that to happen.  Not sure why, and
Android docs aren't very helpful.  But this is obviously the right way
to set the priority, so I am checking in the change.)
