### PR TITLE
Turn on vibration for event notifications

### DIFF
--- a/NachoClient.Android/NachoPlatform.Android/NotifAndroid.cs
+++ b/NachoClient.Android/NachoPlatform.Android/NotifAndroid.cs
@@ -126,6 +126,7 @@ namespace NachoClient.AndroidClient
             builder.SetSmallIcon (Resource.Drawable.Loginscreen_2);
             builder.SetPriority (NotificationCompat.PriorityHigh);
             builder.SetCategory (NotificationCompat.CategoryEvent);
+            builder.SetVibrate (new long[] { 0, 100 }); // Vibration or sound needs to be set to trigger a heads-up notification.
             builder.SetContentTitle ("Nacho Mail");
             builder.SetContentText (message);
             builder.SetAutoCancel (true);


### PR DESCRIPTION
Sound or vibration is necessary, along with high priority, to cause a
heads-up notification.  We are going with vibration for now.
