### PR TITLE
Better text for event notifications; remove notification when done

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/Pretty.cs
+++ b/NachoClient.Android/NachoCore/Utils/Pretty.cs
@@ -479,6 +479,27 @@ namespace NachoCore.Utils
             return string.Format ("in {0}:{1:D2}", minutes / 60, minutes % 60);
         }
 
+        public static void EventNotification (McEvent ev, out string title, out string body)
+        {
+            var calendarItem = ev.GetCalendarItemforEvent ();
+            if (null == calendarItem) {
+                title = "Event";
+            } else {
+                title = Pretty.SubjectString (calendarItem.GetSubject ());
+            }
+            if (ev.AllDayEvent) {
+                body = string.Format ("{0} all day", Pretty.MediumFullDate (ev.GetStartTimeLocal ()));
+            } else {
+                body = string.Format ("{0} - {1}", Pretty.Time (ev.GetStartTimeLocal ()), Pretty.Time (ev.GetEndTimeLocal ()));
+            }
+            if (null != calendarItem) {
+                var location = calendarItem.GetLocation ();
+                if (!string.IsNullOrEmpty (location)) {
+                    body += ": " + location;
+                }
+            }
+        }
+
         public static string PrettyFileSize (long fileSize)
         {
             NcAssert.True (0 <= fileSize);

--- a/NachoClient.Android/NachoPlatform/IPlatform.cs
+++ b/NachoClient.Android/NachoPlatform/IPlatform.cs
@@ -104,23 +104,6 @@ namespace NachoPlatform
     }
 
     /// <summary>
-    /// Information necessary for a notification of an upcoming event.
-    /// </summary>
-    public struct NotificationInfo
-    {
-        public int Handle;
-        public DateTime When;
-        public string Message;
-
-        public NotificationInfo (int handle, DateTime when, string message)
-        {
-            Handle = handle;
-            When = when;
-            Message = message;
-        }
-    }
-
-    /// <summary>
     /// Local notifications.  Used to inform the user about events in the near future.
     /// </summary>
     public interface IPlatformNotif
@@ -128,20 +111,12 @@ namespace NachoPlatform
         /// <summary>
         /// Notify the user right away.
         /// </summary>
-        void ImmediateNotification (int handle, string message);
+        void ImmediateNotification (McEvent ev);
 
         /// <summary>
         /// Schedule a notification some time in the future.
         /// </summary>
-        /// <param name="handle">An identifier that can be used to cancel the notification.</param>
-        /// <param name="when">When the notification should happen.</param>
-        /// <param name="message">The message to display to the user.</param>
-        void ScheduleNotification (int handle, DateTime when, string message);
-
-        /// <summary>
-        /// Schedule a notification some time in the future.
-        /// </summary>
-        void ScheduleNotification (NotificationInfo notification);
+        void ScheduleNotification (McEvent ev);
 
         /// <summary>
         /// Schedule a set of notifications. This might replace all existing
@@ -151,12 +126,12 @@ namespace NachoPlatform
         /// <remarks>iOS and Android have very different capabilities for
         /// local notifications, which makes it difficult to nail down the
         /// exact behavior of this method.</remarks>
-        void ScheduleNotifications (List<NotificationInfo> notifications);
+        void ScheduleNotifications (List<McEvent> events);
 
         /// <summary>
-        /// Cancel the scheduled notification with the given handle.
+        /// Cancel the scheduled notification with the given ID.
         /// </summary>
-        void CancelNotification (int handle);
+        void CancelNotification (int eventId);
     }
 
     public abstract class PlatformContactRecord

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -843,25 +843,14 @@ namespace NachoClient.iOS
                 if ((0 == emailMutables.Count) && (0 == eventMutables.Count)) {
                     // Now we know that the app was already running.  In this case,
                     // we notify the user of the upcoming event with an alert view.
-                    if (null != eventNotification) {
-                        var eventId = eventNotification.ToMcModelIndex ();
-                        var eventItem = McEvent.QueryById<McEvent> (eventId);
-                        if (null != eventItem) {
-                            var calendarItem = McCalendar.QueryById<McCalendar> (eventItem.CalendarId);
-                            if (null != calendarItem) {
-                                var subject = Pretty.SubjectString (calendarItem.Subject);
-                                if (!String.IsNullOrEmpty (subject)) {
-                                    subject += " ";
-                                } else {
-                                    subject = "Event at ";
-                                }
-                                var msg = subject + Pretty.MediumFullDateTime (eventItem.GetStartTimeUtc ());
-                                UIAlertView alert = new UIAlertView ("Reminder", msg, null, "OK", null);
-
-                                alert.Show ();
-                            }
-                        }
+                    string title = notification.AlertTitle;
+                    string body = notification.AlertBody;
+                    if (string.IsNullOrEmpty (title)) {
+                        title = "Reminder";
+                    } else if (body.StartsWith (title + ": ")) {
+                        body = body.Substring (title.Length + 2);
                     }
+                    new UIAlertView (title, body, null, "OK").Show ();
                     return;
                 }
             }


### PR DESCRIPTION
Improve the text of event notification on both iOS and Android.

On Android, automatically remove the notification for an event once
the event is over (if the user hasn't already dismissed it).  This
prevents notifications from accumulating over time.
