### PR TITLE
Keep the calendar view up to date

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
@@ -322,7 +322,8 @@ namespace NachoClient.AndroidClient
             var s = (StatusIndEventArgs)e;
 
             switch (s.Status.SubKind) {
-            case NcResult.SubKindEnum.Info_CalendarSetChanged:
+            case NcResult.SubKindEnum.Info_EventSetChanged:
+            case NcResult.SubKindEnum.Info_SystemTimeZoneChanged:
                 Refresh ();
                 break;
             }


### PR DESCRIPTION
The Android calendar view was listening for the wrong event to trigger
a refresh.  It needs to listen for EventSetChanged, not
CalendarSetChanged.  This resulted in the calendar view sometimes
being out of date with no obvious way to refresh it.
