### PR TITLE
register the broadcast received only once we're initialized

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcTask.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcTask.cs
@@ -109,6 +109,7 @@ namespace NachoCore.Utils
 
         public static Task Run (Action action, string name, bool stfu, bool isUnique, TaskCreationOptions option = TaskCreationOptions.None)
         {
+            NcAssert.NotNull (TaskMap);
             string dummy = null;
             var taskId = Interlocked.Increment (ref TaskId);
             var taskName = name + taskId.ToString ();


### PR DESCRIPTION
otherwise it’s possible we’re called before the app starts running and
bad things happen.
