### PR TITLE
fix scrolling and zooming (mostly) in message view

### DIFF
--- a/NachoClient.Android/Resources/layout/MessageViewFragment.axml
+++ b/NachoClient.Android/Resources/layout/MessageViewFragment.axml
@@ -6,7 +6,8 @@
     android:background="@android:color/white">
     <include
         layout="@layout/ButtonBar" />
-    <ScrollView
+    <NachoClient.AndroidClient.MessageScrollView
+        android:id="@+id/message_scrollview"
         android:layout_above="@+id/footer"
         android:layout_below="@id/button_bar"
         android:orientation="vertical"
@@ -36,7 +37,7 @@
                 android:layout_height="0dp"
                 android:layout_weight="1" />
         </LinearLayout>
-    </ScrollView>
+    </NachoClient.AndroidClient.MessageScrollView>
     <LinearLayout
         android:id="@+id/footer"
         android:layout_alignParentBottom="true"


### PR DESCRIPTION
The zooming still needs work.  While it properly scales and re-renders the web view, parts of the message become unreachable, as if the scroll view thinks it's already at the top.
