### PR TITLE
Support the Android device calendar

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NcEventsCalendarMap.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcEventsCalendarMap.cs
@@ -41,7 +41,7 @@ namespace NachoCore
         /// Get the events that should be displayed.  The list of events must be in chronological
         /// order.
         /// </summary>
-        protected abstract List<McEvent> GetEvents ();
+        protected abstract List<McEvent> GetEventsWithDuplicates ();
 
         protected NcEventsCalendarMapCommon ()
         {
@@ -274,30 +274,12 @@ namespace NachoCore
             }, "NcEventsCalendarMapCommonRefresh");
         }
 
-        /// <summary>
-        /// Return the midnight that is the same or later than the given date/time
-        /// </summary>
-        private DateTime NextMidnight (DateTime time)
-        {
-            DateTime midnight = time.ToLocalTime ().Date;
-            if (midnight != time) {
-                midnight = midnight.AddDays (1);
-            }
-            return midnight;
-        }
-    }
-
-    /// <summary>
-    /// A mapping between events and days on a calendar where all events are displayed.
-    /// </summary>
-    public class NcAllEventsCalendarMap : NcEventsCalendarMapCommon
-    {
-        protected override List<McEvent> GetEvents ()
+        private List<McEvent> GetEvents ()
         {
             var deviceAccount = McAccount.GetDeviceAccount ().Id;
             var currentAccount = NcApplication.Instance.Account.Id;
 
-            var result = McEvent.QueryAllEventsInOrder ();
+            var result = GetEventsWithDuplicates ();
 
             // Go through the list of events, removing duplicates.  In the initial pass, set any duplicate events
             // to null.  Then remove any null events in a single call to RemoveAll().  This two pass approach
@@ -332,6 +314,29 @@ namespace NachoCore
             });
 
             return result;
+        }
+
+        /// <summary>
+        /// Return the midnight that is the same or later than the given date/time
+        /// </summary>
+        private DateTime NextMidnight (DateTime time)
+        {
+            DateTime midnight = time.ToLocalTime ().Date;
+            if (midnight != time) {
+                midnight = midnight.AddDays (1);
+            }
+            return midnight;
+        }
+    }
+
+    /// <summary>
+    /// A mapping between events and days on a calendar where all events are displayed.
+    /// </summary>
+    public class NcAllEventsCalendarMap : NcEventsCalendarMapCommon
+    {
+        protected override List<McEvent> GetEventsWithDuplicates ()
+        {
+            return McEvent.QueryAllEventsInOrder ();
         }
     }
 }

--- a/NachoClient.Android/NachoCore/Model/McEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McEvent.cs
@@ -148,6 +148,16 @@ namespace NachoCore.Model
         }
 
         /// <summary>
+        /// All events where at least part of the event is within the given range.  The events are returned in random order.
+        /// </summary>
+        public static List<McEvent> QueryEventsInRange (DateTime start, DateTime end)
+        {
+            start = start.ToUniversalTime ();
+            end = end.ToUniversalTime ();
+            return NcModel.Instance.Db.Table<McEvent> ().Where (x => x.EndTime >= start || x.StartTime < end).ToList ();
+        }
+
+        /// <summary>
         /// All events that have a reminder time within the given range, ordered by reminder time.
         /// </summary>
         public static IEnumerable<McEvent> QueryEventsWithRemindersInRange (DateTime start, DateTime end)

--- a/NachoClient.Android/NachoPlatform.Android/CalendarsAndroid.cs
+++ b/NachoClient.Android/NachoPlatform.Android/CalendarsAndroid.cs
@@ -6,9 +6,142 @@ using System.Linq;
 using NachoCore;
 using NachoCore.Utils;
 using NachoCore.Model;
+using NachoClient.AndroidClient;
+using Android.Provider;
+using Android.Content;
+using Android.Database;
 
 namespace NachoPlatform
 {
+    /// <summary>
+    /// Access the Android device calendar database, other than synching all the events into Nacho Mail.
+    /// </summary>
+    public static class AndroidCalendars
+    {
+        private static string[] instancesProjection = new string[] {
+            CalendarContract.Instances.EventId,
+            CalendarContract.Instances.Begin,
+            CalendarContract.Instances.End,
+            CalendarContract.Instances.InterfaceConsts.AllDay,
+            CalendarContract.Instances.InterfaceConsts.Uid2445,
+        };
+        private const int INSTANCES_EVENT_ID_INDEX = 0;
+        private const int INSTANCES_BEGIN_INDEX = 1;
+        private const int INSTANCES_END_INDEX = 2;
+        private const int INSTANCES_ALL_DAY_INDEX = 3;
+        private const int INSTANCES_UID_INDEX = 4;
+
+        /// <summary>
+        /// Create in-memory McEvent objects for all of the device events within the given date range.
+        /// The McEvents that are crated will have a negative CalendarId, which is the negative value
+        /// of the event's ID in the Android database.
+        /// </summary>
+        public static List<McEvent> GetDeviceEvents (DateTime startRange, DateTime endRange)
+        {
+            var resolver = MainApplication.Instance.ContentResolver;
+            var uriBuilder = CalendarContract.Instances.ContentSearchUri.BuildUpon ();
+            ContentUris.AppendId (uriBuilder, startRange.MillisecondsSinceEpoch ());
+            ContentUris.AppendId (uriBuilder, endRange.MillisecondsSinceEpoch ());
+            ICursor eventCursor;
+            try {
+                eventCursor = CalendarContract.Instances.Query (resolver, instancesProjection, startRange.MillisecondsSinceEpoch (), endRange.MillisecondsSinceEpoch ());
+            } catch (Exception e) {
+                Log.Error (Log.LOG_SYS, "Querying device events failed with {0}", e.ToString ());
+                return new List<McEvent> ();
+            }
+
+            var deviceAccount = McAccount.GetDeviceAccount ().Id;
+
+            var result = new List<McEvent> ();
+
+            while (eventCursor.MoveToNext ()) {
+                long eventId = eventCursor.GetLong (INSTANCES_EVENT_ID_INDEX);
+                DateTime start = eventCursor.GetLong (INSTANCES_BEGIN_INDEX).JavaMsToDateTime ();
+                DateTime end = eventCursor.GetLong (INSTANCES_END_INDEX).JavaMsToDateTime ();
+                bool allDay = eventCursor.GetInt (INSTANCES_ALL_DAY_INDEX) != 0;
+                string uid = eventCursor.GetString (INSTANCES_UID_INDEX);
+
+                result.Add (new McEvent () {
+                    AccountId = deviceAccount,
+                    CalendarId = (int)(-eventId),
+                    StartTime = start,
+                    EndTime = end,
+                    AllDayEvent = allDay,
+                    UID = uid,
+                });
+            }
+
+            return result;
+        }
+
+        private static string[] eventProjection = new string[] {
+            Android.Provider.CalendarContract.Events.InterfaceConsts.Title,
+            Android.Provider.CalendarContract.Events.InterfaceConsts.EventLocation,
+        };
+        private const int EVENT_TITLE_INDEX = 0;
+        private const int EVENT_LOCATION_INDEX = 1;
+
+        /// <summary>
+        /// Get some of the details for a particular event in the Android calendar database.
+        /// </summary>
+        public static bool GetEventDetails (long eventId, out string title, out string location, out int colorIndex)
+        {
+            title = null;
+            location = null;
+            colorIndex = 0;
+            var resolver = MainApplication.Instance.ContentResolver;
+            ICursor eventCursor;
+            try {
+                eventCursor = resolver.Query(CalendarContract.Events.ContentUri,eventProjection,CalendarContract.Events.InterfaceConsts.Id + " = ?", new string[] { eventId.ToString() }, null, null);
+            } catch (Exception e) {
+                Log.Error (Log.LOG_SYS, "Looking up device details failed with {0}", e.ToString ());
+                return false;
+            }
+            if (!eventCursor.MoveToNext ()) {
+                return false;
+            }
+            title = eventCursor.GetString (EVENT_TITLE_INDEX);
+            location = eventCursor.GetString (EVENT_LOCATION_INDEX);
+
+            // TODO Somehow get the color from the calendar that owns this event.
+            colorIndex = McFolder.GetDeviceCalendarsFolder().DisplayColor;
+
+            return true;
+        }
+
+        /// <summary>
+        /// An Android intent that will view the given event in the Android calendar app.
+        /// </summary>
+        public static Intent ViewEventIntent (McEvent ev)
+        {
+            var intent = new Intent (Intent.ActionView, ContentUris.WithAppendedId (CalendarContract.Events.ContentUri, -ev.CalendarId));
+            intent.PutExtra (CalendarContract.ExtraEventBeginTime, ev.StartTime.MillisecondsSinceEpoch ());
+            intent.PutExtra (CalendarContract.ExtraEventEndTime, ev.EndTime.MillisecondsSinceEpoch ());
+            return intent;
+        }
+
+        /// <summary>
+        /// An Android intent to create a new event using the Android calendar app.
+        /// </summary>
+        /// <returns>The event intent.</returns>
+        public static Intent NewEventIntent ()
+        {
+            return NewEventOnDayIntent (DateTime.Now);
+        }
+
+        /// <summary>
+        /// An Android intent to create a new event on the given day using the Android calendar app.
+        /// </summary>
+        public static Intent NewEventOnDayIntent (DateTime day)
+        {
+            var tempCal = CalendarHelper.DefaultMeeting (day);
+            var intent = new Intent (Intent.ActionInsert, CalendarContract.Events.ContentUri);
+            intent.PutExtra (CalendarContract.ExtraEventBeginTime, tempCal.StartTime.MillisecondsSinceEpoch ());
+            intent.PutExtra (CalendarContract.ExtraEventEndTime, tempCal.EndTime.MillisecondsSinceEpoch ());
+            return intent;
+        }
+    }
+
     public sealed class Calendars : IPlatformCalendars
     {
         private const int SchemaRev = 0;
@@ -32,26 +165,14 @@ namespace NachoPlatform
             }
         }
 
-        public class PlatformCalendarRecordAndroid : PlatformCalendarRecord
-        {
-            public override string ServerId { get { return null; } }
-
-            public override DateTime LastUpdate { get { return DateTime.MaxValue; } } // FIXME.
-
-            public override PlatformCalendarFolderRecord ParentFolder { get { return null; } }
-
-            public override NcResult ToMcCalendar ()
-            {
-                return null;
-            }
-
-        }
         public void AskForPermission (Action<bool> result)
         {
+            // Permissions are controlled by the app's manifest.  They aren't changed at runtime.
         }
 
         public void GetCalendars (out IEnumerable<PlatformCalendarFolderRecord> folders, out IEnumerable<PlatformCalendarRecord> events)
         {
+            // On Android, calendars are not synched.  Calendar items are accessed on demand.
             folders = null;
             events = null;
         }
@@ -75,7 +196,6 @@ namespace NachoPlatform
 
         public bool AuthorizationStatus {
             get {
-                // TODO Not yet implemented.
                 return false;
             }
         }

--- a/NachoClient.Android/NachoPlatform.Android/ContactsAndroid.cs
+++ b/NachoClient.Android/NachoPlatform.Android/ContactsAndroid.cs
@@ -2,16 +2,16 @@
 //
 using System;
 using System.Collections.Generic;
-using NachoCore.Model;
-using NachoCore.Utils;
+using System.IO;
+using Android.Content;
+using Android.Graphics;
+using Android.OS;
 using Android.Provider;
 using NachoClient.AndroidClient;
-using Android.Content;
-using NachoPlatform;
-using System.IO;
-using Android.Graphics;
 using NachoCore.ActiveSync;
-using Android.OS;
+using NachoCore.Model;
+using NachoCore.Utils;
+using NachoPlatform;
 
 namespace NachoPlatform
 {
@@ -76,7 +76,7 @@ namespace NachoPlatform
                     long id = GetFieldLong (cur, ContactsContract.Contacts.InterfaceConsts.Id);
 
                     String lastUpdateString = GetField (cur, ContactsContract.Contacts.InterfaceConsts.ContactLastUpdatedTimestamp);
-                    var lastUpdate = FromUnixTimeMilliseconds (lastUpdateString);
+                    var lastUpdate = FromUnixTimeMilliseconds (lastUpdateString, DateTime.UtcNow);
                     //bool HasPhoneNumber = int.Parse (GetField (cur, ContactsContract.Contacts.InterfaceConsts.HasPhoneNumber)) > 0;
                     var entry = new PlatformContactRecordAndroid (deviceAccount, id, lastUpdate);
                     retval.Add (entry);
@@ -129,11 +129,13 @@ namespace NachoPlatform
             return cur.GetLong (cur.GetColumnIndex (Column));
         }
 
-        public static DateTime FromUnixTimeMilliseconds (string unixTimeStr)
+        public static DateTime FromUnixTimeMilliseconds (string unixTimeStr, DateTime defaultValue)
         {
-            long unixTime = long.Parse (unixTimeStr);
-            var d = new DateTime (1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            return d.AddMilliseconds (unixTime);
+            try {
+                return long.Parse (unixTimeStr).JavaMsToDateTime ();
+            } catch (Exception) {
+                return defaultValue;
+            }
         }
 
         #endregion

--- a/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
@@ -17,6 +17,7 @@ using NachoCore.Utils;
 using NachoCore.Model;
 using NachoCore;
 using NachoCore.ActiveSync;
+using NachoPlatform;
 
 namespace NachoClient.AndroidClient
 {
@@ -322,17 +323,25 @@ namespace NachoClient.AndroidClient
 
         public static Intent NewEventIntent (Context context)
         {
-            var intent = new Intent (context, typeof(EventEditActivity));
-            intent.SetAction (Intent.ActionCreateDocument);
-            return intent;
+            if (NcApplication.Instance.Account.HasCapability (McAccount.AccountCapabilityEnum.CalWriter)) {
+                var intent = new Intent (context, typeof(EventEditActivity));
+                intent.SetAction (Intent.ActionCreateDocument);
+                return intent;
+            } else {
+                return AndroidCalendars.NewEventIntent ();
+            }
         }
 
         public static Intent NewEventOnDayIntent (Context context, DateTime day)
         {
-            var intent = new Intent (context, typeof(EventEditActivity));
-            intent.SetAction (Intent.ActionCreateDocument);
-            intent.PutExtra (EXTRA_START_DATE, day.ToString ("O"));
-            return intent;
+            if (NcApplication.Instance.Account.HasCapability (McAccount.AccountCapabilityEnum.CalWriter)) {
+                var intent = new Intent (context, typeof(EventEditActivity));
+                intent.SetAction (Intent.ActionCreateDocument);
+                intent.PutExtra (EXTRA_START_DATE, day.ToString ("O"));
+                return intent;
+            } else {
+                return AndroidCalendars.NewEventOnDayIntent (day);
+            }
         }
 
         public static Intent EditEventIntent (Context context, McEvent ev)

--- a/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
@@ -66,6 +66,10 @@ namespace NachoClient.AndroidClient
             base.OnActivityCreated (savedInstanceState);
             this.ev = ((IEventViewFragmentOwner)Activity).EventToView;
             this.detail = new NcEventDetail (ev);
+            if (!detail.IsValid) {
+                EventWasDeleted ();
+                return;
+            }
             userResponse = detail.SpecificItem.HasResponseType () ? detail.SpecificItem.GetResponseType () : NcResponseType.None;
             BindEventView ();
             if (null != savedInstanceState) {

--- a/NachoClient.Android/Properties/AndroidManifest.xml
+++ b/NachoClient.Android/Properties/AndroidManifest.xml
@@ -11,4 +11,5 @@
 	<uses-permission android:name="android.permission.BLUETOOTH" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
 	<uses-permission android:name="android.permission.CAMERA" />
+	<uses-permission android:name="android.permission.READ_CALENDAR" />
 </manifest>

--- a/Test.Android/NcEventsCommonTest.cs
+++ b/Test.Android/NcEventsCommonTest.cs
@@ -23,7 +23,7 @@ namespace Test.Common
 
         public class EmptyInstance : NcEventsCalendarMapCommon
         {
-            protected override System.Collections.Generic.List<McEvent> GetEvents ()
+            protected override System.Collections.Generic.List<McEvent> GetEventsWithDuplicates ()
             {
                 return new System.Collections.Generic.List<NachoCore.Model.McEvent> ();
             }
@@ -31,7 +31,7 @@ namespace Test.Common
 
         public class Instance1 : NcEventsCalendarMapCommon
         {
-            protected override System.Collections.Generic.List<McEvent> GetEvents ()
+            protected override System.Collections.Generic.List<McEvent> GetEventsWithDuplicates ()
             {
                 var id = account.Id;
 


### PR DESCRIPTION
This is done very differently from iOS.  Synching the device calendar
with the app is problematic because Android does not keep a "last
modified" field for events, so there is no feasible way to figure out
which events need to be synched.

Instead, events are read from the Android calendar database as needed
when showing the calendar list view.  When the user want to view an
event detail or create a new event, an activity is started in the
Android calendar app.

The code is mostly complete.  But there are still some edge cases,
limitations, and bugs that need to be dealt with.  Fixing those issues
will happen after it has been decided whether or not this is the
correct approach for handling the Android calendar.
