### PR TITLE
Fix race condition crash in HotEventView.ConfigureCurrentEvent()

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
@@ -80,11 +80,7 @@ namespace NachoCore.Utils
             if (null == e) {
                 return null;  // may be deleted
             }
-            var c = McCalendar.QueryById<McCalendar> (e.CalendarId);
-            if (null == c) {
-                return null; // may be deleted
-            }
-            return c;
+            return McCalendar.QueryById<McCalendar> (e.CalendarId);
         }
 
         public static void CancelOccurrence (McCalendar cal, DateTime occurrence)

--- a/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/HotEventView.cs
@@ -190,7 +190,7 @@ namespace NachoClient.iOS
 
             if (null != currentEvent) {
                 c = currentEvent.GetCalendarItemforEvent ();
-                cRoot =  CalendarHelper.GetMcCalendarRootForEvent (currentEvent.Id);
+                cRoot = McCalendar.QueryById<McCalendar> (currentEvent.CalendarId);
             }
 
             var view = (SwipeActionView)this.ViewWithTag (SWIPE_TAG);
@@ -200,9 +200,7 @@ namespace NachoClient.iOS
             var dotView = (UIImageView)this.ViewWithTag (DOT_TAG);
             var iconView = (UIImageView)this.ViewWithTag (ICON_TAG);
 
-            view.EnableSwipe ((null != c) && (null != cRoot) && (!String.IsNullOrEmpty(cRoot.OrganizerEmail)));
-
-            if (null == c) {
+            if (null == c || null == cRoot) {
                 noMessagesLabelView.Text = "No upcoming events";
                 noMessagesLabelView.Hidden = false;
                 subjectLabelView.Hidden = true;
@@ -211,8 +209,11 @@ namespace NachoClient.iOS
                 dotView.Hidden = true;
                 view.OnSwipe = null;
                 view.OnClick = null;
+                view.DisableSwipe ();
                 return;
             }
+
+            view.EnableSwipe (!string.IsNullOrEmpty (cRoot.OrganizerEmail));
 
             noMessagesLabelView.Hidden = true;
 


### PR DESCRIPTION
If a McEvent is deleted from the database as
HotEventView.ConfigureCurrentEvent() is being called, then the app
would crash with a NullReferenceException due to cRoot being null.
Tweak the code of ConfigureCurrentEvent() to avoid this problem.

This hopefully fixes https://rink.hockeyapp.net/manage/apps/178752/crash_reasons/70725280?no_iphone_ui=true
but I can't be completely sure that this is the cause of that crash.
