### PR TITLE
Create back stack when app is launched by an event notification

### DIFF
--- a/NachoClient.Android/NachoPlatform.Android/NotifAndroid.cs
+++ b/NachoClient.Android/NachoPlatform.Android/NotifAndroid.cs
@@ -213,7 +213,14 @@ namespace NachoClient.AndroidClient
                 eventIntent = EventViewActivity.ShowEventIntent (this, ev);
             }
             eventIntent.SetFlags (ActivityFlags.NoAnimation);
-            StartActivity (eventIntent);
+            if (!NcTabBarActivity.TabBarWasCreated && null != ev) {
+                // Since the app was just launched, pressing Back from the event detail view will return to
+                // the home screen, which is not the desired behavior.  To keep the user in the app, insert
+                // a calendar view activity into the activity back stack.
+                StartActivities (new Intent[] { NcTabBarActivity.CalendarIntent (this), eventIntent });
+            } else {
+                StartActivity (eventIntent);
+            }
             Finish ();
         }
     }

--- a/NachoClient.Android/NachoUI.Android/Activities/NcTabBarActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/NcTabBarActivity.cs
@@ -19,10 +19,19 @@ namespace NachoClient.AndroidClient
     {
         SwitchAccountFragment switchAccountFragment = new SwitchAccountFragment ();
 
+        static bool tabBarCreated = false;
+
+        public static bool TabBarWasCreated {
+            get {
+                return tabBarCreated;
+            }
+        }
+
         protected void OnCreate (Bundle bundle, int layoutId)
         {
             base.OnCreate (bundle);
             SetContentView (layoutId);
+            tabBarCreated = true;
         }
 
         protected override void OnResume ()


### PR DESCRIPTION
When the app is launched by tapping an event notification, insert a
calendar view activity into the activity back stack behind the event
detail view activity.  This keeps the user within the app when tapping
the back button rather than returning the user to the device's home
screen.

(Figuring out whether or not the app is being launched is not trivial.
I am not sure about the accuracy of the code that I have.)
