### PR TITLE
Don't crash when calendar item is deleted as user starts to edit it

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EditEventViewController.cs
@@ -982,6 +982,9 @@ namespace NachoClient.iOS
 
         protected McFolder GetCalendarFolderForItem ()
         {
+            if (null == item) {
+                return McFolder.GetDeviceCalendarsFolder ();
+            }
             return McFolder.QueryByFolderEntryId<McCalendar> (item.AccountId, item.Id).FirstOrDefault ();
         }
 


### PR DESCRIPTION
Hockey App reported a crash that I believe happened because a calendar
item was deleted (probably by a sync) just as the user was tapping the
edit event button.  Fix the code so it won't crash in this situation.

https://rink.hockeyapp.net/manage/apps/124088/crash_reasons/74921135?no_iphone_ui=true
