### PR TITLE
Correct start time when device event changed to be not all-day

### DIFF
--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -600,8 +600,8 @@ namespace NachoPlatform
 
         private void ToEKEvent (EKEvent ekEvent, McCalendar cal)
         {
-            ekEvent.StartDate = cal.StartTime.ToNSDate ();
             ekEvent.AllDay = cal.AllDayEvent;
+            ekEvent.StartDate = cal.StartTime.ToNSDate ();
             if (cal.AllDayEvent) {
                 // iOS wants the end time of an all-day event to be one second before midnight.
                 ekEvent.EndDate = (cal.EndTime - TimeSpan.FromSeconds (1)).ToNSDate ();


### PR DESCRIPTION
When an iOS device event was edited in the app and changed from
all-day to not all-day, the start time was always set to midnight
regardless of what the user specified.  That bug is now fixed.

Fix nachocove/qa#1457
