### PR TITLE
Better representation for McEvents for Android device calendar items

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McEvent.cs
@@ -49,6 +49,14 @@ namespace NachoCore.Model
         /// </summary>
         public string UID { get; set; }
 
+        /// <summary>
+        /// The identifier of the calendar item in the device calendar for this instance.  This field is used
+        /// only for transitory McEvent objects that represent device calendar items.  This field is not stored
+        /// in the database.  If it is non-zero, then this McEvent is an in-memory object only.
+        /// </summary>
+        [Ignore]
+        public long DeviceCalendarId { get; set; }
+
         static public McEvent Create (int accountId, DateTime startTime, DateTime endTime, string UID, bool allDayEvent, int calendarId, int exceptionId)
         {
             // Save the event

--- a/NachoClient.Android/NachoPlatform.Android/CalendarsAndroid.cs
+++ b/NachoClient.Android/NachoPlatform.Android/CalendarsAndroid.cs
@@ -65,7 +65,7 @@ namespace NachoPlatform
 
                 result.Add (new McEvent () {
                     AccountId = deviceAccount,
-                    CalendarId = (int)(-eventId),
+                    DeviceCalendarId = eventId,
                     StartTime = start,
                     EndTime = end,
                     AllDayEvent = allDay,
@@ -477,7 +477,7 @@ namespace NachoPlatform
             CalendarContract.EventsColumns.Rrule,
         };
 
-        public static void WriteDeviceEvent (McCalendar cal, long eventId)
+        public static void UpdateDeviceEvent (McCalendar cal, long eventId)
         {
             var resolver = MainApplication.Instance.ContentResolver;
             var values = new ContentValues ();
@@ -547,17 +547,6 @@ namespace NachoPlatform
         {
             var resolver = MainApplication.Instance.ContentResolver;
             resolver.Delete (ContentUris.AppendId (CalendarContract.Events.ContentUri.BuildUpon (), eventId).Build (), null, null);
-        }
-
-        /// <summary>
-        /// An Android intent that will view the given event in the Android calendar app.
-        /// </summary>
-        public static Intent ViewEventIntent (McEvent ev)
-        {
-            var intent = new Intent (Intent.ActionView, ContentUris.WithAppendedId (CalendarContract.Events.ContentUri, -ev.CalendarId));
-            intent.PutExtra (CalendarContract.ExtraEventBeginTime, ev.StartTime.MillisecondsSinceEpoch ());
-            intent.PutExtra (CalendarContract.ExtraEventEndTime, ev.EndTime.MillisecondsSinceEpoch ());
-            return intent;
         }
 
         /// <summary>

--- a/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
@@ -196,10 +196,10 @@ namespace NachoClient.AndroidClient
 
                     cal = null;
                     if (null != dataFromIntent.Event) {
-                        if (0 < dataFromIntent.Event.CalendarId) {
+                        if (0 == dataFromIntent.Event.DeviceCalendarId) {
                             cal = McCalendar.QueryById<McCalendar> (dataFromIntent.Event.CalendarId);
                         } else {
-                            cal = AndroidCalendars.GetEventDetails (-dataFromIntent.Event.CalendarId, out deviceCalendarName);
+                            cal = AndroidCalendars.GetEventDetails (dataFromIntent.Event.DeviceCalendarId, out deviceCalendarName);
                             isAppEvent = false;
                         }
                     }
@@ -480,7 +480,7 @@ namespace NachoClient.AndroidClient
                 }
                 BackEnd.Instance.DeleteCalCmd (account.Id, cal.Id);
             } else {
-                AndroidCalendars.DeleteEvent (-RetainedData.Event.CalendarId);
+                AndroidCalendars.DeleteEvent (RetainedData.Event.DeviceCalendarId);
             }
         }
 
@@ -561,7 +561,7 @@ namespace NachoClient.AndroidClient
                 cal.DtStamp = DateTime.UtcNow;
 
                 if (!isAppEvent) {
-                    AndroidCalendars.WriteDeviceEvent (cal, -RetainedData.Event.CalendarId);
+                    AndroidCalendars.UpdateDeviceEvent (cal, RetainedData.Event.DeviceCalendarId);
                 } else if (Intent.ActionCreateDocument == Intent.Action) {
                     cal.Insert ();
                     calendarFolder.Link (cal);

--- a/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
@@ -668,11 +668,11 @@ namespace NachoClient.AndroidClient
 
         public AndroidEventDetail (McEvent occurrence)
         {
-            isAppEvent = 0 < occurrence.CalendarId;
+            isAppEvent = 0 == occurrence.DeviceCalendarId;
             if (isAppEvent) {
                 base.Initialize (occurrence);
             } else {
-                var calItem = AndroidCalendars.GetEventDetails (-occurrence.CalendarId, out calendarName);
+                var calItem = AndroidCalendars.GetEventDetails (occurrence.DeviceCalendarId, out calendarName);
                 base.Initialize (occurrence, calItem, calItem, McAccount.GetDeviceAccount ());
             }
         }
@@ -688,7 +688,7 @@ namespace NachoClient.AndroidClient
             if (isAppEvent) {
                 base.Refresh ();
             } else {
-                var calItem = AndroidCalendars.GetEventDetails (-Occurrence.CalendarId, out calendarName);
+                var calItem = AndroidCalendars.GetEventDetails (Occurrence.DeviceCalendarId, out calendarName);
                 base.Initialize (Occurrence, calItem, calItem, McAccount.GetDeviceAccount ());
             }
         }

--- a/NachoClient.Android/NachoUI.Android/Support/Bind.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/Bind.cs
@@ -216,9 +216,9 @@ namespace NachoClient.AndroidClient
             DateTime endTime;
             int colorIndex = 0;
 
-            if (0 > ev.CalendarId) {
+            if (0 != ev.DeviceCalendarId) {
 
-                if (!AndroidCalendars.GetEventDetails (-ev.CalendarId, out title, out location, out colorIndex)) {
+                if (!AndroidCalendars.GetEventDetails (ev.DeviceCalendarId, out title, out location, out colorIndex)) {
                     BindEmptyEventCell (titleView, colorView, durationView, locationView, locationImageView);
                     return;
                 }


### PR DESCRIPTION
The Android device event ID is now stored in its own McEvent field
rather than piggybacking on the CalendarId field.  This should make
the code more clear.  There is no behavior change, just a different
implementation.
