### PR TITLE
Don't leak brain index locks

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrainActions.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainActions.cs
@@ -228,7 +228,7 @@ namespace NachoCore.Brain
                 var id = emailMessage.Id.ToString ();
                 if (0 != emailMessage.IsIndexed) {
                     // There is an old version in the index. Remove it first.
-                    OpenedIndexes.Cleanup ();
+                    OpenedIndexes.Release (emailMessage.AccountId);
                     index.Remove ("message", id);
                     index = OpenedIndexes.Get (emailMessage.AccountId);
                     Log.Warn (Log.LOG_SEARCH, "IndexEmailMessage: replacing index for {0}", id);
@@ -322,7 +322,7 @@ namespace NachoCore.Brain
                 var id = contact.Id.ToString ();
                 if (0 != contact.IndexVersion) {
                     // There is an old version in the index. Remove it first.
-                    OpenedIndexes.Cleanup ();
+                    OpenedIndexes.Release (contact.AccountId);
                     index.Remove ("contact", id);
                     index = OpenedIndexes.Get (contact.AccountId);
                 }
@@ -349,7 +349,7 @@ namespace NachoCore.Brain
                 Log.Info (Log.LOG_SEARCH, "Account {0} no longer exists. Ignore unindexing email message {1}", accountId, emailMessageId);
                 return;
             }
-            OpenedIndexes.Cleanup ();
+            OpenedIndexes.Release (accountId);
             var index = Index (accountId);
             if (null == index) {
                 Log.Warn (Log.LOG_SEARCH, "fail to find index for account {0}", accountId);
@@ -364,7 +364,7 @@ namespace NachoCore.Brain
                 Log.Info (Log.LOG_SEARCH, "Account {0} no longer exists. Ignore unindexing contact {1}", accountId, contactId);
                 return;
             }
-            OpenedIndexes.Cleanup ();
+            OpenedIndexes.Release (accountId);
             var index = Index (accountId);
             if (null == index) {
                 Log.Warn (Log.LOG_SEARCH, "fail to find index for account {0}", accountId);

--- a/NachoClient.Android/NachoCore/Brain/NcBrainEventHandler.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainEventHandler.cs
@@ -74,7 +74,12 @@ namespace NachoCore.Brain
                 break;
             case NcBrainEventType.PERSISTENT_QUEUE:
                 var persistentQueueVent = (NcBrainPersistentQueueEvent)brainEvent;
-                ProcessPersistedRequests (persistentQueueVent.EventCount);
+                try {
+                    ProcessPersistedRequests (persistentQueueVent.EventCount);
+                } finally {
+                    // A reindex contact event can result in an index being left open.
+                    OpenedIndexes.Cleanup ();
+                }
                 break;
             case NcBrainEventType.UNINDEX_CONTACT:
             case NcBrainEventType.UNINDEX_MESSAGE:

--- a/NachoClient.Android/NachoCore/Brain/NcBrainHelpers.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainHelpers.cs
@@ -36,6 +36,17 @@ namespace NachoCore.Brain
             return index;
         }
 
+        public void Release (int accountId)
+        {
+            NcIndex index;
+            if (!TryGetValue (accountId, out index)) {
+                Log.Error (Log.LOG_BRAIN, "Attempt to release the index write lock for account {0} when the lock was not held.", accountId);
+                return;
+            }
+            index.EndAddTransaction ();
+            Remove (accountId);
+        }
+
         public void Cleanup ()
         {
             foreach (var index in Values) {


### PR DESCRIPTION
A code path involving reindexing a contact could result in the brain
task shutting down while an index lock was still held.  This would
result in a crash when the brain was restarted because the lock was
released from a different thread than the one that acquired the lock.
This has been fixed by being more diligent about releasing locks.
(See nachocove/qa#1467 for more details.)

Don't release all the index locks (and close all the index writers)
when only one account needs to be cleaned up.

Fix nachocove/qa#1467
