### PR TITLE
Allow changing the device calendar that owns a device event

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McEvent.cs
@@ -55,7 +55,7 @@ namespace NachoCore.Model
         /// in the database.  If it is non-zero, then this McEvent is an in-memory object only.
         /// </summary>
         [Ignore]
-        public long DeviceCalendarId { get; set; }
+        public long DeviceEventId { get; set; }
 
         static public McEvent Create (int accountId, DateTime startTime, DateTime endTime, string UID, bool allDayEvent, int calendarId, int exceptionId)
         {

--- a/NachoClient.Android/NachoUI.Android/Activities/CalendarChooserFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/CalendarChooserFragment.cs
@@ -8,6 +8,7 @@ using NachoCore;
 using Android.Widget;
 using Android.Views;
 using Android.OS;
+using NachoPlatform;
 
 namespace NachoClient.AndroidClient
 {
@@ -127,7 +128,7 @@ namespace NachoClient.AndroidClient
                 } else {
                     cellView = convertView ?? LayoutInflater.From (parent.Context).Inflate (Resource.Layout.CalendarChooserCell, parent, false);
                     var icon = cellView.FindViewById<ImageView> (Resource.Id.calendar_chooser_icon);
-                    if (item.Item2.Id == selected.Id) {
+                    if (SameFolder (item.Item2, selected)) {
                         icon.SetImageResource (Resource.Drawable.gen_checkbox_checked);
                     } else {
                         icon.SetImageResource (Resource.Drawable.gen_checkbox);
@@ -136,6 +137,16 @@ namespace NachoClient.AndroidClient
                     text.Text = item.Item2.DisplayName;
                 }
                 return cellView;
+            }
+
+            private bool SameFolder (McFolder a, McFolder b)
+            {
+                var aDevice = a as AndroidDeviceCalendarFolder;
+                var bDevice = b as AndroidDeviceCalendarFolder;
+                if (null != aDevice && null != bDevice) {
+                    return aDevice.DeviceCalendarId == bDevice.DeviceCalendarId;
+                }
+                return null == aDevice && null == bDevice && a.Id == b.Id;
             }
         }
     }

--- a/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
@@ -668,11 +668,13 @@ namespace NachoClient.AndroidClient
 
         public AndroidEventDetail (McEvent occurrence)
         {
-            isAppEvent = 0 == occurrence.DeviceCalendarId;
+            isAppEvent = 0 == occurrence.DeviceEventId;
             if (isAppEvent) {
                 base.Initialize (occurrence);
             } else {
-                var calItem = AndroidCalendars.GetEventDetails (occurrence.DeviceCalendarId, out calendarName);
+                AndroidDeviceCalendarFolder folder;
+                var calItem = AndroidCalendars.GetEventDetails (occurrence.DeviceEventId, out folder);
+                calendarName = (null == folder) ? null : folder.DisplayName;
                 base.Initialize (occurrence, calItem, calItem, McAccount.GetDeviceAccount ());
             }
         }
@@ -688,7 +690,9 @@ namespace NachoClient.AndroidClient
             if (isAppEvent) {
                 base.Refresh ();
             } else {
-                var calItem = AndroidCalendars.GetEventDetails (Occurrence.DeviceCalendarId, out calendarName);
+                AndroidDeviceCalendarFolder folder;
+                var calItem = AndroidCalendars.GetEventDetails (Occurrence.DeviceEventId, out folder);
+                calendarName = (null == folder) ? null : folder.DisplayName;
                 base.Initialize (Occurrence, calItem, calItem, McAccount.GetDeviceAccount ());
             }
         }

--- a/NachoClient.Android/NachoUI.Android/Support/Bind.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/Bind.cs
@@ -215,10 +215,10 @@ namespace NachoClient.AndroidClient
             DateTime startTime;
             DateTime endTime;
 
-            if (0 != ev.DeviceCalendarId) {
+            if (0 != ev.DeviceEventId) {
 
                 int displayColor;
-                if (!AndroidCalendars.GetEventDetails (ev.DeviceCalendarId, out title, out location, out displayColor)) {
+                if (!AndroidCalendars.GetEventDetails (ev.DeviceEventId, out title, out location, out displayColor)) {
                     BindEmptyEventCell (titleView, colorView, durationView, locationView, locationImageView);
                     return;
                 }


### PR DESCRIPTION
When creating a new event, allow the user to select one of the device
calendars as the owner of the event.

When editing an existing event on one of the device calendars, allow
the user to move the event to a different device calendar.  (But like
iOS, the event cannot be moved to a different account, only a
different calendar within the same account.)

Allow the user to change the reminder time for a device event when
editing the event.  (Changing the reminder for device events is still
not implemented yet from the event detail view.)
