### PR TITLE
Don't crash when there is no default iOS device calendar

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrainHelpers.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainHelpers.cs
@@ -39,12 +39,10 @@ namespace NachoCore.Brain
         public void Release (int accountId)
         {
             NcIndex index;
-            if (!TryGetValue (accountId, out index)) {
-                Log.Error (Log.LOG_BRAIN, "Attempt to release the index write lock for account {0} when the lock was not held.", accountId);
-                return;
+            if (TryGetValue (accountId, out index)) {
+                index.EndAddTransaction ();
+                Remove (accountId);
             }
-            index.EndAddTransaction ();
-            Remove (accountId);
         }
 
         public void Cleanup ()

--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -579,7 +579,10 @@ namespace NachoPlatform
                 return;
             }
 
-            var defaultId = Es.DefaultCalendarForNewEvents.CalendarIdentifier;
+            string defaultId = "no default";
+            if (null != Es.DefaultCalendarForNewEvents) {
+                defaultId = Es.DefaultCalendarForNewEvents.CalendarIdentifier;
+            }
             foreach (var ekCalendar in ekCalendars) {
                 cancellationToken.ThrowIfCancellationRequested ();
                 appFolders.Add (new PlatformCalendarFolderRecordiOS (ekCalendar, ekCalendar.CalendarIdentifier == defaultId));


### PR DESCRIPTION
My best guess for
https://rink.hockeyapp.net/manage/apps/178752/crash_reasons/81107076?no_iphone_ui=true
is that there are device calendars, but none of them is marked as the
default calendar.  Fix the code to protect against that situation.

Remove an error message that was added by mistake.  The situation is
not always an error.
