### PR TITLE
Several Android calendar fixes

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -809,6 +809,15 @@ namespace NachoCore.ActiveSync
                     break;
                 }
             }
+
+            if (null == c.OrganizerEmail) {
+                // AWS leaves out the OrganizerEmail field for calendar items owned by the current user.
+                // Other servers always include the OrganizerEmail field.  The code assumes that OrganizerEmail
+                // is always set (since AWS is the most recent server to be supported).  So make sure it
+                // is always set.
+                c.OrganizerEmail = McAccount.QueryById<McAccount>(accountId).EmailAddr;
+            }
+
             c.attendees = attendees;
             c.categories = categories;
             c.recurrences = recurrences;

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageViewFragment.cs
@@ -436,7 +436,7 @@ namespace NachoClient.AndroidClient
                 eventExists = (0 == exceptions.Count || 0 == exceptions [0].Deleted);
             }
 
-            var messageView = View.FindViewById<ImageView> (Resource.Id.event_message_view);
+            var messageView = View.FindViewById<View> (Resource.Id.event_message_view);
             var iconView = View.FindViewById<ImageView> (Resource.Id.event_message_icon);
             var textView = View.FindViewById<TextView> (Resource.Id.event_message_text);
             if (eventExists) {


### PR DESCRIPTION
Don't crash when a meeting cancelation message is opened in the
message detail view.

Implement the "Remove from calendar" button in the event detail view.
(It was accidentally forgotten when the view was implemented.)

Don't crash when deleting a meeting that was created in the AmazonMail
web UI.  The Amazon Exchange server, unlike all of the other Exchange
servers the app interacts with, leaves the OrganizerEmail field unset
for meetings where the current user is the organizer.  The code was
expecting that field to always be set.  Change the ActiveSync code to
always set the OrganizerEmail field.
Fix nachocove/qa#1497
