### PR TITLE
Start the back end during PerformFetch and RemoteNotification

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -837,6 +837,7 @@ namespace NachoClient.iOS
             NcApplication.Instance.UnmarkStartup ();
             if (FinalShutdownHasHappened) {
                 ReverseFinalShutdown ();
+                BackEnd.Instance.Start ();
             }
             NcApplication.Instance.StatusIndEvent += FetchStatusHandler;
             // iOS only allows a limited amount of time to fetch data in the background.


### PR DESCRIPTION
A change not too long ago removed the BackEnd.Instance.Start() call
from the normal startup process, moving the call to when the app comes
into the foreground.  That meant it was never called during QuickSync
mode, so the app wasn't never synching anything unless it was in the
foreground.

Explicitly call BackEnd.Instance.Start() when starting a QuickSync.
