### PR TITLE
Fix nachocove/qa#1491. 

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/FolderLists.cs
+++ b/NachoClient.Android/NachoCore/Utils/FolderLists.cs
@@ -25,7 +25,6 @@ namespace NachoClient.AndroidClient
 
             public Node Copy (McFolder folder)
             {
-                this.children = new List<Node> ();
                 this.id = folder.ServerId;
                 this.folder = folder;
                 this.opened = false;


### PR DESCRIPTION
Do not clear child list when copying info from the folder.
