### PR TITLE
Handle nameless attendees in Android message detail view

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/MessageViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageViewFragment.cs
@@ -388,10 +388,14 @@ namespace NachoClient.AndroidClient
                         attendeeNameView.Text = "";
                     } else if (a < attendeesFromMessage.Count) {
                         var attendee = attendeesFromMessage [a] as MailboxAddress;
-                        var initials = ContactsHelper.NameToLetters (attendee.Name);
+                        string displayName = attendee.Name;
+                        if (string.IsNullOrEmpty (displayName)) {
+                            displayName = attendee.Address;
+                        }
+                        var initials = ContactsHelper.NameToLetters (displayName);
                         var color = Util.ColorResourceForEmail (attendee.Address);
                         attendeePhotoView.SetEmailAddress (message.AccountId, attendee.Address, initials, color);
-                        attendeeNameView.Text = GetFirstName (attendee.Name);
+                        attendeeNameView.Text = GetFirstName (displayName);
                     } else {
                         attendeePhotoView.Visibility = ViewStates.Gone;
                         attendeeNameView.Visibility = ViewStates.Gone;
@@ -554,7 +558,7 @@ namespace NachoClient.AndroidClient
         private static string GetFirstName (string displayName)
         {
             string[] names = displayName.Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            if (names [0] == null) {
+            if (0 == names.Length || names [0] == null) {
                 return "";
             }
             if (names [0].Length > 1) {


### PR DESCRIPTION
When a meeting attendee has an e-mail address but no name, don't crash
when showing the meeting request message in the message detail view.
And use the e-mail address to figure out the initials and the first
name.
