### PR TITLE
Show meeting related messages for AWS account

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -1144,6 +1144,26 @@ namespace NachoCore.ActiveSync
             if (null == emailMessage.ConversationId) {
                 emailMessage.ConversationId = System.Guid.NewGuid ().ToString ();
             }
+            if (null != emailMessage.MeetingRequest) {
+                // AWS Exchange servers include several flags in all meeting request messages.
+                // Those flags mess up the app's handling of the messages, causing the messages
+                // to not show up in the inbox if the meeting is in the future.  (And having the
+                // meeting request message appear only after the meeting is over is not user-friendly
+                // behavior.)  To work around this quirky server behavior, ignore the flags in all
+                // messages that have a MeetingRequest element.
+                emailMessage.FlagStatus = (uint)McEmailMessage.FlagStatusValue.Cleared;
+                emailMessage.FlagType = null;
+                emailMessage.FlagStartDate = DateTime.MinValue;
+                emailMessage.FlagUtcStartDate = DateTime.MinValue;
+                emailMessage.FlagDue = DateTime.MinValue;
+                emailMessage.FlagUtcDue = DateTime.MinValue;
+                emailMessage.FlagReminderSet = false;
+                emailMessage.FlagReminderTime = DateTime.MinValue;
+                emailMessage.FlagCompleteTime = DateTime.MinValue;
+                emailMessage.FlagDateCompleted = DateTime.MinValue;
+                emailMessage.FlagOrdinalDate = DateTime.MinValue;
+                emailMessage.FlagSubOrdinalDate = DateTime.MinValue;
+            }
             return NcResult.OK (emailMessage);
         }
 


### PR DESCRIPTION
The AWS Exchange server is setting flags in meeting related messages,
and those flags were messing up the app's handling of those messages.
Change the app to ignore flags on incoming ActiveSync meeting related
e-mail messages.

Fix nachocove/qa#1432
