### PR TITLE
Fix nachocove/qa#1422. 

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/CredentialsFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/CredentialsFragment.cs
@@ -530,7 +530,7 @@ namespace NachoClient.AndroidClient
                     statusLabel.Text = "We were unable to verify your information.  Please confirm or enter advanced configuration information.";
                 }
             } else {
-                Log.Info (Log.LOG_UI, "CredentialsFragment got ServerConfWait for service {0}, showing advanced", service);
+                Log.Info (Log.LOG_UI, "CredentialsFragment got unexpected ServerConfWait for service {0}", service);
                 ShowCredentialsError ("We were unable to verify your information.  Please confirm it is correct and try again.");
             }
         }


### PR DESCRIPTION
The predefined servers, like hotmail, should not ever kick back a server conf error; however, sometimes there's a problem.  In this case, just tell the user to retry.
