### PR TITLE
Other Android apps can share with Nacho Mail

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -626,6 +626,7 @@
     <Compile Include="NachoUI.Android\Activities\ContactEditFragment.cs" />
     <Compile Include="NachoPlatform.Android\PushAssistAndroid.cs" />
     <Compile Include="NachoUI.Android\Activities\ContactLabelChooserFragment.cs" />
+    <Compile Include="NachoUI.Android\Activities\MessageComposePublicListener.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Properties\AndroidManifest.xml" />

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageComposeActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageComposeActivity.cs
@@ -41,6 +41,7 @@ namespace NachoClient.AndroidClient
         public const string EXTRA_INITIAL_RECIPIENT = "com.nachocove.nachomail.initialRecipient";
         public const string EXTRA_INITIAL_QUICK_REPLY = "com.nachocove.nachomail.initialQuickReply";
         public const string EXTRA_INITIAL_ATTACHMENT = "com.nachocove.nachomail.initialAttachment";
+        public const string EXTRA_INITIAL_ATTACHMENTS = "com.nachocove.nachomail.initialAttachments";
 
         private const string COMPOSE_FRAGMENT_TAG = "ComposeFragment";
 
@@ -101,12 +102,21 @@ namespace NachoClient.AndroidClient
                 if (Intent.HasExtra (EXTRA_INITIAL_QUICK_REPLY)) {
                     composeFragment.Composer.InitialQuickReply = Intent.GetBooleanExtra (EXTRA_INITIAL_QUICK_REPLY, false);
                 }
-                if(Intent.HasExtra(EXTRA_INITIAL_ATTACHMENT)) {
-                    var attachmentId = Intent.GetIntExtra(EXTRA_INITIAL_ATTACHMENT, 0);
-                    if(0 != attachmentId) {
-                        var attachment = McAttachment.QueryById<McAttachment>(attachmentId);
-                        if(null != attachment) {
-                            composeFragment.Composer.InitialAttachments.Add(attachment);
+                if (Intent.HasExtra (EXTRA_INITIAL_ATTACHMENT)) {
+                    var attachmentId = Intent.GetIntExtra (EXTRA_INITIAL_ATTACHMENT, 0);
+                    if (0 != attachmentId) {
+                        var attachment = McAttachment.QueryById<McAttachment> (attachmentId);
+                        if (null != attachment) {
+                            composeFragment.Composer.InitialAttachments.Add (attachment);
+                        }
+                    }
+                }
+                if (Intent.HasExtra (EXTRA_INITIAL_ATTACHMENTS)) {
+                    var attachmentIds = Intent.GetIntArrayExtra (EXTRA_INITIAL_ATTACHMENTS);
+                    foreach (int id in attachmentIds) {
+                        var attachment = McAttachment.QueryById<McAttachment> (id);
+                        if (null != attachment) {
+                            composeFragment.Composer.InitialAttachments.Add (attachment);
                         }
                     }
                 }
@@ -160,6 +170,21 @@ namespace NachoClient.AndroidClient
             intent.SetAction (Intent.ActionSend);
             intent.PutExtra (EXTRA_MESSAGE, IntentHelper.StoreValue (message));
             intent.PutExtra (EXTRA_INITIAL_TEXT, text);
+            return intent;
+        }
+
+        public static Intent MessageWithAttachmentsIntent (Context context, McEmailMessage message, string text, IList<McAttachment> attachments)
+        {
+            var intent = new Intent (context, typeof(MessageComposeActivity));
+            intent.SetAction (Intent.ActionSend);
+            intent.PutExtra (EXTRA_MESSAGE, IntentHelper.StoreValue (message));
+            intent.PutExtra (EXTRA_INITIAL_TEXT, text);
+            int[] attachmentIds = new int[attachments.Count];
+            int a = 0;
+            foreach (var attachment in attachments) {
+                attachmentIds [a++] = attachment.Id;
+            }
+            intent.PutExtra (EXTRA_INITIAL_ATTACHMENTS, attachmentIds);
             return intent;
         }
 

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageComposePublicListener.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageComposePublicListener.cs
@@ -1,0 +1,129 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using NachoCore.Model;
+using NachoCore;
+using Java.Net;
+using NachoCore.Utils;
+
+namespace NachoClient.AndroidClient
+{
+    [Activity (Label = "Nacho Mail")]
+    [IntentFilter (new[] { Intent.ActionSend, Intent.ActionSendMultiple }, Categories = new[] { Intent.CategoryDefault }, DataMimeType = "*/*")]
+    [IntentFilter (new[] { Intent.ActionSendto }, Categories = new[] { Intent.CategoryDefault }, DataScheme = "mailto", DataMimeType = "*/*")]
+    public class MessageComposePublicListener : NcActivity
+    {
+        private static string[] dataColumnProjection = {
+            Android.Provider.MediaStore.MediaColumns.Data,
+            Android.Provider.MediaStore.MediaColumns.DisplayName,
+        };
+
+        protected override void OnCreate (Bundle savedInstanceState)
+        {
+            base.OnCreate (savedInstanceState);
+            SetContentView (Resource.Layout.WaitingFragment);
+            FindViewById<TextView> (Resource.Id.textview).Text = "Loading Nacho Mail";
+
+            // Use a C# task instead of an NcTask, because the app might not be initialized yet.
+            System.Threading.Tasks.Task.Run (() => {
+
+                MainApplication.OneTimeStartup ("MessageComposePublicListener");
+
+                var message = new McEmailMessage ();
+                message.AccountId = NcApplication.Instance.Account.Id;
+
+                string initialText = "";
+
+                if (Intent.HasExtra (Intent.ExtraEmail)) {
+                    message.To = string.Join (", ", Intent.GetStringArrayExtra (Intent.ExtraEmail));
+                }
+                if (Intent.HasExtra (Intent.ExtraCc)) {
+                    message.Cc = string.Join (", ", Intent.GetStringArrayExtra (Intent.ExtraCc));
+                }
+                if (Intent.HasExtra (Intent.ExtraBcc)) {
+                    message.Bcc = string.Join (", ", Intent.GetStringArrayExtra (Intent.ExtraBcc));
+                }
+                if (Intent.HasExtra (Intent.ExtraSubject)) {
+                    message.Subject = Intent.GetStringExtra (Intent.ExtraSubject);
+                }
+                if (Intent.HasExtra (Intent.ExtraText)) {
+                    initialText = Intent.GetStringExtra (Intent.ExtraText);
+                }
+
+                var attachments = new List<McAttachment> ();
+                if (Intent.HasExtra (Intent.ExtraStream)) {
+                    try {
+                        if (Intent.ActionSendMultiple == Intent.Action) {
+                            var uris = Intent.GetParcelableArrayListExtra (Intent.ExtraStream);
+                            foreach (var uriObject in uris) {
+                                var attachment = UriToAttachment ((Android.Net.Uri)uriObject, Intent.Type);
+                                if (null != attachment) {
+                                    attachments.Add (attachment);
+                                }
+                            }
+                        } else {
+                            var uri = (Android.Net.Uri)Intent.GetParcelableExtra (Intent.ExtraStream);
+                            var attachment = UriToAttachment (uri, Intent.Type);
+                            if (null != attachment) {
+                                attachments.Add (attachment);
+                            }
+                        }
+                    } catch (Exception e) {
+                        Log.Error (Log.LOG_LIFECYCLE, "Exception while processing the STREAM extra of a Send intent: {0}", e.ToString ());
+                    }
+                }
+
+                Intent composeIntent;
+                if (0 < attachments.Count) {
+                    composeIntent = MessageComposeActivity.MessageWithAttachmentsIntent (this, message, initialText, attachments);
+                } else {
+                    composeIntent = MessageComposeActivity.InitialTextIntent (this, message, initialText);
+                }
+
+                RunOnUiThread (() => {
+                    StartActivity (composeIntent);
+                    Finish ();
+                });
+            });
+        }
+
+        private McAttachment MakeAttachment (string filePath, string displayName, string type)
+        {
+            var attachment = McAttachment.InsertSaveStart (NcApplication.Instance.Account.Id);
+            attachment.ContentType = type;
+            attachment.DisplayName = displayName;
+            attachment.UpdateFileCopy (filePath);
+            attachment.UpdateSaveFinish ();
+            return attachment;
+        }
+
+        private McAttachment UriToAttachment (Android.Net.Uri uri, string mimeType)
+        {
+            try {
+                if ("file" == uri.Scheme) {
+                    return MakeAttachment (uri.Path, new System.IO.FileInfo (uri.Path).Name, mimeType);
+                } else if ("content" == uri.Scheme) {
+                    var cursor = ContentResolver.Query (uri, dataColumnProjection, null, null, null);
+                    if (cursor.MoveToNext ()) {
+                        return MakeAttachment (cursor.GetString (0), cursor.GetString (1), mimeType);
+                    }
+                }
+            } catch (Exception e) {
+                Log.Error (Log.LOG_LIFECYCLE, "Exception while creating an attachment during processing of a Send intent: {0}", e.ToString ());
+            }
+            return null;
+        }
+    }
+}
+


### PR DESCRIPTION
Add an activity with intent filters so that other apps can share data
with Nacho Mail, which will open the message compose view so the user
can send the shared data in an e-mail message.  If the shared data is
text, it will be part of the body of the new message.  If the shared
data is files, such as pictures, those files will be attachments on
the new message.

Work still to do:
1. Allow the user to select the account from which the new message will be sent.  (Currently it's the current account, but the user can't change that, and can't even check to see which account it is.)
2. Figure out why tapping an e-mail address in the Contacts app doesn't show Nacho Mail as an option for the e-mail app to use.
