### PR TITLE
Allow iOS account settings page to scroll all the way to the bottom

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/AccountSettingsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/AccountSettingsViewController.cs
@@ -95,6 +95,7 @@ namespace NachoClient.iOS
             View.BackgroundColor = A.Color_NachoBackgroundGray;
 
             scrollView = new UIScrollView (new CGRect (0, 0, View.Frame.Width, View.Frame.Height));
+            scrollView.AutoresizingMask = UIViewAutoresizing.FlexibleDimensions;
             scrollView.BackgroundColor = A.Color_NachoBackgroundGray;
             scrollView.ScrollEnabled = true;
             scrollView.AlwaysBounceVertical = true;


### PR DESCRIPTION
If the settings page for an individual account was too tall for the
device's screen (which can happen on iPhone 4s, 5, and 5s), it was not
possible to scroll the view all the way to the bottom.  The delete
button was always off the bottom of the screen, making it impossible
to delete the account.  Fix the scroll view settings to avoid this
problem.
