### PR TITLE
Avoid a large number of calender view refresh tasks

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
@@ -320,14 +320,29 @@ namespace NachoClient.AndroidClient
             return (int)Android.Util.TypedValue.ApplyDimension (Android.Util.ComplexUnitType.Dip, (float)dp, Resources.DisplayMetrics);
         }
 
+        private bool refreshInProgress = false;
+        private bool refreshWaitingToStart = false;
+
         void StatusIndicatorCallback (object sender, EventArgs e)
         {
             var s = (StatusIndEventArgs)e;
 
             switch (s.Status.SubKind) {
+
             case NcResult.SubKindEnum.Info_EventSetChanged:
             case NcResult.SubKindEnum.Info_SystemTimeZoneChanged:
-                eventListAdapter.Refresh ();
+                // Don't queue up a whole bunch of refresh tasks.  If there is one running and one waiting to
+                // run, there is no point in starting yet another refresh task.
+                if (!refreshWaitingToStart) {
+                    if (refreshInProgress) {
+                        refreshWaitingToStart = true;
+                    }
+                    refreshInProgress = true;
+                    eventListAdapter.Refresh (() => {
+                        refreshWaitingToStart = false;
+                        refreshInProgress = false;
+                    });
+                }
                 break;
 
             case NcResult.SubKindEnum.Info_ExecutionContextChanged:


### PR DESCRIPTION
It is possible for a huge number of Info_EventSetChanged events to get
queued up, which would result in a huge number of
NcEventsCalendarMapCommonRefresh tasks.  In one (admittedly
convoluted) case, I saw more than 2,000 refresh tasks running at once,
which exhausted all available threads and crashed the app.

Add logic that prevents a huge number of refresh tasks.  There can
still be several such tasks running at once, but this change should
prevent the number from growing dangerously large.
