### PR TITLE
do the same host-compare we do when looking into the cache

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsAutodiscoverCommand/StepRobot.cs
@@ -546,7 +546,7 @@ namespace NachoCore.ActiveSync
                                                        SslPolicyErrors sslPolicyErrors, 
                                                        EventArgs e)
             {
-                if (sender.RequestUri.Equals (ReDirUri)) {
+                if (sender.RequestUri.Host.Equals (ReDirUri.Host)) {
                     // Capture the server cert.
                     ServerCertificate = certificate;
                 }
@@ -710,7 +710,7 @@ namespace NachoCore.ActiveSync
 
             private void DoRobotGotCert ()
             {
-                Log.Info (Log.LOG_AS, "AUTOD:{0}:PROGRESS: Retrieved sever SSL cert.", Step);
+                Log.Info (Log.LOG_AS, "AUTOD:{0}:PROGRESS: Retrieved server SSL cert.", Step);
                 DoRobotUiCertAsk ();
             }
 


### PR DESCRIPTION
resolves nachocove/qa#1578

This is an artifact of the OkHttp HostVerifier, which only passes us the hostname, not the full URL of the request.

```
        class HostnameVerifier : Java.Lang.Object, IHostnameVerifier
        {
            public HostnameVerifier ()
            {
            }

            public bool Verify (string hostname, ISSLSession session)
            {
                var uriBuilder = new UriBuilder (null == session ? "http" : "https", hostname);
                return verifyServerCertificate (uriBuilder.Uri, session) & NcHttpCertificateValidation.verifyClientCiphers (uriBuilder.Uri, session.Protocol, session.CipherSuite);
            }
```

When the Robot starts, it first looks into a cache-dictionary, using ONLY the hostname as a key. 

```
                if (ServerCertificatePeek.Instance.Cache.TryGetValue (ReDirUri.Host, out cached)) {
```

If we don't find anything, we do a GET request, and intercept the SSL cert validation, comparing the FULL URL, instead of the hostname.

```
                if (sender.RequestUri.Equals (ReDirUri)) {
                    // Capture the server cert.
                    ServerCertificate = certificate;
                }
```

In iOS, we do get the full URL, but in android we don't, so this check never passes. It worked on re-submit, because now the cache has been populated, and the lookup by hostname succeeds.

It is my feeling, that:
1) we do a lookup in the cache by hostname initially anyway, and
2) a certificate does not belong to a URL, but to a host,
and that therefore this fix is valid.

@jeff7091, do you concur?
