### PR TITLE
Avoid long scroll times in calendar when jumping to a particular date

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
@@ -244,6 +244,8 @@ namespace NachoClient.AndroidClient
             ScrollToPosition (position);
         }
 
+        const int MAX_SCROLL = 20;
+
         void ScrollToPosition (int position)
         {
             // The internet says that we might not always get a ScrollState.Idle event in ListView_ScrollStateChanged,
@@ -253,6 +255,14 @@ namespace NachoClient.AndroidClient
             if (isTouchScrolling) {
                 listView.Scroll -= ListView_Scroll;
                 isTouchScrolling = false;
+            }
+            // The duration parameter for SmoothScrollToPositionFromTop is a lower bound, not a hard value.
+            // If there is a long way to scroll, jump most of the way there and then scroll the rest of the way.
+            int existingPosition = listView.FirstVisiblePosition;
+            if (existingPosition + MAX_SCROLL < position) {
+                listView.SetSelection (position - MAX_SCROLL);
+            } else if (existingPosition - MAX_SCROLL > position) {
+                listView.SetSelection (position + MAX_SCROLL);
             }
             listView.SmoothScrollToPositionFromTop (position, offset: 0, duration: 200);
         }


### PR DESCRIPTION
Android list views have a maximum speed at which they can scroll.
Scrolling a long ways will always take a long time.  To avoid long
scroll times in the calendar view when jumping to a particular date,
change the code to instantly jump most of the way there and then
scroll the remaining portion.  The user still has the experience of
scrolling, but never has to wait for scrolling to complete.

This does not work if the month is pulled down and the month needs to
be changed as part of scrolling.  For reasons that I can't figure out,
the listView.SetSelection() call has no effect, so the view ends up
scrolling the entire way.  Because the month view is not often used,
and because the user experiences a delay, not a loss in functionality,
I am not taking the time to fix this right now.

Fix nachocove/qa#1576
