### PR TITLE
End of calendar shouldn't have date headers from a month ago

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NcEventsCalendarMap.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcEventsCalendarMap.cs
@@ -135,8 +135,8 @@ namespace NachoCore
 
         public int NumberOfEvents()
         {
-            // Events before the starting date are not counted.
-            return events.Count - days [0];
+            // Events before the starting date or after the ending date are not counted.
+            return days [days.Length - 1] - days [0];
         }
 
         public DateTime GetDateUsingDayIndex (int day)


### PR DESCRIPTION
A math error in the calendar list adapter could result in too many
rows in the event list table.  Those extra rows were filled with date
headers from a month before the current date, leaving users very
confused.  Fix the math error.

Fix nachocove/qa#1412
