### PR TITLE
Fast calendar scrolling, even when month view is open

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
@@ -258,13 +258,15 @@ namespace NachoClient.AndroidClient
             }
             // The duration parameter for SmoothScrollToPositionFromTop is a lower bound, not a hard value.
             // If there is a long way to scroll, jump most of the way there and then scroll the rest of the way.
-            int existingPosition = listView.FirstVisiblePosition;
-            if (existingPosition + MAX_SCROLL < position) {
-                listView.SetSelection (position - MAX_SCROLL);
-            } else if (existingPosition - MAX_SCROLL > position) {
-                listView.SetSelection (position + MAX_SCROLL);
-            }
-            listView.SmoothScrollToPositionFromTop (position, offset: 0, duration: 200);
+            listView.Post (() => {
+                int existingPosition = listView.FirstVisiblePosition;
+                if (existingPosition + MAX_SCROLL < position) {
+                    listView.SetSelection (position - MAX_SCROLL);
+                } else if (existingPosition - MAX_SCROLL > position) {
+                    listView.SetSelection (position + MAX_SCROLL);
+                }
+                listView.SmoothScrollToPositionFromTop (position, offset: 0, duration: 200);
+            });
         }
 
         bool PagerHasEvents (DateTime date)


### PR DESCRIPTION
Fix the problem where the "Today" button was taking a long time to
scroll the calendar list to today when the month view was pulled down.
Do this by delaying the calendar list scroll until after the month
view has been adjusted, so that adjusting the month view doesn't
interfere with the calendar list view SetSelection() call.
