### PR TITLE
Don't crash when tapping a date far in the future

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NcEventsCalendarMap.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcEventsCalendarMap.cs
@@ -54,6 +54,15 @@ namespace NachoCore
 
         public int IndexOfDate (DateTime date)
         {
+            if (firstDay <= date && date < finalDay) {
+                return UnsafeIndexOfDate (date);
+            } else {
+                return -1;
+            }
+        }
+
+        private int UnsafeIndexOfDate (DateTime date)
+        {
             return (date.ToLocalTime () - firstDay).Days;
         }
 
@@ -73,7 +82,7 @@ namespace NachoCore
                 NcEventManager.AddEventWindow (this, untilDate.ToUniversalTime ());
             }
 
-            int numDays = IndexOfDate (untilDate);
+            int numDays = UnsafeIndexOfDate (untilDate);
             int numNewDays = numDays - NumberOfDays ();
 
             int[] newDays = new int[numDays + 1];
@@ -89,7 +98,7 @@ namespace NachoCore
                     break;
                 }
                 if (firstDay <= start) {
-                    for (int day = IndexOfDate (start); 0 <= day && int.MaxValue == newDays [day]; --day) {
+                    for (int day = UnsafeIndexOfDate (start); 0 <= day && int.MaxValue == newDays [day]; --day) {
                         newDays [day] = e;
                     }
                 }
@@ -163,14 +172,16 @@ namespace NachoCore
         {
             date = date.ToLocalTime ();
             int day = IndexOfDate (date);
-            for (int i = days [day]; i < events.Count; ++i) {
-                if (date <= events [i].GetStartTimeLocal ()) {
-                    while (days [day + 1] <= i) {
-                        ++day;
+            if (0 <= day) {
+                for (int i = days [day]; i < events.Count; ++i) {
+                    if (date <= events [i].GetStartTimeLocal ()) {
+                        while (days [day + 1] <= i) {
+                            ++day;
+                        }
+                        section = day;
+                        item = i - days [day];
+                        return true;
                     }
-                    section = day;
-                    item = i - days [day];
-                    return true;
                 }
             }
             section = -1;
@@ -224,7 +235,7 @@ namespace NachoCore
                     // Make a copy of the end date, in case it changes while the events are being processed.
                     DateTime untilDate = finalDay;
 
-                    int numDays = IndexOfDate (untilDate);
+                    int numDays = UnsafeIndexOfDate (untilDate);
                     int[] newDays = new int[numDays + 1];
                     for (int day = 0; day < newDays.Length; ++day) {
                         newDays [day] = int.MaxValue;

--- a/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
@@ -110,6 +110,7 @@ namespace NachoClient.AndroidClient
             calendarPager = view.FindViewById<CalendarPagerView> (Resource.Id.calendar_pager);
             calendarPager.DateSelected = PagerSelectedDate;
             calendarPager.HasEvents = PagerHasEvents;
+            calendarPager.IsSupportedDate = PagerIsSupportedDate;
 
             // Highlight the tab bar icon of this activity
             var inboxImage = view.FindViewById<Android.Widget.ImageView> (Resource.Id.calendar_image);
@@ -272,6 +273,11 @@ namespace NachoClient.AndroidClient
         bool PagerHasEvents (DateTime date)
         {
             return eventListAdapter.HasEvents (date);
+        }
+
+        bool PagerIsSupportedDate (DateTime date)
+        {
+            return eventListAdapter.IsSupportedDate (date);
         }
 
         void TodayButton_Click (object sender, EventArgs e)
@@ -484,7 +490,10 @@ namespace NachoClient.AndroidClient
         public int PositionForDate (DateTime date)
         {
             var day = eventCalendarMap.IndexOfDate (date);
-            return eventCalendarMap.IndexFromDayItem (day, -1);
+            if (0 <= day) {
+                return eventCalendarMap.IndexFromDayItem (day, -1);
+            }
+            return -1;
         }
 
         public DateTime DateForPosition (int position)
@@ -499,12 +508,17 @@ namespace NachoClient.AndroidClient
         {
             if ((date.Month >= DateTime.UtcNow.Month && date.Year == DateTime.UtcNow.Year) || date.Year > DateTime.UtcNow.Year) {
                 var index = eventCalendarMap.IndexOfDate (date);
-                if ((eventCalendarMap.NumberOfDays () - 1) >= index) {
+                if (0 <= index) {
                     return eventCalendarMap.NumberOfItemsForDay (index) > 0;
                 }
                 return false;
             }
             return false;
+        }
+
+        public bool IsSupportedDate (DateTime date)
+        {
+            return 0 <= eventCalendarMap.IndexOfDate (date);
         }
 
         private class AndroidEventsCalendarMap : NcEventsCalendarMapCommon

--- a/NachoClient.Android/NachoUI.Android/Support/CalendarPagerView.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/CalendarPagerView.cs
@@ -20,8 +20,8 @@ using NachoCore.Utils;
 
 namespace NachoClient.AndroidClient
 {
-    public delegate void CalendarDateSelected (DateTime date);
-    public delegate bool CalendarHasEvents (DateTime date);
+    public delegate void CalendarDateActionDelegate (DateTime date);
+    public delegate bool CalendarDateCheckDelegate (DateTime date);
 
     public class CalendarPagerView : ViewGroup, GestureDetector.IOnGestureListener
     {
@@ -30,8 +30,9 @@ namespace NachoClient.AndroidClient
         List<PageView> PageViews;
         TextView MonthLabelA;
         TextView MonthLabelB;
-        public CalendarDateSelected DateSelected;
-        public CalendarHasEvents HasEvents;
+        public CalendarDateActionDelegate DateSelected;
+        public CalendarDateCheckDelegate HasEvents;
+        public CalendarDateCheckDelegate IsSupportedDate;
         Calendar Calendar;
         DateTime FocusDate;
         DateTime HighlightedDate;
@@ -585,9 +586,11 @@ namespace NachoClient.AndroidClient
 
         public void DateClicked (DateTime date)
         {
-            SetHighlightedDate (date);
-            if (DateSelected != null) {
-                DateSelected (date);
+            if (null != IsSupportedDate && IsSupportedDate (date)) {
+                SetHighlightedDate (date);
+                if (DateSelected != null) {
+                    DateSelected (date);
+                }
             }
         }
 


### PR DESCRIPTION
The Android app calendar only supports dates one month in the past and
five months in the future.  If the user attempts to go beyond those
limits by tapping on a date in either the weekly or monthly calendar
bar, have the app do nothing rather than crash.

Fix nachocove/qa#1593
