### PR TITLE
Fix some annoyances with the Android credentials input fields

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/CredentialsFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/CredentialsFragment.cs
@@ -197,10 +197,6 @@ namespace NachoClient.AndroidClient
                 LoginEvents.CheckBackendState ();
             }
                 
-            emailField.KeyPress += EmailField_KeyPress; 
-
-            passwordField.KeyPress += PasswordField_KeyPress;
-
             return view;
         }
 
@@ -216,25 +212,13 @@ namespace NachoClient.AndroidClient
             outState.PutBoolean (ACCEPT_CERT_KEY, AcceptCertOnNextReq);
         }
 
-        void EmailField_KeyPress (object sender, View.KeyEventArgs e)
+        public override void OnResume ()
         {
-            if ((KeyEventActions.Down == e.Event.Action) && (Keycode.Enter == e.KeyCode)) {
-                e.Handled = true;
-                emailField.ClearFocus ();
-                passwordField.RequestFocus ();
-            } else {
-                e.Handled = false;
-            }
-        }
-
-        void PasswordField_KeyPress (object sender, View.KeyEventArgs e)
-        {
-            if ((KeyEventActions.Down == e.Event.Action) && (Keycode.Enter == e.KeyCode)) {
-                e.Handled = true;
-                passwordField.ClearFocus ();
-                submitButton.RequestFocus ();
-            } else {
-                e.Handled = false;
+            base.OnResume ();
+            if (!IsSubmitting && !LockEmailField) {
+                emailField.RequestFocus ();
+                var imm = (Android.Views.InputMethods.InputMethodManager)this.Activity.GetSystemService (Context.InputMethodService);
+                imm.ShowSoftInput (emailField, Android.Views.InputMethods.ShowFlags.Implicit);
             }
         }
 

--- a/NachoClient.Android/Resources/layout/CredentialsFragment.axml
+++ b/NachoClient.Android/Resources/layout/CredentialsFragment.axml
@@ -61,7 +61,7 @@
                 android:maxHeight="40dp" />
             <EditText
                 android:id="@+id/password"
-                android:password="true"
+                android:inputType="textPassword"
                 android:textSize="17dp"
                 android:layout_height="wrap_content"
                 android:layout_width="match_parent"


### PR DESCRIPTION
Tweak the text input fields on the Android credentials page to behave
as most user would expect:

When the credentials page become visible, focus is placed in the email
field and the soft keyboard is made visible.  The user no longer has
to tap in the email field to start input.

When pressing the next button on the keyboard to transfer from the
email field to the password field, the soft keyboard remains visible
rather than becoming hidden.  The user no longer has to tap in the
password field to make the keyboard visible again.

When pressing the done button on the keyboard after entering the
password, the keyboard disappears making the Submit button visible.
The password field is no longer a multi-line text field, and the user
no longer has to explicitly dismiss the keyboard in order to tap the
Submit button.
