### PR TITLE
parse the ContentType to extract out the mimetype

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Operations/AsHttpOperation.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Operations/AsHttpOperation.cs
@@ -434,7 +434,7 @@ namespace NachoCore.ActiveSync
 
             MimeKit.ContentType cType;
             if (!string.IsNullOrEmpty (response.ContentType)) {
-                if (MimeKit.ContentType.TryParse (Encoding.ASCII.GetBytes (response.ContentType), out cType)) {
+                if (MimeKit.ContentType.TryParse (response.ContentType, out cType)) {
                     ContentType = cType.MimeType;
                 } else {
                     ContentType = null;


### PR DESCRIPTION
the rest of the code expects just the mimetype (i.e. “text/xml” etc).
There’s cases where the contentType comes back with a charset like
“text/xml; charset=utf-8”
resolves nachocove/qa#1615
