### PR TITLE
Don't crash when the user hits Enter in an empty attendee search field

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/ContactEmailChooserFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/ContactEmailChooserFragment.cs
@@ -79,7 +79,11 @@ namespace NachoClient.AndroidClient
 
         private void EnterPressed ()
         {
-            this.Activity.SetResult (Result.Ok, ContactEmailChooserActivity.ResultIntent (searchField.Text, null));
+            if (string.IsNullOrEmpty (searchField.Text)) {
+                this.Activity.SetResult (Result.Canceled);
+            } else {
+                this.Activity.SetResult (Result.Ok, ContactEmailChooserActivity.ResultIntent (searchField.Text, null));
+            }
             this.Activity.Finish ();
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/EventAttendeeViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/EventAttendeeViewController.cs
@@ -547,7 +547,7 @@ namespace NachoClient.iOS
         // INachoContactChooser delegate
         public void DeleteEmailAddress (INachoContactChooser vc, NcEmailAddress address)
         {
-            NcAssert.CaseError ();
+            // This is called when the user presses Enter in an empty search field.  There is nothing to delete.
         }
 
         // INachoContactChooser delegate


### PR DESCRIPTION
When editing the attendees for a meeting, if the user hit the Add
button then hit Enter in the search field without typing anything, the
app would crash.  This has been fixed.  The app now behaves as if the
user canceled the add.

(The same bug happened on both iOS and Android.  The causes, and
fixes, were different.  But the symptoms were identical, so the fixes
are lumped together.)
