### PR TITLE
detect (and possibly ignore) circular redirection, if settings were sent as well.

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsXmlFilters/AsXmlFilterSet.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsXmlFilters/AsXmlFilterSet.cs
@@ -89,5 +89,62 @@ namespace NachoCore.Wbxml
             AsXmlFilterSet._Responses.Add (new AsXmlFilterTasks ());
         }
     }
+
+    public class AutoDiscoverXmlFilter : NcXmlFilter
+    {
+        public AutoDiscoverXmlFilter () : base (new[]{"http://schemas.microsoft.com/exchange/autodiscover/mobilesync/responseschema/2006", "http://schemas.microsoft.com/exchange/autodiscover/responseschema/2006"})
+        {
+            Root = new NcXmlFilterNode ("xml", RedactionType.NONE, RedactionType.NONE);
+            var autoDRoot = new NcXmlFilterNode ("Autodiscover", RedactionType.NONE, RedactionType.NONE);
+
+            var responseNode = new NcXmlFilterNode ("Response", RedactionType.NONE, RedactionType.NONE);
+            {
+                {
+                    responseNode.Add (new NcXmlFilterNode ("Culture", RedactionType.NONE, RedactionType.NONE));
+                }
+                {
+                    var userNode = new NcXmlFilterNode ("User", RedactionType.NONE, RedactionType.NONE);
+                    {
+                        var emailNode = new NcXmlFilterNode ("EMailAddress", RedactionType.FULL, RedactionType.FULL);
+                        var displayNameNode = new NcXmlFilterNode ("DisplayName", RedactionType.FULL, RedactionType.FULL);
+                        userNode.Add (emailNode);
+                        userNode.Add (displayNameNode);
+                    }
+                    responseNode.Add (userNode);
+                }
+                {
+                    var actionNode = new NcXmlFilterNode ("Action", RedactionType.NONE, RedactionType.NONE);
+                    {
+                        var redirectNode = new NcXmlFilterNode ("Redirect", RedactionType.FULL, RedactionType.FULL);
+                        actionNode.Add (redirectNode);
+                
+                        var settingsNode = new NcXmlFilterNode ("Settings", RedactionType.NONE, RedactionType.NONE);
+                        {
+                            var serverNode = new NcXmlFilterNode ("Server", RedactionType.NONE, RedactionType.NONE);
+                            serverNode.Add (new NcXmlFilterNode ("Type", RedactionType.NONE, RedactionType.NONE));
+                            serverNode.Add (new NcXmlFilterNode ("Url", RedactionType.NONE, RedactionType.NONE));
+                            serverNode.Add (new NcXmlFilterNode ("Name", RedactionType.NONE, RedactionType.NONE));
+                            serverNode.Add (new NcXmlFilterNode ("ServerData", RedactionType.NONE, RedactionType.NONE));
+                            settingsNode.Add (serverNode);
+                        }
+                        actionNode.Add (settingsNode);
+                    }
+                    var errorNode = new NcXmlFilterNode ("Error", RedactionType.NONE, RedactionType.NONE);
+                    {
+                        errorNode.Add (new NcXmlFilterNode ("Status", RedactionType.NONE, RedactionType.NONE));
+                        errorNode.Add (new NcXmlFilterNode ("Message", RedactionType.NONE, RedactionType.NONE));
+                        errorNode.Add (new NcXmlFilterNode ("ErrorCode", RedactionType.NONE, RedactionType.NONE));
+                        errorNode.Add (new NcXmlFilterNode ("DebugData", RedactionType.NONE, RedactionType.NONE));
+                        actionNode.Add (errorNode);
+                    }
+                    responseNode.Add (actionNode);
+                }
+            }
+            autoDRoot.Add (responseNode);
+            Root.Add (autoDRoot);
+        }
+    }
+
+
 }
 

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsXmlFilters/AsXmlFilterSettingsResponse.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsXmlFilters/AsXmlFilterSettingsResponse.cs
@@ -216,6 +216,14 @@ namespace NachoCore.Wbxml
             node5.Add(node6); // Account -> EmailAddresses
             node4.Add(node5); // Accounts -> Account
             node3.Add(node4); // Get -> Accounts
+            node4 = new NcXmlFilterNode ("EmailAddresses", RedactionType.NONE, RedactionType.NONE);
+            // SMTPAddress
+            node5 = new NcXmlFilterNode ("SMTPAddress", RedactionType.FULL, RedactionType.FULL);
+            node4.Add(node5); // EmailAddresses -> SMTPAddress
+            // PrimarySmtpAddress
+            node5 = new NcXmlFilterNode ("PrimarySmtpAddress", RedactionType.FULL, RedactionType.FULL);
+            node4.Add(node5); // EmailAddresses -> PrimarySmtpAddress
+            node3.Add(node4); // Get -> EmailAddresses
             node2.Add(node3); // UserInformation -> Get
             node1.Add(node2); // Settings -> UserInformation
             // RightsManagementInformation

--- a/NachoClient.Android/NachoCore/Utils/NcXmlFilter.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcXmlFilter.cs
@@ -38,11 +38,6 @@ namespace NachoCore.Wbxml
     {
         public RedactionType ElementRedaction { get; set; }
 
-        /// <summary>
-        /// This doesn't appear to be used, i.e. Attribute redaction is not used (we don't copy attributes,
-        /// so redaction appears to always be FULL.
-        /// </summary>
-        /// <value>The attribute redaction.</value>
         public RedactionType AttributeRedaction { get; set; }
 
         public NcXmlFilterNode (string name, RedactionType elementRedaction, RedactionType attributeRedaction) :
@@ -103,7 +98,7 @@ namespace NachoCore.Wbxml
 
         public NcXmlFilterNode Root { set; get; }
 
-        public string NameSpace { set; get; }
+        public string[] NameSpaces { set; get; }
 
         // Filtered XDocument
         private XDocument DocOut { get; set; }
@@ -115,7 +110,24 @@ namespace NachoCore.Wbxml
         {
             ParentSet = null;
             Root = null;
-            NameSpace = nameSpace;
+            NameSpaces = new [] {nameSpace};
+        }
+
+        public NcXmlFilter (string[] nameSpaces)
+        {
+            ParentSet = null;
+            Root = null;
+            NameSpaces = nameSpaces;
+        }
+
+        public bool ContainsNameSpace (string nameSpace)
+        {
+            foreach (var ns in NameSpaces) {
+                if (ns.ToLowerInvariant () == nameSpace.ToLowerInvariant ()) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 
@@ -128,10 +140,22 @@ namespace NachoCore.Wbxml
             FilterList = new List<NcXmlFilter> ();
         }
 
+        public NcXmlFilter FindFilter (string[] nameSpaces)
+        {
+            foreach (var ns in nameSpaces) {
+                var filter = FindFilter (ns);
+                if (null != filter) {
+                    return filter;
+                }
+            }
+            return null;
+        }
+
         public NcXmlFilter FindFilter (string nameSpace)
         {
             foreach (NcXmlFilter filter in FilterList) {
-                if (filter.NameSpace == nameSpace) {
+                foreach (var ns in filter.NameSpaces)
+                if (ns.ToLowerInvariant () == nameSpace.ToLowerInvariant ()) {
                     return filter;
                 }
             }
@@ -159,7 +183,7 @@ namespace NachoCore.Wbxml
 
         public void Add (NcXmlFilter filter)
         {
-            NcAssert.True (null == FindFilter (filter.NameSpace));
+            NcAssert.True (null == FindFilter (filter.NameSpaces));
             FilterList.Add (filter);
             filter.ParentSet = this;
         }
@@ -277,18 +301,36 @@ namespace NachoCore.Wbxml
             FilterStack.Clear ();
         }
 
+        string GetNamespace (XElement element)
+        {
+            var ns = element.Name.NamespaceName;
+            if (string.IsNullOrEmpty (ns) && element.HasAttributes) {
+                foreach (var attr in element.Attributes ()) {
+                    if (attr.IsNamespaceDeclaration) {
+                        ns = attr.Value;
+                        break;
+                    }
+                }
+            }
+            return ns;
+        }
+
         private Frame InitializeFrame (XNode node)
         {
             Frame current = null;
-
             if (0 == FilterStack.Count) {
                 current = new Frame ();
 
                 NcAssert.True (IsElement (node));
                 XElement element = (XElement)node;
-                current.Filter = FilterSet.FindFilter (element.Name.NamespaceName);
+                var ns = GetNamespace (element);
+                // if we couldn't find a namespace, try using the element LocalName.
+                if (string.IsNullOrEmpty (ns) && !string.IsNullOrEmpty (element.Name.LocalName)) {
+                    ns = element.Name.LocalName;
+                }
+                current.Filter = FilterSet.FindFilter (ns);
                 if (null == current.Filter) {
-                    Log.Warn (Log.LOG_XML_FILTER, "No filter for namespace {0}", element.Name.NamespaceName);
+                    Log.Warn (Log.LOG_XML_FILTER, "No filter for namespace {0}", ns);
                 } else {
                     current.ParentNode = current.Filter.Root.FindChildNode (element);
                     if (null == current.ParentNode) {
@@ -300,20 +342,22 @@ namespace NachoCore.Wbxml
 
                 if (IsElement (node)) {
                     XElement element = (XElement)node;
+                    var ns = GetNamespace (element);
 
                     // Is there a namespace switch?
                     if (null != current.Filter) {
-                        if ((current.Filter.NameSpace != element.Name.NamespaceName) &&
+                        if (!string.IsNullOrEmpty (ns) && // if the namespace is empty, assume it's the same as the parent.
+                            !current.Filter.ContainsNameSpace (ns) &&
                             // Do not do a namespace switch if we are already in redacted mode.
                             // This is because it will put a non-null parent node and make it think
                             // this is no longer in redacted mode. So, just ignore the namespace change
                             !current.IsRedacted ()) {
-                            current.Filter = FilterSet.FindFilter (element.Name.NamespaceName);
+                            current.Filter = FilterSet.FindFilter (ns);
                             if (null != current.Filter) {
                                 current.ParentNode = current.Filter.Root;
                                 NcAssert.True (null != current.ParentNode);
                             } else {
-                                Log.Warn (Log.LOG_XML_FILTER, "Switching to an unknown namespace {0}", element.Name.NamespaceName);
+                                Log.Warn (Log.LOG_XML_FILTER, "Switching to an unknown namespace {0}:{1}", element.Name, ns);
                                 current.ParentNode = null;
                             }
                         }
@@ -322,9 +366,10 @@ namespace NachoCore.Wbxml
                     // Look for the filter node for this element
                     if (null != current.ParentNode) {
                         if (RedactionType.FULL != current.ParentNode.ElementRedaction) {
+                            var previousParent = current.ParentNode;
                             current.ParentNode = current.ParentNode.FindChildNode (element);
                             if (null == current.ParentNode) {
-                                Log.Warn (Log.LOG_XML_FILTER, "Unknown element tag {0}", element.Name);
+                                Log.Warn (Log.LOG_XML_FILTER, "Unknown element tag {0}:{1}\n{2}", previousParent.Name, element.Name, previousParent.ToString ());
                             }
                         } else {
                             current.ParentNode = null;
@@ -342,7 +387,37 @@ namespace NachoCore.Wbxml
                 Wbxml.AddRange (wbxml);
             } else {
                 newElement = new XElement (element.Name);
-                // TODO Add attribute redaction here? No attributes are copied from element, so redaction is always FULL.
+                if (element.HasAttributes && frame.AttributeRedaction != RedactionType.FULL) {
+                    foreach (var attr in element.Attributes ()) {
+                        string value;
+                        if (attr.IsNamespaceDeclaration) {
+                            value = attr.Value;
+                        } else {
+                            string hash;
+                            switch (frame.AttributeRedaction) {
+                            default:
+                                NcAssert.CaseError ("Should not reach here");
+                                return null;
+
+                            case RedactionType.NONE:
+                                value = attr.Value;
+                                break;
+                            case RedactionType.LENGTH:
+                                value = String.Format ("[{0} redacted bytes]", attr.Value.Length);
+                                break;
+                            case RedactionType.SHORT_HASH:
+                                hash = ShortHash (attr.Value);
+                                value = String.Format ("[{0} redacted bytes] {1}", attr.Value.Length, hash);
+                                break;
+                            case RedactionType.FULL_HASH:
+                                hash = FullHash (attr.Value);
+                                value = String.Format ("[{0} redacted bytes] {1}", attr.Value.Length, hash);
+                                break;
+                            }
+                        }
+                        newElement.SetAttributeValue (attr.Name, value);
+                    }
+                }
                 if (0 == FilterStack.Count) {
                     NcAssert.True (null == XmlDoc.Root);
                     XmlDoc.Add (newElement);

--- a/Test.iOS/Test.iOS.csproj
+++ b/Test.iOS/Test.iOS.csproj
@@ -353,6 +353,9 @@
     <Compile Include="..\Test.Android\NcQueueTests.cs">
       <Link>NcQueueTests.cs</Link>
     </Compile>
+    <Compile Include="..\Test.Android\NcXmlFilterTest.cs">
+      <Link>NcXmlFilterTest.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />


### PR DESCRIPTION
The theory for the customer's issue (see https://support.nachocove.com/helpdesk/tickets/559) is that we are getting a circular redirect (autodiscover.xml says "restart auto-d with this OTHER email address", but the OTHER email address is the same as we already have), and that perhaps there's a settings section in the same downloaded xml file. So instead of failing on the 'circular redirect', check to see if there are settings, and if they have the required information, use them).

I added autodiscovery logging and redaction and also updated and fixed the redaction filter unit tests, and added them to ios (they were android only so far).
I also completed some code that seemed to be missing entirely, i.e. filling in (and possibly redacting) the xml attributes. Unit tests were enhanced for that as well.
Also, I added an xml section to the settings filter, since I noticed quite a few "Unknown element tag {Settings}EmailAddresses" in the logs.
