### PR TITLE
Don't crash when deleting an account while in unified mode

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NachoUnifiedInbox.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoUnifiedInbox.cs
@@ -96,7 +96,8 @@ namespace NachoCore
 
         public bool IsCompatibleWithAccount (McAccount account)
         {
-            return NcApplication.Instance.Account.ContainsAccount (account.Id);
+            var currentAccount = NcApplication.Instance.Account;
+            return null != currentAccount && currentAccount.ContainsAccount (account.Id);
         }
 
     }


### PR DESCRIPTION
The app crashed when I deleted an account.  From the stack trace, it
looks like a status indicator was sent while the account deletion was
in progress, and NachoUnifiedInbox crashed while accessing
NcApplication.Instance.Account.  Change the code to protect against
this situation.
