### PR TITLE
android contacts import fixes

### DIFF
--- a/NachoClient.Android/NachoPlatform.Android/ContactsAndroid.cs
+++ b/NachoClient.Android/NachoPlatform.Android/ContactsAndroid.cs
@@ -357,6 +357,7 @@ namespace NachoPlatform
                         PhoneDataKind type = (PhoneDataKind)GetFieldInt (pCur, ContactsContract.CommonDataKinds.Phone.InterfaceConsts.Type);
                         String phLabel = GetField (pCur, ContactsContract.CommonDataKinds.Phone.InterfaceConsts.Label);
                         string phoneType = ContactsContract.CommonDataKinds.Phone.GetTypeLabel (MainApplication.Instance.ApplicationContext.Resources, type, phLabel);
+                        int starred = GetFieldInt (pCur, ContactsContract.CommonDataKinds.Phone.InterfaceConsts.Starred);
                         string name;
                         string label;
                         if (!string.IsNullOrEmpty (phoneType)) {
@@ -386,7 +387,11 @@ namespace NachoPlatform
                             name = Xml.Contacts.MobilePhoneNumber;
                             label = null;
                         }
-                        Contact.AddPhoneNumberAttribute (Contact.AccountId, name, label, phoneNo);
+                        if (starred == 0) {
+                            Contact.AddPhoneNumberAttribute (Contact.AccountId, name, label, phoneNo);
+                        } else {
+                            Contact.AddDefaultPhoneNumberAttribute (Contact.AccountId, name, label, phoneNo);
+                        }
                     } while (pCur.MoveToNext ());
                 }
                 pCur.Close ();
@@ -406,17 +411,28 @@ namespace NachoPlatform
                         EmailDataKind type = (EmailDataKind)GetFieldInt (pCur, ContactsContract.CommonDataKinds.Email.InterfaceConsts.Type);
                         String label = GetField (pCur, ContactsContract.CommonDataKinds.Email.InterfaceConsts.Label);
                         string emailType = ContactsContract.CommonDataKinds.Email.GetTypeLabel (MainApplication.Instance.ApplicationContext.Resources, type, label);
+                        int starred = GetFieldInt (pCur, ContactsContract.CommonDataKinds.Email.InterfaceConsts.Starred);
                         InternetAddressList addresses;
                         if (!InternetAddressList.TryParse (email, out addresses) || 0 == addresses.Count) {
                             continue;
                         }
-                        foreach (var iAddr in addresses) {
-                            var addr = iAddr as MailboxAddress;
-                            if (null == addr) {
-                                continue;
+                        if (addresses.Count > 1) {
+                            foreach (var iAddr in addresses) {
+                                var addr = iAddr as MailboxAddress;
+                                if (null == addr) {
+                                    continue;
+                                }
+                                var name = string.Format ("EmailAddress{0}-{1}", emailType, addresses.IndexOf (addr));
+                                Contact.AddEmailAddressAttribute (Contact.AccountId, name, emailType, addr.ToString ()); // FIXME what are name and label?
                             }
-                            var name = string.Format ("EmailAddress{0}-{1}", emailType, addresses.IndexOf (addr));
-                            Contact.AddEmailAddressAttribute (Contact.AccountId, name, emailType, addr.ToString ()); // FIXME what are name and label?
+                        } else {
+                            var addr = addresses[0] as MailboxAddress;
+                            var name = string.Format ("EmailAddress{0}", emailType, addresses.IndexOf (addr));
+                            if (starred == 0) {
+                                Contact.AddEmailAddressAttribute (Contact.AccountId, name, emailType, addr.ToString ()); // FIXME what are name and label?
+                            } else {
+                                Contact.AddDefaultEmailAddressAttribute (Contact.AccountId, name, emailType, addr.ToString ()); // FIXME what are name and label?
+                            }
                         }
                     } while (pCur.MoveToNext ());
                 }


### PR DESCRIPTION
we only handled single-addresses, and we need to create new names for each address anyway, so parse the addresses in the android platform function and loop to add them.
resolves nachocove/qa#1663

Also capture the starred nature of phone numbers and (individual ONLY) email addresses, and set them as default. I noticed I can 'set default' on a field where I entered multiple addresses (for the previous bug's testing) and decided it doesn't make sense to mark two addresses as default, so the star will be ignored if there's more than one email in the field.
resolves nachocove/qa#1642
