### PR TITLE
The dispose in OnDestroy seems to be causing a crash.

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/ContactsListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/ContactsListFragment.cs
@@ -195,7 +195,7 @@ namespace NachoClient.AndroidClient
         public override void OnDestroyView ()
         {
             base.OnDestroyView ();
-            contactsListAdapter.Dispose ();
+            // contactsListAdapter.Dispose ();
         }
 
         public override void OnSaveInstanceState (Bundle outState)


### PR DESCRIPTION
Crashes when the class unregisters its data observer. Here's a workaround; the bug is still open.
