### PR TITLE
Fix crash caused by inappropriate calling of Dispose()

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/ComposeFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/ComposeFragment.cs
@@ -113,7 +113,7 @@ namespace NachoClient.AndroidClient
 
         public override void OnDestroyView ()
         {
-            HeaderView.Dispose ();
+            HeaderView.Cleanup ();
             base.OnDestroyView ();
         }
 

--- a/NachoClient.Android/NachoUI.Android/Activities/ContactsListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/ContactsListFragment.cs
@@ -195,7 +195,7 @@ namespace NachoClient.AndroidClient
         public override void OnDestroyView ()
         {
             base.OnDestroyView ();
-            // contactsListAdapter.Dispose ();
+            contactsListAdapter.Cleanup ();
         }
 
         public override void OnSaveInstanceState (Bundle outState)
@@ -396,14 +396,11 @@ namespace NachoClient.AndroidClient
             });
         }
 
-        protected override void Dispose (bool disposing)
+        public void Cleanup ()
         {
-            if (disposing) {
-                NcApplication.Instance.StatusIndEvent -= StatusIndicatorCallback;
-                searcher.Dispose ();
-                searcher = null;
-            }
-            base.Dispose (disposing);
+            NcApplication.Instance.StatusIndEvent -= StatusIndicatorCallback;
+            searcher.Dispose ();
+            searcher = null;
         }
 
         public int PositionForSection (int section)

--- a/NachoClient.Android/NachoUI.Android/Support/MessageComposeHeaderView.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/MessageComposeHeaderView.cs
@@ -184,14 +184,11 @@ namespace NachoClient.AndroidClient
             base.OnLayout (changed, l, t, r, b);
         }
 
-        protected override void Dispose (bool disposing)
+        public void Cleanup ()
         {
-            if (disposing) {
-                ToField.Adapter.Dispose ();
-                CcField.Adapter.Dispose ();
-                BccField.Adapter.Dispose ();
-            }
-            base.Dispose (disposing);
+            ((ContactAddressAdapter)ToField.Adapter).Cleanup ();
+            ((ContactAddressAdapter)CcField.Adapter).Cleanup ();
+            ((ContactAddressAdapter)BccField.Adapter).Cleanup ();
         }
     }
 
@@ -258,13 +255,10 @@ namespace NachoClient.AndroidClient
                 return;
             }
 
-            protected override void Dispose (bool disposing)
+            public void Cleanup ()
             {
-                if (disposing) {
-                    searcher.Dispose ();
-                    searcher = null;
-                }
-                base.Dispose (disposing);
+                searcher.Dispose ();
+                searcher = null;
             }
         }
 
@@ -343,13 +337,10 @@ namespace NachoClient.AndroidClient
             }
         }
 
-        protected override void Dispose (bool disposing)
+        public void Cleanup ()
         {
-            if (disposing) {
-                filter.Dispose ();
-                filter = null;
-            }
-            base.Dispose (disposing);
+            filter.Cleanup ();
+            filter = null;
         }
     }
 }


### PR DESCRIPTION
Calling Dispose() on Android UI objects is not kosher.  Don't
piggyback on the IDisposable mechanism to clean up contact search
objects.  Use differently named functions instead.

Fix nachocove/qa#1662
Fix nachocove/qa#1687
