### PR TITLE
Defer background transitions until we are sure

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Support/LifecycleSpy.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/LifecycleSpy.cs
@@ -67,13 +67,15 @@ namespace NachoClient.AndroidClient
             lock (BackgroundTimerLock) {
                 if (null == GoToBackgroundTimer) {
                     GoToBackgroundTimer = new NcTimer ("LifecycleSpy:GoToBackgroundTimer", (state) => {
-                        Log.Info (Log.LOG_LIFECYCLE, "LifecycleSpy:GoToBackgroundTimer called.");
-                        GoToBackgroundTimer.Dispose ();
-                        GoToBackgroundTimer = null;
-                        isForeground = false;
-                        NcApplication.Instance.PlatformIndication = NcApplication.ExecutionContextEnum.Background;
-                        McMutables.Set (McAccount.GetDeviceAccount ().Id, "Android", "BackgroundTime", DateTime.UtcNow.ToString ());
-                        Log.Info (Log.LOG_LIFECYCLE, "LifecycleSpy:GoToBackgroundTimer exited.");
+                        lock (BackgroundTimerLock) {
+                            Log.Info (Log.LOG_LIFECYCLE, "LifecycleSpy:GoToBackgroundTimer called.");
+                            GoToBackgroundTimer.Dispose ();
+                            GoToBackgroundTimer = null;
+                            isForeground = false;
+                            NcApplication.Instance.PlatformIndication = NcApplication.ExecutionContextEnum.Background;
+                            McMutables.Set (McAccount.GetDeviceAccount ().Id, "Android", "BackgroundTime", DateTime.UtcNow.ToString ());
+                            Log.Info (Log.LOG_LIFECYCLE, "LifecycleSpy:GoToBackgroundTimer exited.");
+                        }
                     }, null, new TimeSpan (0, 0, 5), TimeSpan.Zero);
                 }
             }


### PR DESCRIPTION
Android doesn't have proper fg/bg transition events so the view
transitions are used as a proxy. The problem is background will
be signaled too often and incorrectly, so a timer is introduced
to delay the transition to background in case it is just a view
transition.
