### PR TITLE
don't crash on no parts

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapFetchCommands/ImapFetchBody.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapFetchCommands/ImapFetchBody.cs
@@ -148,7 +148,7 @@ namespace NachoCore.IMAP
 
             Cts.Token.ThrowIfCancellationRequested ();
             try {
-                if (null == fetchBody.Parts) {
+                if (null == fetchBody.Parts || !fetchBody.Parts.Any ()) {
                     result = DownloadEntireMessage (ref body, mailKitFolder, uid, imapBody);
                 } else {
                     result = DownloadIndividualParts (email, ref body, mailKitFolder, uid, fetchBody.Parts, imapBody.ContentType.Boundary);


### PR DESCRIPTION
DownloadIndividualParts checks both for null Parts and Parts.any. But
the caller didn’t. Fix that.

resolves nachocove/qa#1710
