### PR TITLE
A few more places of default account instead of current account

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventEditActivity.cs
@@ -160,7 +160,7 @@ namespace NachoClient.AndroidClient
                     endTime = cal.EndTime.ToLocalTime ();
 
                     // Figure out the correct account for the new event.
-                    account = NcApplication.Instance.Account;
+                    account = NcApplication.Instance.DefaultCalendarAccount;
                     if (!account.HasCapability (McAccount.AccountCapabilityEnum.CalWriter) || 0 == new NachoFolders (account.Id, NachoFolders.FilterForCalendars).Count ()) {
                         if (AndroidCalendars.DeviceCalendarsExist ()) {
                             isAppEvent = false;

--- a/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventListFragment.cs
@@ -150,7 +150,7 @@ namespace NachoClient.AndroidClient
                 switch (index) {
                 case LATE_TAG:
                     if (null != cal) {
-                        var outgoingMessage = McEmailMessage.MessageWithSubject (NcApplication.Instance.Account, "Re: " + cal.GetSubject ());
+                        var outgoingMessage = McEmailMessage.MessageWithSubject (NcApplication.Instance.DefaultEmailAccount, "Re: " + cal.GetSubject ());
                         outgoingMessage.To = cal.OrganizerEmail;
                         StartActivity (MessageComposeActivity.InitialTextIntent (this.Activity, outgoingMessage, "Running late."));
                     }
@@ -158,7 +158,7 @@ namespace NachoClient.AndroidClient
                 case FORWARD_TAG:
                     if (null != cal) {
                         StartActivity (MessageComposeActivity.ForwardCalendarIntent (
-                            this.Activity, cal.Id, McEmailMessage.MessageWithSubject (NcApplication.Instance.Account, "Fwd: " + cal.GetSubject ())));
+                            this.Activity, cal.Id, McEmailMessage.MessageWithSubject (NcApplication.Instance.DefaultEmailAccount, "Fwd: " + cal.GetSubject ())));
                     }
                     break;
                 default:

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageListFragment.cs
@@ -189,7 +189,7 @@ namespace NachoClient.AndroidClient
                     switch (index) {
                     case LATE_TAG:
                         if (null != cal) {
-                            var outgoingMessage = McEmailMessage.MessageWithSubject (NcApplication.Instance.Account, "Re: " + cal.GetSubject ());
+                            var outgoingMessage = McEmailMessage.MessageWithSubject (NcApplication.Instance.DefaultEmailAccount, "Re: " + cal.GetSubject ());
                             outgoingMessage.To = cal.OrganizerEmail;
                             StartActivity (MessageComposeActivity.InitialTextIntent (this.Activity, outgoingMessage, "Running late."));
                         }
@@ -197,7 +197,7 @@ namespace NachoClient.AndroidClient
                     case FORWARD_TAG:
                         if (null != cal) {
                             StartActivity (MessageComposeActivity.ForwardCalendarIntent (
-                                this.Activity, cal.Id, McEmailMessage.MessageWithSubject (NcApplication.Instance.Account, "Fwd: " + cal.GetSubject ())));
+                                this.Activity, cal.Id, McEmailMessage.MessageWithSubject (NcApplication.Instance.DefaultEmailAccount, "Fwd: " + cal.GetSubject ())));
                         }
                         break;
                     default:


### PR DESCRIPTION
Fix a few calendar related places where DefaultEmailAccount or
DefaultCalendarAccount should be used instead of
NcApplication.Instance.Account.
