### PR TITLE
Don't use McAttendee.AccountId

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/AttendeeListBaseFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/AttendeeListBaseFragment.cs
@@ -42,6 +42,7 @@ namespace NachoClient.AndroidClient
             base.OnCreate (savedInstanceState);
 
             adapter = new AttendeeListAdapter (CheckEmptyList);
+            adapter.AccountId = accountId;
             state = CurrentTab.All;
         }
 
@@ -84,6 +85,9 @@ namespace NachoClient.AndroidClient
         public int AccountId {
             set {
                 accountId = value;
+                if (null != adapter) {
+                    adapter.AccountId = value;
+                }
             }
         }
 
@@ -176,6 +180,8 @@ namespace NachoClient.AndroidClient
 
         private Action changedCallback;
 
+        private int accountId;
+
         public List<McAttendee> Attendees {
             get {
                 return allAttendees;
@@ -190,6 +196,12 @@ namespace NachoClient.AndroidClient
         {
             this.changedCallback = changedCallback;
             Attendees = new List<McAttendee> ();
+        }
+
+        public int AccountId {
+            set {
+                accountId = value;
+            }
         }
 
         public void SetState (AttendeeListBaseFragment.CurrentTab newState)
@@ -299,8 +311,8 @@ namespace NachoClient.AndroidClient
             var nameView = cell.FindViewById<TextView> (Resource.Id.attendee_name);
             var emailView = cell.FindViewById<TextView> (Resource.Id.attendee_email);
             var initials = ContactsHelper.NameToLetters (attendee.DisplayName);
-            var color = Util.ColorResourceForEmail (attendee.AccountId, attendee.Email);
-            initialsView.SetEmailAddress (attendee.AccountId, attendee.Email, initials, color);
+            var color = Util.ColorResourceForEmail (accountId, attendee.Email);
+            initialsView.SetEmailAddress (accountId, attendee.Email, initials, color);
             nameView.Text = attendee.DisplayName;
             emailView.Text = attendee.Email;
             return cell;

--- a/NachoClient.Android/NachoUI.Android/Activities/AttendeeListViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/AttendeeListViewFragment.cs
@@ -94,7 +94,7 @@ namespace NachoClient.AndroidClient
             var attendee = adapter [position];
             switch (index) {
             case EMAIL_SWIPE_TAG:
-                StartActivity (MessageComposeActivity.NewMessageIntent (this.Activity, attendee.AccountId, attendee.Email));
+                StartActivity (MessageComposeActivity.NewMessageIntent (this.Activity, accountId, attendee.Email));
                 break;
             case DIAL_SWIPE_TAG:
                 var contact = McContact.QueryByEmailAddress (accountId, attendee.Email).FirstOrDefault ();

--- a/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/EventViewFragment.cs
@@ -298,8 +298,8 @@ namespace NachoClient.AndroidClient
                     } else if (a < attendees.Count) {
                         var attendee = attendees [a];
                         var initials = ContactsHelper.NameToLetters (attendee.DisplayName);
-                        var color = Util.ColorResourceForEmail (attendee.AccountId, attendee.Email);
-                        attendeePhotoView.SetEmailAddress (attendee.AccountId, attendee.Email, initials, color);
+                        var color = Util.ColorResourceForEmail (detail.Account.Id, attendee.Email);
+                        attendeePhotoView.SetEmailAddress (detail.Account.Id, attendee.Email, initials, color);
                         attendeeNameView.Text = GetFirstName (attendee.DisplayName);
                     } else {
                         attendeePhotoView.Visibility = ViewStates.Gone;


### PR DESCRIPTION
Stop referencing McAttendee.AccountId, because it is sometimes not
set, since McAttendees are in-memory only and are no longer saved in
the database.

Fix nachocove/qa#1709
