### PR TITLE
fix date checks to not crash

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcEmailMessageBundle.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcEmailMessageBundle.cs
@@ -856,7 +856,7 @@ namespace NachoCore.Utils
                     if (message.Cc.Count > 0) {
                         IncludeText (String.Format ("Cc: {0}\n", message.Cc.ToString ()));
                     }
-                    if (!message.Date.Equals (DateTime.MinValue)) {
+                    if (message.Date != default(DateTimeOffset)) {
                         IncludeText (String.Format ("Sent: {0}\n", message.Date.ToString ()));
                     }
                     if (!String.IsNullOrEmpty (message.Subject)) {
@@ -890,7 +890,7 @@ namespace NachoCore.Utils
                     if (message.Cc.Count > 0) {
                         headersElement.AppendChild (SimpleMessageHeaderNode (doc, "Cc", message.Cc.ToString ()));
                     }
-                    if (!message.Date.Equals (DateTime.MinValue)) {
+                    if (message.Date != default(DateTimeOffset)) {
                         headersElement.AppendChild (SimpleMessageHeaderNode (doc, "Sent", message.Date.ToString ()));
                     }
                     if (!String.IsNullOrEmpty (message.Subject)) {


### PR DESCRIPTION
fixes nachocove/qa#1719

Was comparing a DateTimeOffset to a DateTime, which was causing an implicit
converstion that would sometimes fail.  This new check uses the same technique
as MimeKit uses internally
