### PR TITLE
Fix nachocove/qa#1588.  Fix nachocove/qa#1587.

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsHelpers.cs
@@ -103,6 +103,14 @@ namespace NachoCore.ActiveSync
                     item.BodyPreview = bodyText;
                 }
             }
+            if (null != item.BodyPreview) {
+                const int TruncationSize = 500;
+                // AWS ignores trunc size & returns the full body
+                if ((2*TruncationSize) < item.BodyPreview.Length) {
+                    Log.Warn (Log.LOG_AS, "Body preview too big: {0}", item.BodyPreview.Length);
+                    item.BodyPreview = item.BodyPreview.Substring (0, TruncationSize);
+                }
+            }
         }
 
         public static T ToEnum<T> (this string enumString)


### PR DESCRIPTION
AWS does not honor truncation size, so trim the preview if it is too big.
