### PR TITLE
Fix nachocove/qa#1395. 

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/BackEnd.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/BackEnd.cs
@@ -110,7 +110,7 @@ namespace NachoCore
                 CreateServices (accountId);
                 services = GetServices (accountId);
                 if (services == null) {
-                    Log.Warn (Log.LOG_BACKEND, "StartBackendIfNotStarted ({1}) could not find services.", accountId);
+                    Log.Warn (Log.LOG_BACKEND, "StartBackendIfNotStarted ({0}) could not find services.", accountId);
                     return null;
                 }
             }
@@ -303,6 +303,10 @@ namespace NachoCore
         {
             var services = new ConcurrentQueue<NcProtoControl> ();
             var account = McAccount.QueryById<McAccount> (accountId);
+            if (null == account) {
+                Log.Info (Log.LOG_BACKEND, "CreateServices account {0} is null", accountId);
+                return;
+            }
             switch (account.AccountType) {
             case McAccount.AccountTypeEnum.Device:
                 services.Enqueue (new DeviceProtoControl (this, accountId));

--- a/NachoClient.Android/NachoUI.Android/Activities/WaitingFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/WaitingFragment.cs
@@ -55,6 +55,7 @@ namespace NachoClient.AndroidClient
         private static AccountSyncingStatusMessage SyncingMessage = new AccountSyncingStatusMessage ("Syncing...", "Syncing your inbox...", true);
         private static AccountSyncingStatusMessage SuccessMessage = new AccountSyncingStatusMessage ("Account Created", "Your account is ready!", false);
         private static AccountSyncingStatusMessage ErrorMessage = new AccountSyncingStatusMessage ("Account Created", "Sorry, we could not fully sync your inbox.  Please see Settings for more information", false);
+        private static AccountSyncingStatusMessage TooManyDevicesMessage = new AccountSyncingStatusMessage ("Cannot Create Account", "You are already using the maximum number of devices for this account.  Please contact your system administrator.", false);
         private static AccountSyncingStatusMessage NetworkMessage = new AccountSyncingStatusMessage ("Account Created", "Syncing will complete when network connectivity is restored", false);
 
         private AccountSyncingStatusMessage Message = SyncingMessage;
@@ -224,10 +225,20 @@ namespace NachoClient.AndroidClient
             CompleteWithMessage (SuccessMessage);
         }
 
-        public void ServerIndTooManyDevices (int acccountId)
+        public void ServerIndTooManyDevices (int accountId)
         {
             LoginEvents.Owner = null;
-            CompleteWithMessage (ErrorMessage);
+            BackEnd.Instance.Stop (accountId);
+            NcAccountHandler.Instance.RemoveAccount (accountId);
+            account = null;
+
+            NcAlertView.Show (this.Activity,
+                "Account Setup Failed",
+                "You are already using the maximum number of devices for this account.  Please contact your system administrator.",
+                () => {
+                    var parent = (WaitingFragmentDelegate)Activity;
+                    parent.WaitingFinished (account);
+                });
         }
 
         public void ServerIndServerErrorRetryLater (int acccountId)


### PR DESCRIPTION
Remove the account if it won't be created properly.  Notify the user.  Fix a log format error.  Don't start services for a null account, which happened when backendstatus was called during or right after remove account.
