### PR TITLE
Index email messages right after they are synched

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcBrain.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrain.cs
@@ -11,6 +11,7 @@ using NachoCore.Utils;
 using NachoCore.Model;
 using NachoCore.Index;
 using System.Threading;
+using System.Linq;
 
 namespace NachoCore.Brain
 {
@@ -269,6 +270,11 @@ namespace NachoCore.Brain
         public void ProcessOneNewEmail (McEmailMessage emailMessage)
         {
             NcContactGleaner.GleanContactsHeaderPart1 (emailMessage);
+
+            var folder = McFolder.QueryByFolderEntryId<McEmailMessage> (emailMessage.AccountId, emailMessage.Id).FirstOrDefault ();
+            if (null != folder && !folder.IsJunkFolder () && NachoCore.ActiveSync.Xml.FolderHierarchy.TypeCode.DefaultDeleted_4 != folder.Type) {
+                NcBrain.IndexMessage (emailMessage);
+            }
         }
     }
 }

--- a/NachoClient.Android/NachoCore/Brain/NcBrainActions.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainActions.cs
@@ -231,7 +231,7 @@ namespace NachoCore.Brain
                     OpenedIndexes.Release (emailMessage.AccountId);
                     index.Remove ("message", id);
                     index = OpenedIndexes.Get (emailMessage.AccountId);
-                    Log.Warn (Log.LOG_SEARCH, "IndexEmailMessage: replacing index for {0}", id);
+                    Log.Info (Log.LOG_BRAIN, "IndexEmailMessage: replacing index for {0}", id);
                 }
                 var indexDoc = new EmailMessageIndexDocument (id, parameters);
 

--- a/NachoClient.Android/NachoCore/Brain/NcBrainApi.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainApi.cs
@@ -13,6 +13,7 @@ namespace NachoCore.Brain
             var dbEvent = new McBrainEvent (brainEvent);
             dbEvent.AccountId = accountId;
             dbEvent.Insert ();
+            SharedInstance.EnqueueIfNotAtTail (new NcBrainPersistentQueueEvent ());
         }
 
         protected static bool ValidEmailMessage (McEmailMessage emailMessage)
@@ -33,7 +34,6 @@ namespace NachoCore.Brain
             }
             var brainEvent = new NcBrainUpdateAddressScoreEvent (emailAddressId, forcedUpdateDependentMessages);
             PersistentEnqueue (accountId, brainEvent);
-            SharedInstance.Enqueue (new NcBrainPersistentQueueEvent ());
         }
 
         public static void UpdateMessageScore (int accountId, int emailMessageId)
@@ -43,7 +43,6 @@ namespace NachoCore.Brain
             }
             var brainEvent = new NcBrainUpdateMessageScoreEvent (accountId, emailMessageId);
             PersistentEnqueue (accountId, brainEvent);
-            SharedInstance.Enqueue (new NcBrainPersistentQueueEvent ());
         }
 
         public static void UpdateUserAction (int accountId, int emailMessageId, int action)
@@ -53,7 +52,6 @@ namespace NachoCore.Brain
             }
             var brainEvent = new NcBrainUpdateUserActionEvent (accountId, emailMessageId, action);
             PersistentEnqueue (accountId, brainEvent);
-            SharedInstance.Enqueue (new NcBrainPersistentQueueEvent ());
         }
 
         public static void UnindexEmailMessage (McEmailMessage emailMessage)
@@ -62,6 +60,15 @@ namespace NachoCore.Brain
                 return;
             }
             var brainEvent = new NcBrainUnindexMessageEvent (emailMessage.AccountId, emailMessage.Id);
+            PersistentEnqueue (emailMessage.AccountId, brainEvent);
+        }
+
+        public static void IndexMessage (McEmailMessage emailMessage)
+        {
+            if (null == emailMessage || 0 == emailMessage.Id || 0 == emailMessage.AccountId) {
+                return;
+            }
+            var brainEvent = new NcBrainIndexMessageEvent (emailMessage.AccountId, emailMessage.Id);
             PersistentEnqueue (emailMessage.AccountId, brainEvent);
         }
 
@@ -116,7 +123,6 @@ namespace NachoCore.Brain
                 Variance = variance,
             };
             PersistentEnqueue (emailMessage.AccountId, brainEvent);
-            SharedInstance.Enqueue (new NcBrainPersistentQueueEvent ());
         }
 
         public static void MessageReadStatusUpdated (McEmailMessage emailMessage, DateTime readTime, double variance)
@@ -133,7 +139,6 @@ namespace NachoCore.Brain
                 Variance = variance,
             };
             PersistentEnqueue (emailMessage.AccountId, brainEvent);
-            SharedInstance.Enqueue (new NcBrainPersistentQueueEvent ());
         }
 
         public static void MessageReplyStatusUpdated (McEmailMessage emailMessage, DateTime replyTime, double variance)
@@ -150,8 +155,6 @@ namespace NachoCore.Brain
                 Variance = variance,
             };
             PersistentEnqueue (emailMessage.AccountId, brainEvent);
-            SharedInstance.Enqueue (new NcBrainPersistentQueueEvent ());
         }
     }
 }
-

--- a/NachoClient.Android/NachoCore/Brain/NcBrainEvent.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainEvent.cs
@@ -26,6 +26,7 @@ namespace NachoCore.Brain
         UPDATE_MESSAGE_READ_STATUS,
         UPDATE_MESSAGE_REPLY_STATUS,
         PAUSE,
+        INDEX_MESSAGE,
     };
 
     [Serializable]
@@ -201,6 +202,15 @@ namespace NachoCore.Brain
     }
 
     [Serializable]
+    public class NcBrainIndexMessageEvent : NcBrainMessageEvent
+    {
+        public NcBrainIndexMessageEvent (Int64 accountId, Int64 emailMessageId)
+            : base (NcBrainEventType.INDEX_MESSAGE, accountId, emailMessageId)
+        {
+        }
+    }
+
+    [Serializable]
     public class NcBrainUnindexMessageEvent : NcBrainMessageEvent
     {
         public NcBrainUnindexMessageEvent (Int64 accountId, Int64 emailMessageId)
@@ -309,19 +319,13 @@ namespace NachoCore.Brain
     // This event is for kickstart processing in the persistent queue. Do not insert this into db.
     public class NcBrainPersistentQueueEvent : NcBrainEvent
     {
-        public int EventCount;
-
-        public NcBrainPersistentQueueEvent (int eventCount = -1) : base (NcBrainEventType.PERSISTENT_QUEUE)
+        public NcBrainPersistentQueueEvent () : base (NcBrainEventType.PERSISTENT_QUEUE)
         {
-            if (-1 == eventCount) {
-                eventCount = McBrainEvent.Count ();
-            }
-            EventCount = eventCount;
         }
 
         public override string ToString ()
         {
-            return String.Format ("[NcBrainPersistentQueueEvent: type={0} eventCount={1}", GetEventType (), EventCount);
+            return String.Format ("[NcBrainPersistentQueueEvent: type={0}", GetEventType ());
         }
     }
 }

--- a/NachoClient.Android/NachoCore/Brain/NcBrainEventHandler.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainEventHandler.cs
@@ -14,18 +14,16 @@ namespace NachoCore.Brain
         protected OpenedIndexSet OpenedIndexes;
         private long BytesIndexed;
         private RoundRobinList Scheduler;
-        private RoundRobinSource ContactIndexingSource;
 
         private void InitializeEventHandler ()
         {
             EventQueue = new NcQueue<NcBrainEvent> ();
             OpenedIndexes = new OpenedIndexSet (this);
             Scheduler = new RoundRobinList ();
-            Scheduler.Add ("update hi priority email messages", new RoundRobinSource (McEmailMessage.QueryNeedUpdateObjectsAbove, UpdateEmailMessageScores, 5), 3);
-            ContactIndexingSource = new RoundRobinSource (McContact.QueryNeedIndexingObjects, IndexContact, 5);
-            Scheduler.Add ("index contacts", ContactIndexingSource, 10);
-            Scheduler.Add ("analyze email messages", new RoundRobinSource (McEmailMessage.QueryNeedAnalysisObjects, AnalyzeEmailMessage, 5), 2);
-            Scheduler.Add ("index email messages", new RoundRobinSource (McEmailMessage.QueryNeedsIndexingObjects, IndexEmailMessage, 5), 3);
+            Scheduler.Add ("update hi priority email messages", new RoundRobinSource (McEmailMessage.QueryNeedUpdateObjectsAbove, UpdateEmailMessageScores, 50), 2);
+            Scheduler.Add ("index contacts", new RoundRobinSource (McContact.QueryNeedIndexingObjects, IndexContact, 50), 1);
+            Scheduler.Add ("analyze email messages", new RoundRobinSource (McEmailMessage.QueryNeedAnalysisObjects, AnalyzeEmailMessage, 50), 2);
+            Scheduler.Add ("index email messages", new RoundRobinSource (McEmailMessage.QueryNeedsIndexingObjects, IndexEmailMessage, 50), 1);
         }
 
         public void Enqueue (NcBrainEvent brainEvent)
@@ -36,8 +34,14 @@ namespace NachoCore.Brain
         public void EnqueueIfNotAlreadyThere (NcBrainEvent brainEvent)
         {
             EventQueue.EnqueueIfNot (brainEvent, (obj) => {
-                NcBrainEvent evt = obj;
-                return evt.Type == brainEvent.Type;
+                return obj.Type == brainEvent.Type;
+            });
+        }
+
+        public void EnqueueIfNotAtTail (NcBrainEvent brainEvent)
+        {
+            EventQueue.EnqueueIfNotTail (brainEvent, (obj) => {
+                return obj.Type == brainEvent.Type;
             });
         }
 
@@ -58,7 +62,7 @@ namespace NachoCore.Brain
 
         private void ProcessEvent (NcBrainEvent brainEvent)
         {
-            Log.Info (Log.LOG_BRAIN, "event type = {0}", Enum.GetName (typeof(NcBrainEventType), brainEvent.Type));
+            Log.Info (Log.LOG_BRAIN, "Process brain event type = {0}", Enum.GetName (typeof(NcBrainEventType), brainEvent.Type));
 
             switch (brainEvent.Type) {
             case NcBrainEventType.PAUSE:
@@ -94,14 +98,17 @@ namespace NachoCore.Brain
                 ProcessInitialRicEvent (brainEvent as NcBrainInitialRicEvent);
                 break;
             case NcBrainEventType.PERSISTENT_QUEUE:
-                var persistentQueueVent = (NcBrainPersistentQueueEvent)brainEvent;
                 try {
-                    ProcessPersistedRequests (persistentQueueVent.EventCount);
+                    ProcessPersistedRequests ();
+                    if (IsInterrupted ()) {
+                        // Not all of the persisted requests were processed.  Make sure they get processed later.
+                        EnqueueIfNotAtTail (new NcBrainPersistentQueueEvent ());
+                    }
                 } finally {
-                    // A reindex contact event can result in an index being left open.
                     OpenedIndexes.Cleanup ();
                 }
                 break;
+            case NcBrainEventType.INDEX_MESSAGE:
             case NcBrainEventType.UNINDEX_CONTACT:
             case NcBrainEventType.UNINDEX_MESSAGE:
             case NcBrainEventType.UPDATE_ADDRESS_SCORE:
@@ -118,57 +125,28 @@ namespace NachoCore.Brain
             }
         }
 
-        private int ProcessLoop (int count, string message, Func<bool> action)
-        {
-            int numProcessed = 0;
-            while (numProcessed < count && !IsInterrupted ()) {
-                if (!action ()) {
-                    break;
-                }
-                numProcessed++;
-            }
-            if (0 != numProcessed) {
-                Log.Info (Log.LOG_BRAIN, "{0} {1}", numProcessed, message);
-            }
-            return numProcessed;
-        }
-
         private bool ProcessPeriodic (DateTime runTill)
         {
             try {
                 bool didSomething = false;
-                bool ranOnce = false;
-                while (DateTime.UtcNow < runTill) {
-                    if (IsInterrupted ()) {
-                        break;
-                    }
-
-                    // Process all events in the persistent queue first
-                    if (0 < ProcessPersistedRequests (100)) {
-                        continue;
-                    }
-                    // Handle all other events
-                    if (!ranOnce) {
-                        Scheduler.Initialize ();
-                        ranOnce = true;
-                    }
-                    bool result;
-                    if (!Scheduler.Run (out result)) {
-                        break;
-                    }
+                int persistedCount = ProcessPersistedRequests ();
+                if (0 < persistedCount) {
                     didSomething = true;
                 }
-                while (DateTime.UtcNow < runTill) {
-                    if (IsInterrupted ()) {
-                        break;
+                if (DateTime.UtcNow < runTill && !IsInterrupted ()) {
+                    Scheduler.Initialize ();
+                    while (DateTime.UtcNow < runTill && !IsInterrupted ()) {
+                        bool ignoredResult;
+                        if (!Scheduler.Run (out ignoredResult)) {
+                            break;
+                        }
+                        didSomething = true;
                     }
-
-                    var emailMessages = McEmailMessage.QueryNeedUpdate (5, above: false);
-                    if (0 == emailMessages.Count) {
-                        break;
-                    }
+                }
+                while (DateTime.UtcNow < runTill && !IsInterrupted ()) {
+                    var emailMessages = McEmailMessage.QueryNeedUpdate (50, above: false);
                     foreach (var emailMessage in emailMessages) {
-                        if (IsInterrupted ()) {
+                        if (DateTime.UtcNow > runTill || IsInterrupted ()) {
                             break;
                         }
                         UpdateEmailMessageScores (emailMessage);
@@ -182,16 +160,19 @@ namespace NachoCore.Brain
             }
         }
 
-        private int ProcessPersistedRequests (int count)
+        private int ProcessPersistedRequests ()
         {
-            bool sourceReset = false;
-            return ProcessLoop (count, "persisted requests processed", () => {
+            int numProcessed = 0;
+            while (!IsInterrupted ()) {
                 var dbEvent = McBrainEvent.QueryNext ();
                 if (null == dbEvent) {
-                    return false;
+                    break;
                 }
                 var brainEvent = dbEvent.BrainEvent ();
                 switch (brainEvent.Type) {
+                case NcBrainEventType.INDEX_MESSAGE:
+                    IndexEmailMessage (McEmailMessage.QueryById<McEmailMessage> ((int)((NcBrainIndexMessageEvent)brainEvent).EmailMessageId));
+                    break;
                 case NcBrainEventType.UNINDEX_MESSAGE:
                     var unindexEvent = brainEvent as NcBrainUnindexMessageEvent;
                     UnindexEmailMessage ((int)unindexEvent.AccountId, (int)unindexEvent.EmailMessageId);
@@ -206,13 +187,6 @@ namespace NachoCore.Brain
                     UnindexContact ((int)reindexEvent.AccountId, (int)reindexEvent.ContactId);
                     if (null != contact) {
                         IndexContact (contact);
-                    }
-                    if (!sourceReset) {
-                        // The contact is already indexed but it may already be sitting
-                        // in contact indexing source's object list. Then, it will be
-                        // indexed twice. So, we manually clears that source's object list
-                        ContactIndexingSource.Reset ();
-                        sourceReset = true;
                     }
                     break;
                 case NcBrainEventType.UPDATE_ADDRESS_SCORE:
@@ -261,8 +235,12 @@ namespace NachoCore.Brain
                     break;
                 }
                 dbEvent.Delete ();
-                return true;
-            });
+                ++numProcessed;
+            }
+            if (0 < numProcessed) {
+                Log.Info (Log.LOG_BRAIN, "{0} persistent requests processed", numProcessed);
+            }
+            return numProcessed;
         }
 
         private void ProcessUIEvent (NcBrainUIEvent brainEvent)

--- a/NachoClient.Android/NachoCore/Utils/NcQueue.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcQueue.cs
@@ -173,6 +173,18 @@ namespace NachoCore.Utils
         }
 
         /// <summary>
+        /// Enqueues an object if a similar object matched with the match function is not already at the tail of the queue.
+        /// </summary>
+        public void EnqueueIfNotTail (T obj, QueueItemMatchFunction match)
+        {
+            lock (Lock) {
+                if (_Queue.Count == 0 || !match (Tail ())) {
+                    Enqueue (obj);
+                }
+            }
+        }
+
+        /// <summary>
         // Dequeues an object from the queue if it matches based on the match function
         /// </summary>
         /// <returns>The object</returns>
@@ -202,6 +214,20 @@ namespace NachoCore.Utils
             lock (Lock) {
                 if (_Queue.Count > 0) {
                     obj = _Queue [0];
+                }
+            }
+            return obj;
+        }
+
+        /// <summary>
+        /// Return the tail of the queue without affecting the queue itself.
+        /// </summary>
+        public T Tail ()
+        {
+            T obj = default(T);
+            lock (Lock) {
+                if (_Queue.Count > 0) {
+                    obj = _Queue [_Queue.Count - 1];
                 }
             }
             return obj;


### PR DESCRIPTION
Tweak the scheduling of brain tasks so that email messages are indexed
shortly after they are synched.  (Unless they are in the junk folder
or the trash, in which case they will be indexed, or not, a little bit
later.)  This initial indexing will be headers only; the message will
be reindexed if its body is downloaded later.
