### PR TITLE
Avoid crash when indexing non-MIME e-mail messages

### DIFF
--- a/NachoClient.Android/NachoCore/Brain/NcTokenizer.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcTokenizer.cs
@@ -225,6 +225,7 @@ namespace NachoCore.Brain
 
         protected override void ExtractContent ()
         {
+            _Content = new System.Text.StringBuilder ();
             ExtractContentFromPlainText (Text);
         }
     }
@@ -241,6 +242,7 @@ namespace NachoCore.Brain
 
         protected override void ExtractContent ()
         {
+            _Content = new System.Text.StringBuilder ();
             ExtractContentFromHtml (Html);
         }
     }


### PR DESCRIPTION
I was not able to reproduce the crash in the issue, so I can't
guarantee that this fixes anything.  But this is a bug that needs
fixing.

Fix nachocove/qa#1747
