### PR TITLE
A couple of indexing fixes

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapSyncCommand.cs
@@ -389,7 +389,9 @@ namespace NachoCore.IMAP
 
             if (!emailMessage.IsIncomplete) {
                 // Extra work that needs to be done, but doesn't need to be in the same database transaction.
-                NcBrain.SharedInstance.ProcessOneNewEmail (emailMessage);
+                if (justCreated) {
+                    NcBrain.SharedInstance.ProcessOneNewEmail (emailMessage);
+                }
                 if (emailMessage.ScoreStates.IsRead != emailMessage.IsRead) {
                     // Another client has remotely read / unread this email.
                     // TODO - Should be the average of now and last sync time. But last sync time does not exist yet

--- a/NachoClient.Android/NachoCore/Brain/NcBrainEventHandler.cs
+++ b/NachoClient.Android/NachoCore/Brain/NcBrainEventHandler.cs
@@ -100,10 +100,6 @@ namespace NachoCore.Brain
             case NcBrainEventType.PERSISTENT_QUEUE:
                 try {
                     ProcessPersistedRequests ();
-                    if (IsInterrupted ()) {
-                        // Not all of the persisted requests were processed.  Make sure they get processed later.
-                        EnqueueIfNotAtTail (new NcBrainPersistentQueueEvent ());
-                    }
                 } finally {
                     OpenedIndexes.Cleanup ();
                 }
@@ -169,6 +165,7 @@ namespace NachoCore.Brain
                     break;
                 }
                 var brainEvent = dbEvent.BrainEvent ();
+                Log.Info (Log.LOG_BRAIN, "Process persisted brain event type = {0}", Enum.GetName (typeof(NcBrainEventType), brainEvent.Type));
                 switch (brainEvent.Type) {
                 case NcBrainEventType.INDEX_MESSAGE:
                     IndexEmailMessage (McEmailMessage.QueryById<McEmailMessage> ((int)((NcBrainIndexMessageEvent)brainEvent).EmailMessageId));


### PR DESCRIPTION
When the processing of the brain's persistent queue is interrupted,
which happens when the back end is supposed to be abated, don't add
another persistent queue event to the brain's queue.  This will result
in a continuous loop of attempting to process persistent queue events
but never making any progress because of the abatement.  That will use
up all the CPU exactly when the brain is supposed to not use any CPU.
There isn't a good way for the brain to block until the abatement is
over, so any unprocessed persistent queue events will just wait until
the next periodic glean event.

Don't reindex e-mail messages when the IMAP server has merely changed
some flags on the message.
