### PR TITLE
add more checks and don't use wrong variable

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/Commands/ImapCommand.cs
@@ -153,6 +153,10 @@ namespace NachoCore.IMAP
                 Log.Info (Log.LOG_IMAP, "ImapCommandException {0}", ex.Message);
                 action = new Tuple<ResolveAction, NcResult.WhyEnum> (ResolveAction.DeferAll, NcResult.WhyEnum.Unknown);
                 evt = Event.Create ((uint)ImapProtoControl.ImapEvt.E.Wait, "IMAPCOMMWAIT", 60);
+            } catch (FolderNotFoundException ex) {
+                Log.Info (Log.LOG_IMAP, "FolderNotFoundException {0}", ex.Message);
+                action = new Tuple<ResolveAction, NcResult.WhyEnum> (ResolveAction.DeferAll, NcResult.WhyEnum.ConflictWithServer);
+                evt = Event.Create ((uint)ImapProtoControl.ImapEvt.E.ReFSync, "IMAPFOLDRESYNC");
             } catch (IOException ex) {
                 Log.Info (Log.LOG_IMAP, "IOException: {0}", ex.ToString ());
                 action = new Tuple<ResolveAction, NcResult.WhyEnum> (ResolveAction.DeferAll, NcResult.WhyEnum.Unknown);


### PR DESCRIPTION
resolves nachocove/qa#1767
- Document the function some more
- Add NcAssert checks for cases that really can’t be null.
- Do a better check initially to find the right folder if it exists, rather than the heuristics. Do heuristics only if the folder was not found.
- Fix use of wrong variable in ‘existing’ case, which now should never be seen (hence it’s not a Log.Error).
- catch FolderNotFoundException and do a folder-resync

I wasn't able to reproduce this, but code-inspection showed the use of a null variable in the 'existing' case (we printed the values from folder, which is null, instead of the 'existing' we just found). I'm not entirely sure how we can even get here, except that we initially look up the folder by DisplayName (imap.Name, which is the last part of imap.FullName in most cases, i.e. the folder with FullName=='[Gmail]/Drafts' has a Name of 'Drafts'), or by distinguished type. If we don't find that, we then look up the folder based on the serverid (imap.FullName) in the existing check.

I'm not entirely sure how we get to the 'existing' check, except that we somehow didn't manage to find the folder with the two types of searches initially, when it's really in our DB. Gmail doesn't allow you to rename the '[Gmail]/*' folder, and I don't think you can 'reassign' the distinguished type in the Gmail server, either. Nevertheless, it appears we're getting there (unless the null reference is somewhere else entirely, for which I hope I covered some cases with NcAsserts).
