### PR TITLE
Fix "Too many open files" crashes on iOS due to leaking DB connections

### DIFF
--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -517,7 +517,11 @@ namespace NachoCore.Model
 
         public void Start ()
         {
-            DbConnGCTimer = new NcTimer ("NcModel.DbConnGCTimer", DbConnGCTimerCallback, null, 15 * 1000, Timeout.Infinite);
+            int initialGcTimerLength = 15 * 1000;
+            if (NcApplication.ExecutionContextEnum.QuickSync == NcApplication.Instance.PlatformIndication) {
+                initialGcTimerLength = 1 * 1000;
+            }
+            DbConnGCTimer = new NcTimer ("NcModel.DbConnGCTimer", DbConnGCTimerCallback, null, initialGcTimerLength, Timeout.Infinite);
             DbConnGCTimer.Stfu = true;
 
             CheckPointTimer = new NcTimer ("NcModel.CheckPointTimer", state => {

--- a/NachoClient.Android/NachoCore/Utils/NcTask.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcTask.cs
@@ -119,7 +119,8 @@ namespace NachoCore.Utils
                 return null; // an entry exists
             }
 
-            if (LoginRunningTasks.Contains (name)) {
+            bool longRunning = LoginRunningTasks.Contains (name);
+            if (longRunning) {
                 Log.Info (Log.LOG_SYS, "NcTask {0} will be long running", name);
                 option = TaskCreationOptions.LongRunning;
             }
@@ -156,9 +157,11 @@ namespace NachoCore.Utils
                     Log.Info (Log.LOG_SYS, "NcTask {0} cancelled.", taskName);
                 } finally {
                     var count = NcModel.Instance.NumberDbConnections;
-                    if (15 < count) {
+                    if (15 < count || longRunning) {
                         NcModel.Instance.Db = null;
-                        Log.Info (Log.LOG_SYS, "NcTask closing DB, connections: {0}", count);
+                        if (15 < count) {
+                            Log.Info (Log.LOG_SYS, "NcTask closing DB, connections: {0}", count);
+                        }
                     }
                 }
                 if (!stfu) {

--- a/NachoClient.Android/NachoCore/Utils/NcTimer.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcTimer.cs
@@ -53,8 +53,6 @@ namespace NachoCore.Utils
             InstanceLockObj = new object ();
             callback = c;
 
-            Log.Info (Log.LOG_TIMER, "NcTimer {0}/{1} created", Id, Who);
-
             return state => {
                 lock (InstanceLockObj) {
                     if (DateTime.MinValue < DueTime) {
@@ -106,6 +104,11 @@ namespace NachoCore.Utils
                         }
                         callback (state);
                         HasFired = true;
+                        int dbCount = NachoCore.Model.NcModel.Instance.NumberDbConnections;
+                        if (15 < dbCount) {
+                            NachoCore.Model.NcModel.Instance.Db = null;
+                            Log.Info(Log.LOG_SYS, "NcTimer {0}/{1} closing DB, connections: {2}", Id, Who, dbCount);
+                        }
                     }
                 }
             };

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -872,6 +872,7 @@ namespace NachoClient.iOS
             if (FinalShutdownHasHappened) {
                 ReverseFinalShutdown ();
                 BackEnd.Instance.Start ();
+                NcApplicationMonitor.Instance.Start (1, 60);
             }
             NcApplication.Instance.StatusIndEvent += FetchStatusHandler;
             // iOS only allows a limited amount of time to fetch data in the background.


### PR DESCRIPTION
NcTimer does not have the code that NcTask does for cleaning up
database connections when the task completes.  Any DB connections used
in a timer callback would only be cleaned up in the DB garbage
collector, which is scheduled to run every 15 seconds.  An iOS quick
sync often takes less than 15 seconds, which means the garbage
collector won't run.  If the user leaves the app in the background for
a long time, there could be a large number of quick syncs that create
a few new DB connections that are never cleaned up.  This would
eventually lead to the app's process running out of file descriptors.

Several changes were made to avoid this problem:

Change NcTimer to close the DB connection when the callback is done if
there are lots of open DB connections.  (This is what NcTask already
does.)  This change should stop DB connections from accumulating if
the DB garbage collector never runs.

Change NcTask to always close the DB connection when a long running
task completes.  The thread for a long running task is unlikely to be
reused in the near future, so there is no advantage to keeping the DB
connection open.  This change should help keep the number of open
connections lower.

When the app is in quick sync mode, set the initial delay for the DB
connection garbage collector timer to 1 second instead of 15 seconds.
(The repeating period is still 15 seconds.  Only the first run is sped
up.)  This change will run the garbage collector at least once per
quick sync, so stale connections should never accumulate over time.

There are also two other changes not directly related to the
too-many-open-files fix:

When the app is in quick sync mode, start the process monitor with an
initial delay of 1 second, so that a monitor report is produced during
each quick sync.

Get rid of the "NcTimer created" log message.  This message was always
followed by an "NcTimer set" message, so the "created" message
contained no useful information.
