### PR TITLE
Compute unread count for unified inbox in the switcher dropdown.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
@@ -878,6 +878,20 @@ namespace NachoCore.Utils
             }
         }
 
+        public static void GetUnreadMessageCount (McAccount account, out int unreadMessageCount)
+        {
+            unreadMessageCount = 0;
+
+            foreach (var accountId in McAccount.GetAllConfiguredNonDeviceAccountIds ()) {
+                if (account.ContainsAccount (accountId)) {
+                    var inboxFolder = NcEmailManager.InboxFolder (accountId);
+                    if (null != inboxFolder) {
+                        unreadMessageCount += McEmailMessage.CountOfUnreadMessageItems (inboxFolder.AccountId, inboxFolder.Id);
+                    }
+                }
+            }
+        }
+
 
         /// <summary>
         /// Compress the message preview so it is more tightly packed with useful information.

--- a/NachoClient.iOS/NachoUI.iOS/Support/AccountInfoView.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/AccountInfoView.cs
@@ -100,7 +100,7 @@ namespace NachoClient.iOS
                 accountEmailAddress.Text = account.EmailAddr;
 
                 if (showUnreadCount) {
-                    UpdateUnreadMessageCount (account.Id);
+                    UpdateUnreadMessageCount (account);
                 } else if (LoginHelpers.ShouldAlertUser (account.Id)) {
                     HighlightError ();
                 } else {
@@ -109,7 +109,7 @@ namespace NachoClient.iOS
             }
         }
 
-        void UpdateUnreadMessageCount (int accountId)
+        void UpdateUnreadMessageCount (McAccount account)
         {
             unreadCountLabel.Hidden = false;
             unreadCountLabel.Layer.CornerRadius = 4;
@@ -117,11 +117,8 @@ namespace NachoClient.iOS
             SetUnreadCountWidth (UNREAD_COUNT_HEIGHT);
 
             NcTask.Run (() => {
-                var inboxFolder = NcEmailManager.InboxFolder (accountId);
-                var unreadMessageCount = 0;
-                if (null != inboxFolder) {
-                    unreadMessageCount = McEmailMessage.CountOfUnreadMessageItems (inboxFolder.AccountId, inboxFolder.Id);
-                }
+                int unreadMessageCount;
+                EmailHelper.GetUnreadMessageCount(account, out unreadMessageCount);
                 InvokeOnUIThread.Instance.Invoke (() => {
                     if (100000 > unreadMessageCount) {
                         unreadCountLabel.Text = String.Format("{0:N0}", unreadMessageCount);


### PR DESCRIPTION
Unified accounts do not have a proper inbox folder so to get the unread count, we add up the counts from all accounts.
