### PR TITLE
ignore hints if a pending for it exists or is enqueued

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/NcProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/NcProtoControl.cs
@@ -770,6 +770,9 @@ namespace NachoCore
             NcResult.SubKindEnum subKind;
             McEmailMessage emailMessage;
             McFolder folder;
+            // make sure to delete any hint we may have.
+            Log.Info (Log.LOG_BACKEND, "Removing hint due to addition of pending");
+            BackEnd.Instance.BodyFetchHints.RemoveHint (AccountId, emailMessageId);
             NcModel.Instance.RunInTransaction (() => {
                 if (!GetItemAndFolder<McEmailMessage> (emailMessageId, out emailMessage, -1, out folder, out subKind)) {
                     result = NcResult.Error (subKind);


### PR DESCRIPTION
This covers the cases where:
- a Hint is added, and then the user taps on a message. The hint will
  be removed when the pending is added.
- a hint is added after a pending is added. We don’t want to add checks
  to the HintAdd(), so we check for the presence of the pending during
  strategizing.

Not covered in this fix: A hint is added, and processing of it has
started when the pending is enqueued. This will require some more
infrastructure to keep track of existing commands or fetchKits, so we
can tell a download is taking place for a particular body ALREADY.

This fix should hopefully cover the bulk of the cases.

first part of fix for nachocove/qa#1794
