### PR TITLE
Remove the settings button from the switch account dropdown.

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/SwitchAccountFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/SwitchAccountFragment.cs
@@ -254,6 +254,12 @@ namespace NachoClient.AndroidClient
                 return;
             case HEADER_TYPE:
                 account = NcApplication.Instance.Account;
+                var settingsButton = holder.ItemView.FindViewById (Resource.Id.account_settings);
+                if (McAccount.GetUnifiedAccount ().Id == account.Id) {
+                    settingsButton.Visibility = ViewStates.Gone;
+                } else {
+                    settingsButton.Visibility = ViewStates.Visible;
+                }
                 break;
             case ROW_TYPE:
                 int accountIndex = (DisplayMode.AccountSwitcher == displayMode ? position - 1 : position);

--- a/NachoClient.Android/Resources/layout/account_header.axml
+++ b/NachoClient.Android/Resources/layout/account_header.axml
@@ -8,31 +8,29 @@
         android:background="@android:color/white"
         android:orientation="horizontal"
         android:layout_width="fill_parent"
-        android:padding="3dp"
-        android:layout_height="120dp">
+        android:layout_height="wrap_content">
         <ImageView
             android:id="@+id/account_icon"
             android:src="@drawable/avatar_hotmail"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:layout_marginBottom="4dp"
+            android:layout_width="75dp"
+            android:layout_height="75dp"
+            android:layout_marginRight="10dp"
             android:scaleType="fitXY"
-            android:layout_gravity="center|top"
+            android:layout_gravity="center_vertical"
             android:background="@android:color/white" />
         <LinearLayout
             android:orientation="vertical"
-            android:gravity="center_vertical"
+            android:layout_gravity="center_vertical"
             android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
+            android:layout_height="wrap_content">
             <TextView
                 android:id="@+id/account_name"
                 android:text="@string/demo_account"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:gravity="left"
-                android:textSize="14dp"
-                android:textStyle="normal"
+                android:paddingBottom="2dp"
+                android:textSize="17dp"
+                android:textStyle="bold"
                 android:textColor="@android:color/black"
                 android:background="@android:color/white" />
             <TextView
@@ -40,30 +38,31 @@
                 android:text="@string/demo_email"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:gravity="left"
+                android:paddingTop="2dp"
                 android:textSize="14dp"
                 android:textStyle="normal"
                 android:textColor="@android:color/black"
                 android:background="@android:color/white" />
-            <Button
-                android:id="@+id/account_settings"
-                android:layout_height="wrap_content"
-                android:layout_width="wrap_content"
-                android:paddingLeft="20dp"
-                android:paddingRight="20dp"
-                android:text="@string/account_settings"
-                android:textSize="17dp"
-                android:textStyle="bold"
-                android:textColor="@android:color/white"
-                android:background="@color/NachoSubmitButton"
-                android:minHeight="40dp"
-                android:maxHeight="40dp"
-                android:layout_marginTop="20dp" />
         </LinearLayout>
     </LinearLayout>
+    <Button
+        android:id="@+id/account_settings"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
+        android:layout_marginLeft="85dp"
+        android:text="@string/account_settings"
+        android:textSize="17dp"
+        android:textStyle="bold"
+        android:textColor="@android:color/white"
+        android:background="@color/NachoSubmitButton"
+        android:minHeight="40dp"
+        android:maxHeight="40dp" />
     <View
         android:layout_width="fill_parent"
         android:layout_height="2dp"
+        android:layout_marginTop="20dp"
         android:background="@color/NachoLightGray" />
     <LinearLayout
         android:id="@+id/go_to_inbox"

--- a/NachoClient.Android/Resources/layout/account_row.axml
+++ b/NachoClient.Android/Resources/layout/account_row.axml
@@ -21,8 +21,8 @@
             <ImageView
                 android:id="@+id/account_icon"
                 android:src="@drawable/avatar_hotmail"
-                android:layout_width="36dp"
-                android:layout_height="36dp"
+                android:layout_width="75dp"
+                android:layout_height="75dp"
                 android:layout_marginTop="4dp"
                 android:layout_marginBottom="4dp"
                 android:scaleType="fitXY"
@@ -41,8 +41,8 @@
                     android:layout_height="wrap_content"
                     android:gravity="left"
                     android:padding="3dp"
-                    android:textSize="14dp"
-                    android:textStyle="normal"
+                    android:textSize="17dp"
+                    android:textStyle="bold"
                     android:textColor="@android:color/black" />
                 <TextView
                     android:id="@+id/account_email"

--- a/NachoClient.iOS/NachoUI.iOS/SwitchAccountViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/SwitchAccountViewController.cs
@@ -183,18 +183,23 @@ namespace NachoClient.iOS
             accountEmailAddress.TextColor = A.Color_NachoBlack;
             accountInfoView.AddSubview (accountEmailAddress);
 
-            var settingsButton = Util.BlueButton ("Account Settings", 0);
-            settingsButton.Frame = new CGRect (75, 70, 0, LINE_HEIGHT);
-            settingsButton.SizeToFit ();
-            ViewFramer.Create (settingsButton).AdjustWidth (A.Card_Horizontal_Indent);
-            settingsButton.TouchUpInside += SettingsButtonTouchUpInside;
-            accountInfoView.AddSubview (settingsButton);
+            nfloat yOffset = 70;
 
-            var unreadMessagesViewFrame = new CGRect (0, 120, accountInfoView.Frame.Width, 40);
+            if (McAccount.GetUnifiedAccount ().Id != NcApplication.Instance.Account.Id) {
+                var settingsButton = Util.BlueButton ("Account Settings", 0);
+                settingsButton.Frame = new CGRect (75, 70, 0, LINE_HEIGHT);
+                settingsButton.SizeToFit ();
+                ViewFramer.Create (settingsButton).AdjustWidth (A.Card_Horizontal_Indent);
+                settingsButton.TouchUpInside += SettingsButtonTouchUpInside;
+                accountInfoView.AddSubview (settingsButton);
+                yOffset += 50;
+            }
+
+            var unreadMessagesViewFrame = new CGRect (0, yOffset, accountInfoView.Frame.Width, 40);
             var unreadMessagesView = new UnreadMessagesView (unreadMessagesViewFrame, InboxClicked, DeadlinesClicked, DeferredClicked);
             accountInfoView.AddSubview (unreadMessagesView);
 
-            var yOffset = unreadMessagesView.Frame.Bottom;
+            yOffset = unreadMessagesView.Frame.Bottom;
 
             ViewFramer.Create (headerView).Height (yOffset);
             ViewFramer.Create (accountInfoView).Height (yOffset);


### PR DESCRIPTION
Remove the settings button when the switch account dropdown is showing the unified account in the header.
