### PR TITLE
fix bad nav pop animation on iOS

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/AccountSyncingViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/AccountSyncingViewController.cs
@@ -108,7 +108,7 @@ namespace NachoClient.iOS
 
         public override void ViewWillDisappear (bool animated)
         {
-            base.ViewDidDisappear (animated);
+            base.ViewWillDisappear (animated);
             IsVisible = false;
             activityIndicatorView.StopAnimating ();
         }

--- a/NachoClient.iOS/NachoUI.iOS/NachoTabBarController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoTabBarController.cs
@@ -102,6 +102,7 @@ namespace NachoClient.iOS
 
         public override void ViewDidAppear (bool animated)
         {
+            base.ViewDidAppear (animated);
             UpdateNotificationBadge ();
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/StartupMigrationViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/StartupMigrationViewController.cs
@@ -79,6 +79,7 @@ namespace NachoClient.iOS
         public override void ViewDidDisappear (bool animated)
         {
             StopListeningForApplicationStatus ();
+            base.ViewDidDisappear (animated);
         }
 
         public void StatusIndicatorCallback (object sender, EventArgs e)


### PR DESCRIPTION
The main problem was caused by the missing base.ViewDidAppear
call in NachoTabBarController.  However, I noticed a couple other
mismatches and fixed those too.
