### PR TITLE
App shouldn't grind to a halt when searching contacts

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/ContactsSearch.cs
+++ b/NachoClient.Android/NachoCore/Utils/ContactsSearch.cs
@@ -8,6 +8,7 @@ using NachoCore.Brain;
 using NachoCore.Index;
 using NachoCore.Model;
 using NachoPlatform;
+using System.Collections.Concurrent;
 
 namespace NachoCore.Utils
 {
@@ -33,8 +34,7 @@ namespace NachoCore.Utils
         bool serverResultsPending = false;
 
         List<McAccount> accounts;
-        Dictionary<int, string> accountSearchTokens;
-        HashSet<string> searchedStrings;
+        IDictionary<int, string> accountSearchTokens;
 
         public void SearchFor (string searchString)
         {
@@ -87,18 +87,11 @@ namespace NachoCore.Utils
                         if (serverOnly) {
                             IncorporateServerResults (searchString);
                         } else {
-                            // Start the server-based search.  Since server results are cached, there is little point in repeating
-                            // a search that has already happened in this session.  That is what searchedStrings.Add() checks for.
-                            if (!string.IsNullOrEmpty (searchString) && 0 < accounts.Count && searchedStrings.Add (searchString)) {
-                                bool firstSearch = (null == accountSearchTokens);
-                                if (firstSearch) {
-                                    accountSearchTokens = new Dictionary<int, string> (accounts.Count);
-                                }
+                            // Start the server-based search for any account where a search is not already in progress.
+                            if (!string.IsNullOrEmpty (searchString) && 2 < searchString.Length && 0 < accounts.Count) {
                                 foreach (var account in accounts) {
-                                    if (firstSearch) {
+                                    if (!accountSearchTokens.ContainsKey (account.Id)) {
                                         accountSearchTokens [account.Id] = BackEnd.Instance.StartSearchContactsReq (account.Id, searchString, null).GetValue<string> ();
-                                    } else {
-                                        BackEnd.Instance.SearchContactsReq (account.Id, searchString, null, accountSearchTokens [account.Id]);
                                     }
                                 }
                             }
@@ -126,7 +119,7 @@ namespace NachoCore.Utils
 
             // Initializing accounts requires a database query, so delay that until there is a background thread.
             accounts = null;
-            searchedStrings = new HashSet<string> ();
+            accountSearchTokens = new ConcurrentDictionary<int, string> ();
         }
 
         protected void UpdateUi (string searchString, List<McContactEmailAddressAttribute> results)
@@ -160,12 +153,7 @@ namespace NachoCore.Utils
                     // If there is a current search, stop it from updating the UI when it completes.
                     updateUi = (string searchString, List<McContactEmailAddressAttribute> results) => { };
                 }
-                if (null != accountSearchTokens) {
-                    // Cancel any server searches that might be in progress.
-                    foreach (var accountTokenPair in accountSearchTokens) {
-                        McPending.Cancel (accountTokenPair.Key, accountTokenPair.Value);
-                    }
-                }
+                accountSearchTokens.Clear ();
             }
         }
 
@@ -173,10 +161,11 @@ namespace NachoCore.Utils
         {
             var s = (StatusIndEventArgs)e;
             if (NcResult.SubKindEnum.Info_ContactSearchCommandSucceeded == s.Status.SubKind &&
-                null != s.Account && null != s.Tokens && null != accountSearchTokens &&
+                null != s.Account && null != s.Tokens &&
                 accountSearchTokens.Keys.Contains (s.Account.Id) &&
                 s.Tokens.Contains (accountSearchTokens [s.Account.Id]))
             {
+                accountSearchTokens.Remove (s.Account.Id);
                 bool startSearch;
                 lock (lockObject) {
                     startSearch = (null != lastSearch) && !searchInProgress;


### PR DESCRIPTION
The app was too aggressive in its Exchange server searches when
searching for contacts.  This could result in the app being slow or
unresponsive while searching, especially if the user had several
Exchange accounts.

Change the contact search code to issue far fewer server-based
searches.  There is now at most one outstanding search per Exchange
server.

This will result in a slight decrease in the quality of the search
results, since the app will have less information from the server.
But since GAL search results are cached indefinitely, I think the drop
in search results quality will be more than outweighed by the increase
in app responsiveness.

Fix nachocove/qa#1801
