### PR TITLE
Hopefully avoid DB connection GC race condition

### DIFF
--- a/NachoClient.Android/NachoCore/Model/NcModel.cs
+++ b/NachoClient.Android/NachoCore/Model/NcModel.cs
@@ -17,7 +17,7 @@ namespace NachoCore.Model
 {
     public class NcSQLiteConnection : SQLiteConnection
     {
-        private const int KGCSeconds = 60;
+        public const int KGCSeconds = 60;
         private object LockObj;
         private bool DidDispose;
 
@@ -73,11 +73,10 @@ namespace NachoCore.Model
             }
         }
 
-        public void EliminateIfStale (Action action)
+        public void EliminateIfStale (DateTime cutoff, Action action)
         {
             lock (LockObj) {
-                var wayBack = DateTime.UtcNow.AddSeconds (-GCSeconds);
-                if (LastAccess < wayBack) {
+                if (LastAccess < cutoff) {
                     action ();
                     Eliminate ();
                 }
@@ -479,6 +478,7 @@ namespace NachoCore.Model
 
         private NcTimer CheckPointTimer;
         private NcTimer DbConnGCTimer;
+        private DateTime lastDbConnGC = default(DateTime);
 
         private class CheckpointResult
         {
@@ -492,13 +492,20 @@ namespace NachoCore.Model
 
         private void DbConnGCTimerCallback (Object state)
         {
-            Log.Info (Log.LOG_DB, "DbConnGCTimer: Cleaning up stale DB connections");
+            DateTime staleCutoff;
+            if (default(DateTime) == lastDbConnGC) {
+                staleCutoff = DateTime.UtcNow - TimeSpan.FromSeconds (2 * NcSQLiteConnection.KGCSeconds);
+            } else {
+                staleCutoff = lastDbConnGC - TimeSpan.FromSeconds (NcSQLiteConnection.KGCSeconds);
+            }
+            lastDbConnGC = DateTime.UtcNow;
+            Log.Info (Log.LOG_DB, "DbConnGCTimer: Cleaning up stale DB connections older than {0:n0} seconds", (DateTime.UtcNow - staleCutoff).TotalSeconds);
             foreach (var kvp in DbConns) {
                 NcSQLiteConnection dummy;
                 if (kvp.Key == NcApplication.Instance.UiThreadId) {
                     continue;
                 }
-                kvp.Value.EliminateIfStale (() => {
+                kvp.Value.EliminateIfStale (staleCutoff, () => {
                     if (!DbConns.TryRemove (kvp.Key, out dummy)) {
                         Log.Error (Log.LOG_DB, "DbConnGCTimer: unable to remove DbConn for thread {0}", kvp.Key);
                     } else {


### PR DESCRIPTION
When the app's process resumes after having been suspended for a
while, all existing database connections will appear stale until the
thread using that connection gets a chance to run again.  The existing
code could close an apparently stale connection just as its thread was
about to use it again, resulting in an SQLite exception and a crash.

To avoid this race condition, change the definition of "stale" in the
DB connection garbage collector.  To be stale, the connection needs to
have not been used since sometime before the previous time that the
garbage collector was run.  With this change, connections will not be
considered stale just because the process was shut down for a while.

Fix nachocove/qa#1812
