### PR TITLE
Fix the More > Mail > Deadlines link on Android

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/FoldersActivity.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/FoldersActivity.cs
@@ -59,6 +59,9 @@ namespace NachoClient.AndroidClient
             case McFolder.DEFERRED_FAKE_FOLDER_ID:
                 intent = DeferredActivity.ShowDeferredFolderIntent (this, folder);
                 break;
+            case McFolder.DEADLINE_FAKE_FOLDER_ID:
+                intent = DeadlineActivity.ShowDeadlineFolderIntent (this, folder);
+                break;
             default:
                 intent = MessageFolderActivity.ShowFolderIntent (this, folder);
                 folder.UpdateSet_LastAccessed (DateTime.UtcNow);


### PR DESCRIPTION
The More > Mail > Deadlines link was resulting in a view that said
"Deadlines", but the underneath the covers it was doing so the wrong
way, so no messages would ever be displayed.
