### PR TITLE
Change NcTimer locks so Dispose() won't block for very long

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcTimer.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcTimer.cs
@@ -29,9 +29,11 @@ namespace NachoCore.Utils
 
         private static int nextId = 0;
         private static List<NcTimer> ActiveTimers = new List<NcTimer> ();
-        private static Object StaticLockObj = new Object ();
-        // Used to prevent Dispose in the middle of a callback.
-        private Object InstanceLockObj;
+        private static object StaticLockObj = new object ();
+
+        private object InstanceLockObj = new object ();
+        private object CallbackLockObj = new object ();
+
         private bool HasFired = false;
 
         public static CurrentTimeFunction GetCurrentTime = DefaultGetCurrentTime;
@@ -50,64 +52,70 @@ namespace NachoCore.Utils
                 Id = ++nextId;
                 ActiveTimers.Add (this);
             }
-            InstanceLockObj = new object ();
             callback = c;
 
             return state => {
-                lock (InstanceLockObj) {
-                    if (DateTime.MinValue < DueTime) {
-                        DateTime now = GetCurrentTime ();
-                        if (DueTime > now) {
-                            // We are not done with the current due time. See how much time to go
-                            Int64 due = (long)(DueTime - GetCurrentTime ()).TotalMilliseconds;
-                            Int64 period = Period;
-                            if (MAX_DURATION < due) {
-                                // The remaining time is still too large. Fire another
-                                // one-short MAX_DURATION timer.
-                                due = MAX_DURATION;
-                                period = Timeout.Infinite;
-                            }
-                            if (MAX_DURATION < period) {
-                                period = Timeout.Infinite;
-                            }
 
-                            Timer.Dispose ();
-                            Log.Debug (Log.LOG_TIMER, "callback set: due={0}, period={1}", due, period);
-                            Timer = (ITimer)Activator.CreateInstance (TimerClass, WrappedCallback,
-                                Object_, due, period);
-                            return; // no callback yet
-                        } else if (0 < Period) {
-                            // We are past due time. See if the period is too large
-                            Int64 due = Period;
-                            Int64 period = Period;
-                            if (MAX_DURATION < Period) {
-                                DueTime = now + new TimeSpan (Period * MSEC2TICKS);
-                                due = MAX_DURATION;
-                                period = Timeout.Infinite;
-                            } else {
-                                // don't need these anymore
-                                DueTime = DateTime.MinValue;
-                                Period = 0;
+                lock (CallbackLockObj) {
+
+                    TimerCallback localCallback;
+                    lock (InstanceLockObj) {
+
+                        if (DateTime.MinValue < DueTime) {
+                            DateTime now = GetCurrentTime ();
+                            if (DueTime > now) {
+                                // We are not done with the current due time. See how much time to go
+                                Int64 due = (long)(DueTime - GetCurrentTime ()).TotalMilliseconds;
+                                Int64 period = Period;
+                                if (MAX_DURATION < due) {
+                                    // The remaining time is still too large. Fire another
+                                    // one-short MAX_DURATION timer.
+                                    due = MAX_DURATION;
+                                    period = Timeout.Infinite;
+                                }
+                                if (MAX_DURATION < period) {
+                                    period = Timeout.Infinite;
+                                }
+
+                                Timer.Dispose ();
+                                Log.Debug (Log.LOG_TIMER, "callback set: due={0}, period={1}", due, period);
+                                Timer = (ITimer)Activator.CreateInstance (TimerClass, WrappedCallback,
+                                    Object_, due, period);
+                                return; // no callback yet
+                            } else if (0 < Period) {
+                                // We are past due time. See if the period is too large
+                                Int64 due = Period;
+                                Int64 period = Period;
+                                if (MAX_DURATION < Period) {
+                                    DueTime = now + new TimeSpan (Period * MSEC2TICKS);
+                                    due = MAX_DURATION;
+                                    period = Timeout.Infinite;
+                                } else {
+                                    // don't need these anymore
+                                    DueTime = DateTime.MinValue;
+                                    Period = 0;
+                                }
+                                Timer.Dispose ();
+                                Log.Debug (Log.LOG_TIMER, "callback set2: due={0}, period={1}", due, period);
+                                Timer = (ITimer)Activator.CreateInstance (TimerClass, WrappedCallback, Object_, due, period);
                             }
-                            Timer.Dispose ();
-                            Log.Debug (Log.LOG_TIMER, "callback set2: due={0}, period={1}", due, period);
-                            Timer = 
-                                (ITimer)Activator.CreateInstance (TimerClass, WrappedCallback, 
-                                Object_, due, period);
                         }
+                        // Make a local copy of this.callback before releasing the lock.
+                        localCallback = callback;
                     }
-                    if (null == callback) {
+
+                    if (null == localCallback) {
                         Log.Info (Log.LOG_TIMER, "NcTimer {0}/{1} fired after Dispose.", Id, Who);
                     } else {
                         if (!Stfu) {
                             Log.Info (Log.LOG_TIMER, "NcTimer {0}/{1} fired.", Id, Who);
                         }
-                        callback (state);
+                        localCallback (state);
                         HasFired = true;
                         int dbCount = NachoCore.Model.NcModel.Instance.NumberDbConnections;
                         if (15 < dbCount) {
                             NachoCore.Model.NcModel.Instance.Db = null;
-                            Log.Info(Log.LOG_SYS, "NcTimer {0}/{1} closing DB, connections: {2}", Id, Who, dbCount);
+                            Log.Info (Log.LOG_SYS, "NcTimer {0}/{1} closing DB, connections: {2}", Id, Who, dbCount);
                         }
                     }
                 }
@@ -206,13 +214,17 @@ namespace NachoCore.Utils
 
         public bool IsExpired ()
         {
-            return HasFired;
+            lock (CallbackLockObj) {
+                return HasFired;
+            }
         }
 
         public bool DisposeAndCheckHasFired ()
         {
             Dispose ();
-            return HasFired;
+            lock (CallbackLockObj) {
+                return HasFired;
+            }
         }
 
         public void Dispose ()


### PR DESCRIPTION
NcTimer objects had one lock object, which was held while the timer
callback was running.  Because time callbacks can be long running,
this could result in NcTimer.Dispose() blocking for an extended period
of time waiting to acquire the lock.  Dispose() is sometimes called on
the main thread during shutdown, and therefore it must always return
quickly.

Change NcTimer to have two lock objects.  One of the locks is used
when creating, scheduling, and disposing the object.  The other lock
is used when invoking the callback function.  The callback lock will
guarantee that only one callback function is running at a time, but it
will not block the timer from being disposed.

This change should prevent the app's shutdown process from pausing or
hanging.  In some cases, the hang was long enough that the app was
getting killed before it could finish shutting down.
