### PR TITLE
Improved implementation of iOS calendar list view

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
@@ -204,7 +204,9 @@ namespace NachoClient.iOS
 
                 // No actual events are visible.  Section headers only.  Figure out which section
                 // is at the top (which is not trivial), then scroll that section to the top
-                // after reloading the data.
+                // after reloading the data.  (With the zero-height dummy row that has been added
+                // to each day, there should always be visible rows, so this code isn't needed
+                // anymore.  But I am leaving it here just in case.)
                 nint topSection = 0;
                 var visibleArea = calendarTableView.Bounds;
                 nint numSections = calendarSource.NumberOfSections (calendarTableView);


### PR DESCRIPTION
Change the iOS calendar list view to have a zero-height (and therefore
invisible) row as the first entry for every day.  This means that some
rows will always be "visible", even if the calendar is empty.  This
simplifies the code in situations where the app needs to know which
part of the calendar is being shown.  This has no user-visible effect
(except for fixing a very old and minor issue #1291).

Change CalendarTableViewSource.GetHeightForRow() to not do a database
query on every call.  As a result, calendar list entries for items
that have been deleted will be the same height as a regular entry
rather than half the usual height.  Such entries are rare and aren't
visible for very long, so having them be smaller is not important.
This change should result in a faster calendar list view, especially
when scrolling.

Fix #1291
