### PR TITLE
Faster calendar load/refresh times, especially on Android

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/INcEventProvider.cs
+++ b/NachoClient.Android/NachoCore/Adapters/INcEventProvider.cs
@@ -14,8 +14,6 @@ namespace NachoCore
     /// </summary>
     public interface INcEventProvider
     {
-        void Refresh (Action completionAction);
-
         int NumberOfDays ();
 
         int NumberOfItemsForDay (int i);
@@ -26,18 +24,16 @@ namespace NachoCore
 
         McEvent GetEvent (int day, int item);
 
-        McAbstrCalendarRoot GetEventDetail (int day, int item);
-
         int ExtendEventMap (DateTime untilDate);
 
         bool FindEventNearestTo (DateTime date, out int item, out int section);
-
-        void StopTrackingEventChanges ();
 
         void IndexToDayItem (int index, out int day, out int item);
 
         int IndexFromDayItem (int day, int item);
 
         int NumberOfEvents();
+
+        Action UiRefresh { set; }
     }
 }

--- a/NachoClient.Android/NachoCore/Adapters/NcEventManager.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcEventManager.cs
@@ -22,13 +22,20 @@ namespace NachoCore
         private static Dictionary<object, TimeSpan> eventWindows = new Dictionary<object, TimeSpan> ();
         private static TimeSpan maxDuration = TimeSpan.MinValue;
         private static DateTime latestEndDate = DateTime.MinValue;
+        private static DateTime oldestEvent = DateTime.Now.Subtract (TimeSpan.FromDays (30)).Date.ToUniversalTime ();
 
         public static void Initialize ()
         {
             NcApplication.Instance.StatusIndEvent += StatusIndicatorCallback;
 
             // Always keep the events accurate for the next 30 days, so that local notifications will be correct.
-            AddEventWindow (typeof(NcEventManager), new TimeSpan (30, 0, 0, 0));
+            AddEventWindow (typeof(NcEventManager), TimeSpan.FromDays (30));
+        }
+
+        public static DateTime BeginningOfEventsOfInterest {
+            get {
+                return oldestEvent;
+            }
         }
 
         /// <summary>

--- a/NachoClient.Android/NachoCore/Adapters/NcEventsCalendarMap.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NcEventsCalendarMap.cs
@@ -31,25 +31,33 @@ namespace NachoCore
         private DateTime firstDay;
         private DateTime finalDay;
 
-        private bool isActive = false;
+        private Action refreshAction = null;
 
         private object thisLock = new object ();
 
-        private const int startingOffsetInDays = 30;
+        private int refreshCount = 0;
+        private object refreshCountLock = new object ();
 
         /// <summary>
         /// Get the events that should be displayed.  The list of events must be in chronological
         /// order.
         /// </summary>
-        protected abstract List<McEvent> GetEventsWithDuplicates ();
+        protected abstract List<McEvent> GetEventsWithDuplicates (DateTime start, DateTime end);
 
-        protected NcEventsCalendarMapCommon ()
+        protected NcEventsCalendarMapCommon (DateTime end)
         {
             events = new List<McEvent> ();
             days = new int[1] { 0 };
-            firstDay = DateTime.Today.AddDays (-startingOffsetInDays);
+            firstDay = NcEventManager.BeginningOfEventsOfInterest.ToLocalTime ().Date;
             finalDay = firstDay;
-            ExtendEventMap (firstDay.AddDays (6 * startingOffsetInDays));
+            ExtendEventMap (end.ToLocalTime ());
+            NcApplication.Instance.StatusIndEvent += StatusIndicatorCallback;
+        }
+
+        public Action UiRefresh {
+            set {
+                refreshAction = value;
+            }
         }
 
         public int IndexOfDate (DateTime date)
@@ -78,9 +86,7 @@ namespace NachoCore
             // new days will be filled in on a background thread, and an EventSetChanged status will be
             // fired when everything is ready.
 
-            if (isActive) {
-                NcEventManager.AddEventWindow (this, untilDate.ToUniversalTime ());
-            }
+            NcEventManager.AddEventWindow (this, untilDate.ToUniversalTime ());
 
             int numDays = UnsafeIndexOfDate (untilDate);
             int numNewDays = numDays - NumberOfDays ();
@@ -109,6 +115,8 @@ namespace NachoCore
 
             finalDay = untilDate;
             days = newDays;
+
+            Refresh ();
 
             return numNewDays;
         }
@@ -158,16 +166,6 @@ namespace NachoCore
             return events [days [day] + item];
         }
 
-        public McAbstrCalendarRoot GetEventDetail (int day, int item)
-        {
-            var evt = GetEvent (day, item);
-            if (0 == evt.ExceptionId) {
-                return McCalendar.QueryById<McCalendar> (evt.CalendarId);
-            } else {
-                return McException.QueryById<McException> (evt.ExceptionId);
-            }
-        }
-
         public bool FindEventNearestTo (DateTime date, out int item, out int section)
         {
             date = date.ToLocalTime ();
@@ -189,17 +187,15 @@ namespace NachoCore
             return false;
         }
 
-        public void StopTrackingEventChanges ()
+        private void Refresh ()
         {
-            NcEventManager.RemoveEventWindow (this);
-            isActive = false;
-        }
-
-        public void Refresh (Action completionAction)
-        {
-            if (!isActive) {
-                NcEventManager.AddEventWindow (this, finalDay.ToUniversalTime ());
-                isActive = true;
+            lock (refreshCountLock) {
+                if (2 <= refreshCount) {
+                    // There is already one refresh running and one queued up to start.
+                    // There is no point in starting yet another one.
+                    return;
+                }
+                ++refreshCount;
             }
 
             // Most of the work needs to happen on a background thread, because GetEvents() can
@@ -208,89 +204,103 @@ namespace NachoCore
 
                 lock (thisLock) {
 
-                    NcTask.Cts.Token.ThrowIfCancellationRequested ();
+                    try {
+                        // Make a copy of the end date, in case it changes while the events are being processed.
+                        DateTime untilDate = finalDay;
 
-                    // Find all the events that are to be displayed.
-                    var newEvents = GetEvents ();
+                        PauseOrCancel ();
 
-                    NcTask.Cts.Token.ThrowIfCancellationRequested ();
+                        // Find all the events that are to be displayed.
+                        var newEvents = GetEvents (firstDay, untilDate);
 
-                    // The start times for all-day events are stored differently from the start times
-                    // for regular events.  This can result in the database returning the events in a
-                    // slightly different order than what we want.  So the events need to be sorted.
-                    // Hopefully this is fast, since the events should be in almost the correct order.
-                    newEvents.Sort ((McEvent x, McEvent y) => {
-                        TimeSpan diff = x.GetStartTimeUtc () - y.GetStartTimeUtc ();
-                        if (0 > diff.Ticks) {
-                            return -1;
-                        } else if (0 < diff.Ticks) {
-                            return 1;
-                        } else {
-                            return 0;
+                        PauseOrCancel ();
+
+                        // The start times for all-day events are stored differently from the start times
+                        // for regular events.  This can result in the database returning the events in a
+                        // slightly different order than what we want.  So the events need to be sorted.
+                        // Hopefully this is fast, since the events should be in almost the correct order.
+                        newEvents.Sort ((McEvent x, McEvent y) => {
+                            TimeSpan diff = x.GetStartTimeUtc () - y.GetStartTimeUtc ();
+                            if (0 > diff.Ticks) {
+                                return -1;
+                            } else if (0 < diff.Ticks) {
+                                return 1;
+                            } else {
+                                return 0;
+                            }
+                        });
+
+                        PauseOrCancel ();
+
+                        int numDays = UnsafeIndexOfDate (untilDate);
+                        int[] newDays = new int[numDays + 1];
+                        for (int day = 0; day < newDays.Length; ++day) {
+                            newDays [day] = int.MaxValue;
                         }
-                    });
+                        int endEvent = newEvents.Count;
 
-                    NcTask.Cts.Token.ThrowIfCancellationRequested ();
-
-                    // Make a copy of the end date, in case it changes while the events are being processed.
-                    DateTime untilDate = finalDay;
-
-                    int numDays = UnsafeIndexOfDate (untilDate);
-                    int[] newDays = new int[numDays + 1];
-                    for (int day = 0; day < newDays.Length; ++day) {
-                        newDays [day] = int.MaxValue;
-                    }
-                    int endEvent = newEvents.Count;
-
-                    // Iterate over all the events, figuring out on which day they occur.
-                    for (int e = 0; e < newEvents.Count; ++e) {
-                        DateTime start = newEvents [e].GetStartTimeLocal ();
-                        if (start >= untilDate) {
-                            // This event is after our end date.  We can stop processing.
-                            endEvent = e;
-                            break;
-                        }
-                        if (firstDay <= start) {
-                            // If this is the first event of the day, set the day's entry to this event.
-                            // And also set the entry for any previous day that hasn't already been set
-                            // to this event.
-                            for (int day = IndexOfDate (start); 0 <= day && int.MaxValue == newDays [day]; --day) {
-                                newDays [day] = e;
+                        // Iterate over all the events, figuring out on which day they occur.
+                        for (int e = 0; e < newEvents.Count; ++e) {
+                            DateTime start = newEvents [e].GetStartTimeLocal ();
+                            if (start >= untilDate) {
+                                // This event is after our end date.  We can stop processing.
+                                endEvent = e;
+                                break;
+                            }
+                            if (firstDay <= start) {
+                                // If this is the first event of the day, set the day's entry to this event.
+                                // And also set the entry for any previous day that hasn't already been set
+                                // to this event.
+                                for (int day = IndexOfDate (start); 0 <= day && int.MaxValue == newDays [day]; --day) {
+                                    newDays [day] = e;
+                                }
                             }
                         }
-                    }
-                    // Take care of days at the very end that don't have an event yet.
-                    for (int day = numDays; 0 <= day && int.MaxValue == newDays [day]; --day) {
-                        newDays [day] = endEvent;
-                    }
-
-                    NcTask.Cts.Token.ThrowIfCancellationRequested ();
-
-                    // To avoid race conditions, updating "this" with the new values has to happen on the UI thread.
-                    // The completion action also has to be run on the UI thread.
-                    NachoPlatform.InvokeOnUIThread.Instance.Invoke (delegate {
-                        if (untilDate != finalDay) {
-                            // ExtendEventMap was called while Refresh's task was in progress.
-                            // The whole Refresh operation has to be redone.
-                            Refresh (completionAction);
-                        } else {
-                            events = newEvents;
-                            days = newDays;
-                            if (null != completionAction) {
-                                completionAction ();
-                            }
+                        // Take care of days at the very end that don't have an event yet.
+                        for (int day = numDays; 0 <= day && int.MaxValue == newDays [day]; --day) {
+                            newDays [day] = endEvent;
                         }
-                    });
+
+                        PauseOrCancel ();
+
+                        // To avoid race conditions, updating "this" with the new values has to happen on the UI thread.
+                        // The completion action also has to be run on the UI thread.
+                        NachoPlatform.InvokeOnUIThread.Instance.Invoke (delegate {
+                            if (untilDate != finalDay) {
+                                // ExtendEventMap was called while Refresh's task was in progress.
+                                // The whole Refresh operation has to be redone.
+                                Refresh ();
+                            } else {
+                                events = newEvents;
+                                days = newDays;
+                                if (null != refreshAction) {
+                                    refreshAction ();
+                                }
+                            }
+                        });
+                    } finally {
+                        lock (refreshCountLock) {
+                            --refreshCount;
+                        }
+                    }
                 }
             }, "NcEventsCalendarMapCommonRefresh");
         }
 
-        private List<McEvent> GetEvents ()
+        private void PauseOrCancel ()
+        {
+            NcTask.Cts.Token.ThrowIfCancellationRequested ();
+            if (null == refreshAction) {
+                NcAbate.PauseWhileAbated ();
+            }
+        }
+
+        private List<McEvent> GetEvents (DateTime start, DateTime end)
         {
             var deviceAccount = McAccount.GetDeviceAccount ().Id;
             var currentAccount = NcApplication.Instance.Account.Id;
 
-            var result = GetEventsWithDuplicates ();
+            var result = GetEventsWithDuplicates (start, end);
 
             // Go through the list of events, removing duplicates.  In the initial pass, set any duplicate events
             // to null.  Then remove any null events in a single call to RemoveAll().  This two pass approach
@@ -327,6 +337,19 @@ namespace NachoCore
             return result;
         }
 
+        private void StatusIndicatorCallback (object sender, EventArgs e)
+        {
+            var s = (StatusIndEventArgs)e;
+
+            switch (s.Status.SubKind) {
+
+            case NcResult.SubKindEnum.Info_EventSetChanged:
+            case NcResult.SubKindEnum.Info_SystemTimeZoneChanged:
+                Refresh ();
+                break;
+            }
+        }
+
         /// <summary>
         /// Return the midnight that is the same or later than the given date/time
         /// </summary>
@@ -345,9 +368,14 @@ namespace NachoCore
     /// </summary>
     public class NcAllEventsCalendarMap : NcEventsCalendarMapCommon
     {
-        protected override List<McEvent> GetEventsWithDuplicates ()
+        public NcAllEventsCalendarMap (DateTime end)
+            : base(end)
         {
-            return McEvent.QueryAllEventsInOrder ();
+        }
+
+        protected override List<McEvent> GetEventsWithDuplicates (DateTime start, DateTime end)
+        {
+            return McEvent.QueryEventsInRangeInOrder (start, end);
         }
     }
 }

--- a/NachoClient.Android/NachoCore/Model/McEvent.cs
+++ b/NachoClient.Android/NachoCore/Model/McEvent.cs
@@ -166,6 +166,16 @@ namespace NachoCore.Model
         }
 
         /// <summary>
+        /// All events where at least part of the event is within the given range.  The events are returned in order of starting time.
+        /// </summary>
+        public static List<McEvent> QueryEventsInRangeInOrder (DateTime start, DateTime end)
+        {
+            start = start.ToUniversalTime ();
+            end = end.ToUniversalTime ();
+            return NcModel.Instance.Db.Table<McEvent> ().Where (x => x.EndTime >= start || x.StartTime < end).OrderBy (x => x.StartTime).ToList ();
+        }
+
+        /// <summary>
         /// All events that have a reminder time within the given range, ordered by reminder time.
         /// </summary>
         public static IEnumerable<McEvent> QueryEventsWithRemindersInRange (DateTime start, DateTime end)

--- a/NachoClient.Android/NachoCore/NcApplication.cs
+++ b/NachoClient.Android/NachoCore/NcApplication.cs
@@ -537,6 +537,7 @@ namespace NachoCore
                 NcBrain.StartService ();
                 NcCapture.ResumeAll ();
                 NcTimeVariance.ResumeAll ();
+                NachoPlatform.Calendars.Instance.EventProviderInstance.NumberOfDays ();
                 if (null != Class4LateShowEvent) {
                     Class4LateShowEvent (this, EventArgs.Empty);
                 }

--- a/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
@@ -1057,6 +1057,11 @@ namespace NachoCore.Utils
             if (!ValidateRecurrence (c, r)) {
                 return DateTime.MinValue;
             }
+            if (startingTime < NcEventManager.BeginningOfEventsOfInterest) {
+                // Don't bother creating McEvents for times in the past that will never show up on the calendar.
+                startingTime = NcEventManager.BeginningOfEventsOfInterest;
+            }
+
             // All date/time calculations must be done in the event's original time zone.
             TimeZoneInfo timeZone = new AsTimeZone (c.TimeZone).ConvertToSystemTimeZone ();
             DateTime eventStart = ConvertTimeFromUtc (c.StartTime, timeZone);

--- a/NachoClient.Android/NachoPlatform.Android/CalendarsAndroid.cs
+++ b/NachoClient.Android/NachoPlatform.Android/CalendarsAndroid.cs
@@ -22,17 +22,24 @@ namespace NachoPlatform
     public static class AndroidCalendars
     {
         private static List<McEvent> cachedDeviceEvents = new List<McEvent> ();
-        private static DateTime cachedStartRange = DateTime.UtcNow.AddDays (-31);
-        private static DateTime cachedEndRange = DateTime.UtcNow.AddYears (1);
+        private static DateTime cachedStartRange = NcEventManager.BeginningOfEventsOfInterest;
+        private static DateTime cachedEndRange = DateTime.Now.AddDays (151).Date.ToUniversalTime ();
         private static object deviceEventsLock = new object ();
 
         public static List<McEvent> GetDeviceEvents (DateTime startRange, DateTime endRange)
         {
+            bool reloadNeeded;
+            List<McEvent> result;
             lock (deviceEventsLock) {
+                reloadNeeded = startRange < cachedStartRange || endRange > cachedEndRange;
                 cachedStartRange = startRange;
                 cachedEndRange = endRange;
-                return cachedDeviceEvents;
+                result = cachedDeviceEvents;
             }
+            if (reloadNeeded) {
+                Calendars.Instance.DeviceCalendarChanged ();
+            }
+            return result;
         }
 
         private static string[] instancesProjection = new string[] {
@@ -720,9 +727,11 @@ namespace NachoPlatform
     {
         private static volatile Calendars instance;
         private static object syncRoot = new Object ();
+        private INcEventProvider eventsProvider;
 
         private Calendars ()
         {
+            eventsProvider = new AndroidEventsCalendarMap (DateTime.Now.AddDays (151).Date);
         }
 
         public static Calendars Instance {
@@ -735,6 +744,12 @@ namespace NachoPlatform
                     }
                 }
                 return instance;
+            }
+        }
+
+        public INcEventProvider EventProviderInstance {
+            get {
+                return eventsProvider;
             }
         }
 
@@ -784,6 +799,82 @@ namespace NachoPlatform
                     });
                 }
             }, "DeviceCalendarChanged");
+        }
+
+        private class AndroidEventsCalendarMap : NcEventsCalendarMapCommon
+        {
+            public AndroidEventsCalendarMap (DateTime end)
+                : base(end)
+            {
+            }
+
+            protected override List<McEvent> GetEventsWithDuplicates (DateTime start, DateTime end)
+            {
+                var appEvents = McEvent.QueryEventsInRange (start, end);
+                var deviceEvents = AndroidCalendars.GetDeviceEvents (start, end);
+
+                var result = new List<McEvent> (appEvents.Count + deviceEvents.Count);
+                result.AddRange (appEvents);
+                result.AddRange (deviceEvents);
+                result.Sort ((x, y) => {
+                    int startTimeOrder = DateTime.Compare (x.StartTime, y.StartTime);
+                    if (0 == startTimeOrder) {
+                        // If the events have the same start time, put device events before app events.
+                        if (0 != x.DeviceEventId && 0 == y.DeviceEventId) {
+                            return -1;
+                        } else if (0 == x.DeviceEventId && 0 != y.DeviceEventId) {
+                            return 1;
+                        } else {
+                            return 0;
+                        }
+                    }
+                    return startTimeOrder;
+                });
+
+                // The Android calendar item database has a UID field, but in my experience that field
+                // has always been null.  Which renders moot the code that eliminates duplicate events
+                // for the same meeting.  So we have to eliminate duplicates here.  If we see a device
+                // event without a UID, and we find another event with the same start time, end time,
+                // and title, then ignore the UID-less device event.  It is not as accurate as using
+                // the UID, but it is as good as we can do.
+                for (int i = 0; i < result.Count; ++i) {
+                    McEvent e = result [i];
+                    if (0 == e.DeviceEventId || null != e.UID) {
+                        continue;
+                    }
+                    string eTitle = null;
+                    for (int j = i + 1; j < result.Count && result [j].StartTime == e.StartTime; ++j) {
+                        McEvent f = result [j];
+                        if (e.EndTime == f.EndTime) {
+                            if (null == eTitle) {
+                                string dummyLocation;
+                                int dummyColor;
+                                AndroidCalendars.GetEventDetails (e.DeviceEventId, out eTitle, out dummyLocation, out dummyColor);
+                            }
+                            string fTitle = null;
+                            if (0 == f.DeviceEventId) {
+                                var appCal = f.GetCalendarItemforEvent ();
+                                if (null != appCal) {
+                                    fTitle = appCal.GetSubject ();
+                                }
+                            } else {
+                                string dummyLocation;
+                                int dummyColor;
+                                AndroidCalendars.GetEventDetails (f.DeviceEventId, out fTitle, out dummyLocation, out dummyColor);
+                            }
+                            if (null != eTitle && null != fTitle && eTitle == fTitle) {
+                                result [i] = null;
+                                break;
+                            }
+                        }
+                    }
+                }
+                result.RemoveAll ((McEvent obj) => {
+                    return obj == null;
+                });
+
+                return result;
+            }
         }
     }
 

--- a/NachoClient.Android/NachoPlatform/IPlatform.cs
+++ b/NachoClient.Android/NachoPlatform/IPlatform.cs
@@ -198,6 +198,8 @@ namespace NachoPlatform
         NcResult Change (McCalendar contact);
 
         bool AuthorizationStatus { get; }
+
+        NachoCore.INcEventProvider EventProviderInstance { get; }
     }
 
     public enum PowerStateEnum

--- a/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/CalendarsiOS.cs
@@ -19,12 +19,14 @@ namespace NachoPlatform
         private static object syncRoot = new Object ();
         private EKEventStore Es;
         private NSObject NotifToken = null;
+        private INcEventProvider eventsProvider;
 
         public event EventHandler ChangeIndicator;
 
         private Calendars ()
         {
             EKEventStoreCreate ();
+            eventsProvider = new NcAllEventsCalendarMap (DateTime.Now.AddDays (151).Date);
         }
 
         public static Calendars Instance {
@@ -37,6 +39,12 @@ namespace NachoPlatform
                     }
                 }
                 return instance;
+            }
+        }
+
+        public INcEventProvider EventProviderInstance {
+            get {
+                return eventsProvider;
             }
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/CalendarViewController.cs
@@ -43,10 +43,7 @@ namespace NachoClient.iOS
             var a = UILabel.AppearanceWhenContainedIn (typeof(UITableViewHeaderFooterView), typeof(CalendarViewController));
             a.TextColor = UIColor.LightGray;
 
-            // Start populating the event table, so the data will hopefully be ready when this view
-            // first becomes visible.
-            eventCalendarMap = new NcAllEventsCalendarMap ();
-            eventCalendarMap.Refresh (completionAction: null);
+            eventCalendarMap = NachoPlatform.Calendars.Instance.EventProviderInstance;
         }
 
         public override void ViewDidLoad ()
@@ -98,12 +95,13 @@ namespace NachoClient.iOS
 
             switchAccountButton.SetAccountImage (NcApplication.Instance.Account);
 
-            // Start a background refresh, which will update the UI when it is done.
-            calendarSource.Refresh (delegate {
+            eventCalendarMap.UiRefresh = () => {
                 ReloadDataWithoutScrolling ();
                 UpdateDateDotView ();
-            });
+            };
 
+            ReloadDataWithoutScrolling ();
+            UpdateDateDotView ();
             UpdateDateInTodayButton ();
 
             if (firstTime) {
@@ -122,7 +120,7 @@ namespace NachoClient.iOS
         {
             base.ViewWillDisappear (animated);
             NcApplication.Instance.StatusIndEvent -= StatusIndicatorCallback;
-            calendarSource.StopTrackingEventChanges ();
+            eventCalendarMap.UiRefresh = null;
         }
 
         /// <summary>
@@ -155,33 +153,11 @@ namespace NachoClient.iOS
             NcAssert.CaseError ();
         }
 
-        private bool refreshInProgress = false;
-        private bool refreshWaitingToStart = false;
-
         public void StatusIndicatorCallback (object sender, EventArgs e)
         {
             var s = (StatusIndEventArgs)e;
 
             switch (s.Status.SubKind) {
-
-            // When the events change, or when the time zone changes, refresh the UI to reflect the changes.
-            case NcResult.SubKindEnum.Info_EventSetChanged:
-            case NcResult.SubKindEnum.Info_SystemTimeZoneChanged:
-                // Don't queue up a whole bunch refresh tasks.  If there is one running and one waiting to
-                // run, there is no point in starting yet another refresh task.
-                if (!refreshWaitingToStart) {
-                    if (refreshInProgress) {
-                        refreshWaitingToStart = true;
-                    }
-                    refreshInProgress = true;
-                    calendarSource.Refresh (delegate {
-                        refreshWaitingToStart = false;
-                        refreshInProgress = false;
-                        ReloadDataWithoutScrolling ();
-                        UpdateDateDotView ();
-                    });
-                }
-                break;
 
             case NcResult.SubKindEnum.Info_ExecutionContextChanged:
                 if (NcApplication.ExecutionContextEnum.Foreground == NcApplication.Instance.ExecutionContext) {

--- a/NachoClient.iOS/NachoUI.iOS/Support/CalendarTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/CalendarTableViewSource.cs
@@ -35,20 +35,6 @@ namespace NachoClient.iOS
             this.calendar = calendar;
         }
 
-        public void Refresh (Action completionAction)
-        {
-            if (null != calendar) {
-                calendar.Refresh (completionAction);
-            }
-        }
-
-        public void StopTrackingEventChanges ()
-        {
-            if (null != calendar) {
-                calendar.StopTrackingEventChanges ();
-            }
-        }
-
         protected bool NoCalendarEvents ()
         {
             return ((null == calendar) || (0 == calendar.NumberOfDays ()));
@@ -257,8 +243,8 @@ namespace NachoClient.iOS
                 return;
             }
             var e = calendar.GetEvent (indexPath.Section, indexPath.Row - 1);
-            var c = calendar.GetEventDetail (indexPath.Section, indexPath.Row - 1);
-            var cRoot =  CalendarHelper.GetMcCalendarRootForEvent (e.Id);
+            var c = e.GetCalendarItemforEvent ();
+            var cRoot = CalendarHelper.GetMcCalendarRootForEvent (e.Id);
 
             if (null == c || null == cRoot) {
                 cell.ContentView.ViewWithTag (SWIPE_TAG).Hidden = true;

--- a/Test.Android/NcEventsCommonTest.cs
+++ b/Test.Android/NcEventsCommonTest.cs
@@ -23,7 +23,12 @@ namespace Test.Common
 
         public class EmptyInstance : NcEventsCalendarMapCommon
         {
-            protected override System.Collections.Generic.List<McEvent> GetEventsWithDuplicates ()
+            public EmptyInstance ()
+                : base (DateTime.UtcNow.AddMonths (1))
+            {
+            }
+
+            protected override System.Collections.Generic.List<McEvent> GetEventsWithDuplicates (DateTime start, DateTime end)
             {
                 return new System.Collections.Generic.List<NachoCore.Model.McEvent> ();
             }
@@ -31,7 +36,12 @@ namespace Test.Common
 
         public class Instance1 : NcEventsCalendarMapCommon
         {
-            protected override System.Collections.Generic.List<McEvent> GetEventsWithDuplicates ()
+            public Instance1 ()
+                : base (DateTime.UtcNow.AddDays (70))
+            {
+            }
+
+            protected override System.Collections.Generic.List<McEvent> GetEventsWithDuplicates (DateTime start, DateTime end)
             {
                 var id = account.Id;
 


### PR DESCRIPTION
Keep a singleton cache of all the events that could be displayed in
the calendar list view.  Initialize the cache shortly after app
launch, and keep the cache up to date even when the calendar view is
not visible.  With this change, tapping on the Calendar tab should
result in the correct events being displayed almost instantaneously
(except when tapping the Calendar tab within the first few seconds of
launching the app).  This is a significant improvement for Android;
iOS already did this.
Fix nachocove/qa#1825

On Android, the calendar will automatically extend into the future as
the user scrolls the event list, the week view, or the month view.
The user is no longer limited to seeing just five months into the
future.
Fix nachocove/qa#1594
