### PR TITLE
Fix nachocove/qa#1839. NcApplication Account must never be null.

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcAccountHandler.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcAccountHandler.cs
@@ -293,8 +293,7 @@ namespace NachoCore.Model
             // delete all file system data for account id
             RemoveAccountFiles (AccountId);
 
-            // if there is only one account. TODO: deal with multi-account
-            NcApplication.Instance.Account = null;
+            NcApplication.Instance.Account = LoginHelpers.PickStartupAccount();
             // if successful, unmark account is being removed since it is completed.
             DeleteRemovingAccountFile ();
         }


### PR DESCRIPTION
The fallback is the device account.
