### PR TITLE
Don't double delete outgoing meeting related messages

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/CalendarHelper.cs
@@ -389,11 +389,6 @@ namespace NachoCore.Utils
 
             var mcMessage = MimeHelpers.AddToDb (account.Id, mimeMessage);
             BackEnd.Instance.SendEmailCmd (mcMessage.AccountId, mcMessage.Id, c.Id);
-            // TODO: Subtle ugliness. Id is passed to BE, ref-count is ++ in the DB.
-            // The object here still has ref-count of 0, so interlock is lost, and delete really happens in the DB.
-            // BE goes to reference the object later on, and it is missing.
-            mcMessage = McEmailMessage.QueryById<McEmailMessage> (mcMessage.Id);
-            mcMessage.Delete ();
         }
 
         //Used to send a single invite to one attendee at a time rather than all attendees of an event
@@ -410,8 +405,6 @@ namespace NachoCore.Utils
 
             var mcMessage = MimeHelpers.AddToDb (account.Id, mimeMessage);
             BackEnd.Instance.SendEmailCmd (mcMessage.AccountId, mcMessage.Id, c.Id);
-            mcMessage = McEmailMessage.QueryById<McEmailMessage> (mcMessage.Id);
-            mcMessage.Delete ();
         }
 
         public static void SendMeetingResponse (McAccount account, McCalendar c, MimeEntity mimeBody, NcResponseType response)
@@ -427,8 +420,6 @@ namespace NachoCore.Utils
             mimeMessage.Body = mimeBody;
             var mcMessage = MimeHelpers.AddToDb (account.Id, mimeMessage);
             BackEnd.Instance.SendEmailCmd (mcMessage.AccountId, mcMessage.Id, c.Id);
-            mcMessage = McEmailMessage.QueryById<McEmailMessage> (mcMessage.Id);
-            mcMessage.Delete ();
         }
 
         public static void SendMeetingResponse (McAccount account, MailboxAddress to, string subject, string token, MimeEntity mimeBody, NcResponseType response)
@@ -441,8 +432,6 @@ namespace NachoCore.Utils
             mimeMessage.Body = mimeBody;
             var mcMessage = MimeHelpers.AddToDb (account.Id, mimeMessage);
             BackEnd.Instance.SendEmailCmd (mcMessage.AccountId, mcMessage.Id);
-            mcMessage = McEmailMessage.QueryById<McEmailMessage> (mcMessage.Id);
-            mcMessage.Delete ();
         }
 
         public static void SendMeetingCancelations (McAccount account, McCalendar c, string subjectOverride, MimeEntity mimeBody)
@@ -457,8 +446,6 @@ namespace NachoCore.Utils
             mimeMessage.Body = mimeBody;
             var mcMessage = MimeHelpers.AddToDb (account.Id, mimeMessage);
             BackEnd.Instance.SendEmailCmd (mcMessage.AccountId, mcMessage.Id, c.Id);
-            mcMessage = McEmailMessage.QueryById<McEmailMessage> (mcMessage.Id);
-            mcMessage.Delete ();
         }
 
         private static iCalendar iCalendarCommon (McAbstrCalendarRoot cal)


### PR DESCRIPTION
When the handling of outgoing messages was cleaned up many months ago,
only regular messages were adjusted.  Meeting related messages were
forgotten.  The result was that Delete() was called twice for those
messages.  For a while, that double deletion was benign.  But recently
changes related to chat made the double deletion result in crash.

Fix the meeting related message code to not delete the outgoing
message.  Let the back end take care of that once the message has been
successfully sent.

Fix nachocove/qa#1853
