### PR TITLE
Keep contact interactions from slowing down the app

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/INachoEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/INachoEmailMessages.cs
@@ -7,6 +7,8 @@ using NachoCore.Utils;
 
 namespace NachoCore
 {
+    public delegate void NachoMessagesRefreshCompletionDelegate (bool changed, List<int> adds, List<int> deletes);
+
     public interface INachoEmailMessages
     {
         int Count ();
@@ -15,6 +17,10 @@ namespace NachoCore
         /// Refresh the email message list. Return true if there is changes; false otherrwise.
         /// </summary>
         bool Refresh (out List<int> adds, out List<int> deletes);
+
+        bool HasBackgroundRefresh ();
+
+        void BackgroundRefresh (NachoMessagesRefreshCompletionDelegate completionAction);
 
         // Returns the thread, not the messages
         McEmailMessageThread GetEmailThread (int i);
@@ -56,6 +62,18 @@ namespace NachoCore
             adds = null;
             deletes = null;
             return false;
+        }
+
+        public virtual bool HasBackgroundRefresh ()
+        {
+            return false;
+        }
+
+        public virtual void BackgroundRefresh (NachoMessagesRefreshCompletionDelegate completionAction)
+        {
+            if (null != completionAction) {
+                completionAction (false, null, null);
+            }
         }
 
         public virtual McEmailMessageThread GetEmailThread (int i)

--- a/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
+++ b/NachoClient.Android/NachoCore/Model/McEmailMessage/McEmailMessage.cs
@@ -525,8 +525,8 @@ namespace NachoCore.Model
                 " likelihood (m.ClassCode = ?, 0.2) AND " +
                 "{1}" +
                 " likelihood (m.FolderId != ?, 0.5) AND " +
-                " likelihood (e.[From] LIKE ?, 0.05) OR " +
-                " likelihood (e.[To] Like ?, 0.05) " +
+                " (likelihood (e.[From] LIKE ?, 0.05) OR " +
+                "  likelihood (e.[To] Like ?, 0.05) ) " +
                 " ORDER BY e.DateReceived DESC";
 
             var account0 = SingleAccountString (" likelihood (e.AccountId = {0}, 1.0) AND ", accountId);

--- a/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
@@ -1136,13 +1136,10 @@ namespace NachoClient.iOS
                 return;
             }
 
-            using (NcAbate.UIAbatement ()) {
-                UITableView interactionsTableView = (UITableView)View.ViewWithTag (INTERACTIONS_TABLE_VIEW_TAG);
-                List<int> adds;
-                List<int> deletes;
-                messageSource.RefreshEmailMessages (out adds, out deletes);
+            messageSource.BackgroundRefreshEmailMessages ((changed, adds, deletes) => {
+                var interactionsTableView = (UITableView)View.ViewWithTag (INTERACTIONS_TABLE_VIEW_TAG);
                 interactionsTableView.ReloadData ();
-            }
+            });
         }
 
         public void DateSelected (NcMessageDeferral.MessageDateType type, MessageDeferralType request, McEmailMessageThread thread, DateTime selectedDate)

--- a/NachoClient.iOS/NachoUI.iOS/Support/IMessageTableViewSourceDelegate.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/IMessageTableViewSourceDelegate.cs
@@ -32,6 +32,8 @@ namespace NachoClient.iOS
 
         bool RefreshEmailMessages (out List<int> adds, out List<int> deletes);
 
+        void BackgroundRefreshEmailMessages (NachoMessagesRefreshCompletionDelegate completionAction);
+
         bool NoMessageThreads ();
 
         void ReconfigureVisibleCells (UITableView tableView);

--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -194,6 +194,28 @@ namespace NachoClient.iOS
             return didRefresh;
         }
 
+        public void BackgroundRefreshEmailMessages (NachoMessagesRefreshCompletionDelegate completionAction)
+        {
+            if (!messageThreads.HasBackgroundRefresh ()) {
+                List<int> adds;
+                List<int> deletes;
+                bool changed = RefreshEmailMessages (out adds, out deletes);
+                if (null != completionAction) {
+                    completionAction (changed, adds, deletes);
+                }
+                return;
+            }
+            ClearCache ();
+            messageThreads.BackgroundRefresh ((changed, adds, deletes) => {
+                if (null != headerText && messageThreads.HasFilterSemantics ()) {
+                    headerText.Text = Folder_Helpers.FilterString (messageThreads.FilterSetting);
+                }
+                if (null != completionAction) {
+                    completionAction (changed, adds, deletes);
+                }
+            });
+        }
+
         public bool NoMessageThreads ()
         {
             return ((null == messageThreads) || (0 == messageThreads.Count ()));


### PR DESCRIPTION
Fix an order of operations bug in the DB query in
McEmailMessage.QueryInteractions() that was making the query much
slower than it should have been.

Reorganize code so that McEmailMessage.QueryInteractions() is always
run on a background thread.  Even with the bug fix, it is expected
that the query will sometimes be slow enough that it should not happen
on the UI thread.

Fix nachocove/qa#1854
