### PR TITLE
Some minor safe mode improvements

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -855,6 +855,12 @@ namespace NachoClient.iOS
                 Log.Info (Log.LOG_LIFECYCLE, "PerformFetch was called while a previous PerformFetch was still running. This shouldn't happen.");
                 CompletePerformFetchWithoutShutdown ();
             }
+
+            // Crashes while launching in the background shouldn't increment the safe mode counter.
+            // (It would be nice if background launches could simply not increment the counter rather
+            // than clear it completely, but that is not worth the effort.)
+            NcApplication.Instance.UnmarkStartup ();
+
             CompletionHandler = completionHandler;
             // check to see if migrations need to run. If so, we shouldn't let the PerformFetch proceed!
             NcMigration.Setup ();

--- a/NachoClient.iOS/NachoUI.iOS/Startup.storyboard
+++ b/NachoClient.iOS/NachoUI.iOS/Startup.storyboard
@@ -190,7 +190,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="62y-Yo-Unb">
                                 <rect key="frame" x="16" y="226" width="568" height="148"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sorry for the crash!  We are recovering." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Okr-I2-CGo">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sorry for the crash! It may take a minute or two to recover." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Okr-I2-CGo">
                                         <rect key="frame" x="0.0" y="103" width="568" height="24"/>
                                         <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
Background crashes no longer count toward entering safe mode.  Safe
mode will only be entered after the app crashes twice in a row while
being launched into the foreground.  Background crashes are not as
visible to the user, who might be confused about the reference to a
crash on the safe mode screen when the app hasn't crashed.

Improve the message displayed to the user on the safe mode screen.  It
now gives the user a clue as to how long safe mode might last.

Log both an error message and a support request when entering safe
mode.  Both of these increase the chances that a developer will notice
and investigate the problem.  (The support request does not contain
the user's e-mail address, since the user has not given permission to
send it.  Its purpose is to provide an easy and visible link to the
telemetry.)

Keep the safe mode screen visible for at least two seconds, even if
telemetry and HockeyApp are already caught up, so that the user has
time to read the screen.  (Seeing a screen flash with the word "crash"
on it but not having time to read the whole message could be
disconcerting for a user.)

Fix https://support.nachocove.com/helpdesk/tickets/786
