### PR TITLE
Don't crash when dismissed view wants to show alert dialog

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/ComposeFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/ComposeFragment.cs
@@ -589,7 +589,9 @@ namespace NachoClient.AndroidClient
 
         public void MessageComposerDidFailToLoadMessage (MessageComposer composer)
         {
-            NcAlertView.ShowMessage (Activity, "Could not load message", "Sorry, we could not load your message.  Please try again.");
+            if (null != this.Activity) {
+                NcAlertView.ShowMessage (this.Activity, "Could not load message", "Sorry, we could not load your message. Please try again.");
+            }
         }
 
         void DisplayMessageBody ()

--- a/NachoClient.Android/NachoUI.Android/Activities/FileListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/FileListFragment.cs
@@ -322,8 +322,11 @@ namespace NachoClient.AndroidClient
 
         public void AttachmentDownloadDidFail (AttachmentDownloader downloader, NcResult result)
         {
-            RefreshVisibleItems ();
-            NcAlertView.ShowMessage (Activity, "Download Error", "Sorry, we couldn't download the file.  Please try again.");
+            // TODO Display the dialog error message even if the view has already been dismissed.
+            if (null != this.Activity) {
+                RefreshVisibleItems ();
+                NcAlertView.ShowMessage (Activity, "Download Error", "Sorry, we couldn't download the file. Please try again.");
+            }
         }
 
         void RefreshVisibleItems ()

--- a/NachoClient.Android/NachoUI.Android/Activities/FilePickerFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/FilePickerFragment.cs
@@ -174,7 +174,9 @@ namespace NachoClient.AndroidClient
             downloadView.Visibility = ViewStates.Gone;
             downloadIndicator.ClearAnimation ();
             downloadIndicator.Visibility = ViewStates.Gone;
-            NcAlertView.ShowMessage (Activity, "Download Error", "Sorry, we couldn't download the attachment.  Please try again.");
+            if (null != this.Activity) {
+                NcAlertView.ShowMessage (this.Activity, "Download Error", "Sorry, we couldn't download the attachment. Please try again.");
+            }
         }
     }
 

--- a/NachoClient.Android/NachoUI.Android/Activities/MessageViewFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageViewFragment.cs
@@ -596,7 +596,9 @@ namespace NachoClient.AndroidClient
             activityIndicatorView.Visibility = ViewStates.Invisible;
             // TODO: show this inline, possibly with message preview (if available)
             // and give the user an option to retry if appropriate
-            NcAlertView.ShowMessage (Activity, "Could not download message", "Sorry, we were unable to download the message.");
+            if (null != this.Activity) {
+                NcAlertView.ShowMessage (this.Activity, "Could not download message", "Sorry, we were unable to download the message.");
+            }
         }
 
         void RenderBody ()

--- a/NachoClient.Android/NachoUI.Android/Support/Util.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/Util.cs
@@ -120,7 +120,7 @@ namespace NachoClient.AndroidClient
             }
             var emailAddress = contact.GetDefaultOrSingleEmailAddress ();
             if (null == emailAddress) {
-                NcAlertView.ShowMessage (context, "Contact has multiple addresses", "Please send an email address to use.");
+                NcAlertView.ShowMessage (context, "Contact has multiple addresses", "Please select an email address to use.");
                 return;
             }
             context.StartActivity (MessageComposeActivity.NewMessageIntent (context, accountId, emailAddress));


### PR DESCRIPTION
A fragment that has been dismissed has a null Activity, which means it
doesn't have an easy way to get a usable Context, which means it can't
easily show an alert dialog.  Check for a null Activity in fragment
callback functions that might be called after the fragment has been
dismissed.

Fix nachocove/qa#1875
