### PR TITLE
Don't crash when unselecting several messages

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/MessageListFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageListFragment.cs
@@ -645,6 +645,8 @@ namespace NachoClient.AndroidClient
                 value += delta;
                 if (0 == value) {
                     MultiSelectAccounts.Remove (message.AccountId);
+                } else {
+                    MultiSelectAccounts [message.AccountId] = value;
                 }
             } else {
                 NcAssert.True (1 == delta);

--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -460,6 +460,8 @@ namespace NachoClient.iOS
                 value += delta;
                 if (0 == value) {
                     MultiSelectAccounts.Remove (message.AccountId);
+                } else {
+                    MultiSelectAccounts [message.AccountId] = value;
                 }
             } else {
                 NcAssert.True (1 == delta);


### PR DESCRIPTION
Don't crash when unselecting the second message from the same account
in multiselect mode in a message list.

Fix nachocove/qa#1876
