### PR TITLE
make sure to set the most recent account when switching

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/SwitchAccountFragment.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/SwitchAccountFragment.cs
@@ -92,6 +92,7 @@ namespace NachoClient.AndroidClient
         void AccountAdapter_AccountSelected (object sender, McAccount account)
         {
             LoginHelpers.SetSwitchAwayTime (NcApplication.Instance.Account.Id);
+            LoginHelpers.SetMostRecentAccount (account.Id);
             NcApplication.Instance.Account = account;
 
             var parent = (AccountListDelegate)Activity;

--- a/NachoClient.iOS/NachoUI.iOS/SwitchAccountViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/SwitchAccountViewController.cs
@@ -103,6 +103,7 @@ namespace NachoClient.iOS
             spinner.StartAnimating ();
             spinner.HidesWhenStopped = true;
             LoginHelpers.SetSwitchAwayTime (NcApplication.Instance.Account.Id);
+            LoginHelpers.SetMostRecentAccount (account.Id);
             NcApplication.Instance.Account = account;
             switchAccountCallback (account);
             Deactivate (null, (McAccount acct) => {


### PR DESCRIPTION
SetSwitchAwayTime used to be called SetSwitchToTime, and took the account being switch to.  It also called SetMostRecentAccount.  It doesn't make sense to call SetMostRecentAccount in the new SetSwitchAwayTime because that function no longer takes the account being switched to.  Seems reasonable to just do both calls side by side now.
