### PR TITLE
show badge count according to unread count pref

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
@@ -922,6 +922,32 @@ namespace NachoCore.Utils
             }
         }
 
+        public static int GetUnreadMessageCountForBadge ()
+        {
+            var account = McAccount.GetUnifiedAccount ();
+            var unreadPref = HowToDisplayUnreadCount ();
+            DateTime since = default(DateTime);
+            if (unreadPref == ShowUnreadEnum.AllMessages) {
+                since = default(DateTime).AddDays (2);
+            } else if (unreadPref == ShowUnreadEnum.TodaysMessages) {
+                since = DateTime.Now.Date.ToUniversalTime ();
+            } else if (unreadPref == ShowUnreadEnum.RecentMessages) {
+                since = LoginHelpers.GetBackgroundTime ();
+            } else {
+                NcAssert.CaseError ();
+            }
+            var count = 0;
+            foreach (var accountId in McAccount.GetAllConfiguredNormalAccountIds ()) {
+                if (account.ContainsAccount (accountId)) {
+                    var inboxFolder = NcEmailManager.InboxFolder (accountId);
+                    if (null != inboxFolder) {
+                        count += McEmailMessage.CountOfUnreadMessageItems (inboxFolder.AccountId, inboxFolder.Id, since);
+                    }
+                }
+            }
+            return count;
+        }
+
         public const string Unread_McMutablesModule = "Settings";
         public const string Unread_McMutablesKey = "ShowUnread";
 

--- a/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
@@ -280,6 +280,7 @@ namespace NachoClient.iOS
                 break;
             }
             UnreadCountBlock.SetValue (label);
+            (UIApplication.SharedApplication.Delegate as AppDelegate).UpdateBadge ();
         }
 
     }


### PR DESCRIPTION
I used a slightly different count for the badge than the existing unread functions use, because in the "recent" case, the existing count functions where based on the account switch away time, but for the badge it seemed more appropriate to always use the background time because that ensures the badge is always cleared when exiting the app, regardless of if you've actually switched through every account.  For the "today" and "all" cases, the badge count should be the same as the exiting unread counts.
