### PR TITLE
better handling of the SyncKit.PendingSingle

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapStrategy/ImapStrategySyncKit.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapStrategy/ImapStrategySyncKit.cs
@@ -493,12 +493,13 @@ namespace NachoCore.IMAP
         /// Resolves the one sync, i.e. One SyncKit.
         /// </summary>
         /// <param name="BEContext">BEContext.</param>
-        /// <param name="synckit">Synckit.</param>
-        public static void ResolveOneSync (IBEContext BEContext, SyncKit synckit)
+        /// <param name = "pending">A McPending</param>
+        /// <param name = "folder">A McFolder</param>
+        public static void ResolveOneSync (IBEContext BEContext, McPending pending, McFolder folder)
         {
             var protocolState = BEContext.ProtocolState;
-            ResolveOneSync (BEContext, ref protocolState, synckit.Folder, synckit.PendingSingle);
-            MaybeAdvanceSyncStage (ref protocolState, synckit.PendingSingle != null);
+            ResolveOneSync (BEContext, ref protocolState, folder, pending);
+            MaybeAdvanceSyncStage (ref protocolState, pending != null);
         }
 
         /// <summary>

--- a/NachoClient.Android/NachoCore/BackEnd/NcCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/NcCommand.cs
@@ -122,6 +122,10 @@ namespace NachoCore
             lock (PendingResolveLockObj) {
                 ConsolidatePending ();
                 foreach (var pending in PendingList) {
+                    if (pending.State != McPending.StateEnum.Dispatched) {
+                        Log.Error (Log.LOG_BACKEND, "ResolveAllDeferred: Ignoring non-Dispatched pending {0} in state {1}", pending, pending.State);
+                        continue;
+                    }
                     pending.ResolveAsDeferredForce (BEContext.ProtoControl);
                 }
                 PendingList.Clear ();


### PR DESCRIPTION
NcCommand subclasses have some built-in resolving functions, which rely
on NcCommand.PendingSingle and NcCommand.PendingList. By also using
SyncKit.PendingSingle, things got a bit confused.
When we create the command, set the SyncKit.PendingSingle to null so we
aren’t tempted to use it later.
Then, if we resolved the pending ourselves, set NcCommand.PendingSingle
to null, so that any later error paths don’t try to resolve it as
failed or deferred (which is what caused the crash).

Further, if we overlooked a case, log an error instead of crashing.
resolves nachocove/qa#1893
