### PR TITLE
Fix iOS crash when viewing non-empty drafts folder

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -846,7 +846,7 @@ namespace NachoClient.iOS
             userImageView.Hidden = true;
             userLabelView.Hidden = true;
            
-            var unreadMessageView = (UIImageView)cell.ContentView.ViewWithTag (UNREAD_IMAGE_TAG);
+            var unreadMessageView = cell.ContentView.ViewWithTag (UNREAD_IMAGE_TAG);
             unreadMessageView.Hidden = true;
 
             var messageHeaderView = (MessageHeaderView)cell.ContentView.ViewWithTag (MESSAGE_HEADER_TAG);


### PR DESCRIPTION
A recent update changed the type of the UIView object representing the
unread indicator.  There was one place in the code where the type of a
cast was not changed, resulting in a InvalidCastException at runtime.

Fix nachocove/qa#1911
