### PR TITLE
fix chat send errors

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/ChatMessageComposer.cs
+++ b/NachoClient.Android/NachoCore/Utils/ChatMessageComposer.cs
@@ -31,8 +31,11 @@ namespace NachoCore.Utils
             Message.IsChat = true;
             Message.DateReceived = DateTime.Now;
             Message.IsRead = true;
-            if (previousMessages.Count > 0) {
-                Message.ReferencedEmailId = previousMessages [0].Id;
+            foreach (var previousMessage in previousMessages) {
+                if (!String.IsNullOrEmpty (previousMessage.ServerId)) {
+                    Message.ReferencedEmailId = previousMessage.Id;
+                    break;
+                }
             }
             InitialAttachments = McAttachment.QueryByItemId (Chat.AccountId, Chat.Id, McAbstrFolderEntry.ClassCodeEnum.Chat);
             foreach (var attachment in InitialAttachments) {

--- a/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
+++ b/NachoClient.Android/NachoCore/Utils/EmailHelper.cs
@@ -57,15 +57,19 @@ namespace NachoCore.Utils
                 }
             } else {
                 if (referencedMessage != null) {
-                    folders = McFolder.QueryByFolderEntryId<McEmailMessage> (referencedMessage.AccountId, referencedMessage.Id);
-                    if (folders.Count == 0) {
-                        Log.Error (Log.LOG_UI, "The message being forwarded or replied to is not owned by any folder. It will be sent as a regular outgoing message.");
+                    if (String.IsNullOrEmpty (referencedMessage.ServerId)) {
+                        Log.Error (Log.LOG_UI, "The message being forwarded or replied is not on the server. It will be sent as a regular outgoing message.");
                     } else {
-                        int folderId = folders [0].Id;
-                        if (messageToSend.ReferencedIsForward) {
-                            sendResult = NachoCore.BackEnd.Instance.ForwardEmailCmd (messageToSend.AccountId, messageToSend.Id, referencedMessage.Id, folderId, true);
+                        folders = McFolder.QueryByFolderEntryId<McEmailMessage> (referencedMessage.AccountId, referencedMessage.Id);
+                        if (folders.Count == 0) {
+                            Log.Error (Log.LOG_UI, "The message being forwarded or replied to is not owned by any folder. It will be sent as a regular outgoing message.");
                         } else {
-                            sendResult = NachoCore.BackEnd.Instance.ReplyEmailCmd (messageToSend.AccountId, messageToSend.Id, referencedMessage.Id, folderId, true);
+                            int folderId = folders [0].Id;
+                            if (messageToSend.ReferencedIsForward) {
+                                sendResult = NachoCore.BackEnd.Instance.ForwardEmailCmd (messageToSend.AccountId, messageToSend.Id, referencedMessage.Id, folderId, true);
+                            } else {
+                                sendResult = NachoCore.BackEnd.Instance.ReplyEmailCmd (messageToSend.AccountId, messageToSend.Id, referencedMessage.Id, folderId, true);
+                            }
                         }
                     }
                 }

--- a/NachoClient.iOS/NachoUI.iOS/ChatMessagesViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ChatMessagesViewController.cs
@@ -192,7 +192,7 @@ namespace NachoClient.iOS
             }
             var text = ComposeView.GetMessage ();
             var previousMessages = new List<McEmailMessage> ();
-            for (int i = Messages.Count - 1; i >= Messages.Count - 3 && i >= 0; --i){
+            for (int i = Messages.Count - 1; i >= Messages.Count - 5 && i >= 0; --i){
                 previousMessages.Add (Messages [i]);
             }
             ChatMessageComposer.SendChatMessage (Chat, text, previousMessages, (McEmailMessage message, NcResult result) => {


### PR DESCRIPTION
The issue happened for AS servers when chat tried to reply to a
very recent sent message that wasn't yet on the server (or at least
one that we haven't received the ServerId for yet), so the server
complained.  The fix now just uses the most recent chat message with a ServerId
as the reply source

fixes nachocove/qa#1904
