### PR TITLE
make message previews plain text on android, matching iOS

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Activities/MessageListAdapter.cs
+++ b/NachoClient.Android/NachoUI.Android/Activities/MessageListAdapter.cs
@@ -254,7 +254,7 @@ namespace NachoClient.AndroidClient
                 vh.previewView.Text = "";
             } else {
                 var cookedPreview = EmailHelper.AdjustPreviewText (message.GetBodyPreviewOrEmpty ());
-                vh.previewView.SetText (Android.Text.Html.FromHtml (cookedPreview), Android.Widget.TextView.BufferType.Spannable);
+                vh.previewView.SetText (new Java.Lang.String (cookedPreview), Android.Widget.TextView.BufferType.Normal);
             }
 
             if (owner.multiSelectActive) {


### PR DESCRIPTION
The source of the preview is plain text, so it should be displayed as plain text.

When testing the html escaping for link detection, I noticed that the preview was interpreting the plain text as html
