### PR TITLE
catch and log the failure to parse

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapStrategy/ImapStrategyFetchKit.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapStrategy/ImapStrategyFetchKit.cs
@@ -171,9 +171,13 @@ namespace NachoCore.IMAP
         {
             BodyPart imapBody = null;
             if (!string.IsNullOrEmpty (email.ImapBodyStructure)) {
-                if (!BodyPart.TryParse (email.ImapBodyStructure, out imapBody)) {
-                    Log.Error (Log.LOG_IMAP, "Couldn't reconstitute ImapBodyStructure");
-                    return null;
+                try {
+                    if (!BodyPart.TryParse (email.ImapBodyStructure, out imapBody)) {
+                        Log.Error (Log.LOG_IMAP, "Couldn't reconstitute ImapBodyStructure");
+                        return null;
+                    }
+                } catch (Exception ex) {
+                    Log.Error (Log.LOG_IMAP, "Could not parse BodyPart from ImapBodyStructure: {0}\n{1}", email.ImapBodyStructure, ex);
                 }
             }
             List<FetchKit.DownloadPart> Parts = null;


### PR DESCRIPTION
This should be a temporary patch to see what is causing one of owen's messages to crash us. We can leave in the catch/log, but not log the entire bodystructure, since it potentially contains PII (filenames mostly)
