### PR TITLE
The folder selector account should be hardwired when selecting the target of a move.

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ContactDetailViewController.cs
@@ -202,7 +202,19 @@ namespace NachoClient.iOS
             if (segue.Identifier == "MessageListToFolders") {
                 var vc = (INachoFolderChooser)segue.DestinationViewController;
                 var h = (SegueHolder)sender;
-                vc.SetOwner (this, true, h);
+                int accountId = 0;
+                if (h.value is McEmailMessage) {
+                    accountId = ((McEmailMessage)h.value).AccountId;
+                }
+                if (h.value is McEmailMessageThread) {
+                    var message = ((McEmailMessageThread)h.value).FirstMessage ();
+                    if (null == message) {
+                        return;
+                    }
+                    accountId = message.AccountId;
+                }
+                NcAssert.False (0 == accountId);
+                vc.SetOwner (this, true, accountId, h);
                 return;
             }
             if (segue.Identifier == "NachoNowToMessageView") {
@@ -1073,7 +1085,7 @@ namespace NachoClient.iOS
         protected bool PerformAction (string action, string number)
         {
             try {
-                return Util.PerformAction(action, number);
+                return Util.PerformAction (action, number);
             } catch (Exception e) {
                 Log.Warn (Log.LOG_UI, "Cannot perform action {0} ({1})", action, e);
                 return false;
@@ -1160,7 +1172,7 @@ namespace NachoClient.iOS
 
         public void DismissChildFolderChooser (INachoFolderChooser vc)
         {
-            vc.SetOwner (null, false, null);
+            vc.SetOwner (null, false, 0, null);
             vc.DismissFolderChooser (false, null);
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/FoldersViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/FoldersViewController.cs
@@ -29,15 +29,17 @@ namespace NachoClient.iOS
         {
         }
 
+        int accountId;
         protected object cookie;
         protected bool modal;
         protected INachoFolderChooserParent owner;
 
-        public void SetOwner (INachoFolderChooserParent owner, bool modal, object cookie)
+        public void SetOwner (INachoFolderChooserParent owner, bool modal, int accountId, object cookie)
         {
             this.owner = owner;
             this.modal = modal;
             this.cookie = cookie;
+            this.accountId = accountId;
         }
 
         public void DismissFolderChooser (bool animated, Action action)
@@ -65,6 +67,7 @@ namespace NachoClient.iOS
             TableView.TableHeaderView = v;
                 
             if (modal) {
+                NcAssert.False (0 == accountId);
                 var navBar = new UINavigationBar (new CGRect (0, 20, View.Frame.Width, 44));
                 navBar.BarStyle = UIBarStyle.Default;
                 navBar.Translucent = false;
@@ -98,6 +101,7 @@ namespace NachoClient.iOS
                 switchAccountButton = new SwitchAccountButton (switchAccountButtonPressed);
                 switchAccountButton.SetAccountImage (NcApplication.Instance.Account);
                 NavigationItem.TitleView = switchAccountButton;
+                accountId = NcApplication.Instance.Account.Id;
             }
         }
 
@@ -106,15 +110,16 @@ namespace NachoClient.iOS
             base.ViewWillAppear (animated);
 
             if (null == folderTableViewSource) {
-                folderTableViewSource = new FolderTableViewSource (NcApplication.Instance.Account.Id, hideFakeFolders: modal);
+                folderTableViewSource = new FolderTableViewSource (accountId, hideFakeFolders: modal);
                 TableView.Source = folderTableViewSource;
                 TableView.ReloadData ();
             } else {
-                folderTableViewSource.Refresh (NcApplication.Instance.Account.Id);
+                folderTableViewSource.Refresh (accountId);
                 TableView.ReloadData ();
             }
 
             if (null != switchAccountButton) {
+                NcAssert.False (modal);
                 switchAccountButton.SetAccountImage (NcApplication.Instance.Account);
             }
 
@@ -134,6 +139,7 @@ namespace NachoClient.iOS
 
         void FolderTableViewSource_OnAccountSelected (object sender, McAccount account)
         {
+            NcAssert.False (modal);
             FolderLists.SetDefaultAccount (account.Id);
             folderTableViewSource.Refresh (NcApplication.Instance.Account.Id);
             TableView.ReloadData ();
@@ -178,6 +184,8 @@ namespace NachoClient.iOS
 
         void SwitchToAccount (McAccount account)
         {
+            NcAssert.False (modal);
+            accountId = account.Id;
             switchAccountButton.SetAccountImage (account);
             folderTableViewSource.Refresh (NcApplication.Instance.Account.Id);
             TableView.ReloadData ();
@@ -220,6 +228,7 @@ namespace NachoClient.iOS
 
         private void ComposeMessage ()
         {
+            NcAssert.False (modal);
             var account = McAccount.EmailAccountForAccount (NcApplication.Instance.Account);
             var composeViewController = new MessageComposeViewController (account);
             composeViewController.Present ();

--- a/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoFolderChooser.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Interfaces/INachoFolderChooser.cs
@@ -8,7 +8,7 @@ namespace NachoClient.iOS
 {
     public interface INachoFolderChooser
     {
-        void SetOwner (INachoFolderChooserParent owner, bool modal, object cookie);
+        void SetOwner (INachoFolderChooserParent owner, bool modal, int accountId, object cookie);
 
         void DismissFolderChooser (bool animated, Action action);
     }

--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -490,7 +490,23 @@ namespace NachoClient.iOS
             if (segue.Identifier == "MessageListToFolders") {
                 var vc = (INachoFolderChooser)segue.DestinationViewController;
                 var h = sender as SegueHolder;
-                vc.SetOwner (this, true, h);
+                int accountId = 0;
+                if (h.value is McEmailMessage) {
+                    accountId = ((McEmailMessage)h.value).AccountId;
+                }
+                if (h.value is McEmailMessageThread) {
+                    var message = ((McEmailMessageThread)h.value).FirstMessage ();
+                    if (null == message) {
+                        return;
+                    }
+                    accountId = message.AccountId;
+                }
+                if (h.value is UITableView) {
+                    accountId = messageSource.MultiSelectAccount (h.value as UITableView);
+                }
+                // TODO: Multiselect?
+                NcAssert.False (0 == accountId);
+                vc.SetOwner (this, true, accountId, h);
                 return;
             }
             if (segue.Identifier == "NachoNowToEditEvent") {
@@ -579,7 +595,7 @@ namespace NachoClient.iOS
         /// </summary>
         public void DismissChildFolderChooser (INachoFolderChooser vc)
         {
-            vc.SetOwner (null, false, null);
+            vc.SetOwner (null, false, 0, null);
             vc.DismissFolderChooser (false, null);
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -66,6 +66,7 @@ namespace NachoClient.iOS
 
 
 
+
 #else
         const int VIEW_INSET = 0;
         const int ATTACHMENTVIEW_INSET = 15;
@@ -132,7 +133,7 @@ namespace NachoClient.iOS
             // it is about to be popped?  Catch & avoid that case.
             var message = thread.FirstMessageSpecialCase ();
             if (null != message) {
-                if (!NcApplication.Instance.Account.ContainsAccount(message.AccountId)) {
+                if (!NcApplication.Instance.Account.ContainsAccount (message.AccountId)) {
                     Log.Error (Log.LOG_UI, "MessageViewController mismatched accounts {0} {1}.", NcApplication.Instance.Account.Id, message.AccountId);
                     if (null != NavigationController) {
                         NavigationController.PopViewController (false);
@@ -676,7 +677,10 @@ namespace NachoClient.iOS
             }
             if (segue.Identifier == "MessageViewToFolders") {
                 var vc = (INachoFolderChooser)segue.DestinationViewController;
-                vc.SetOwner (this, true, thread);
+                var message = thread.FirstMessage ();
+                if (null != message) {
+                    vc.SetOwner (this, true, message.Id, thread);
+                }
                 return;
             }
             if (segue.Identifier == "MessageViewToEditEvent") {
@@ -792,7 +796,7 @@ namespace NachoClient.iOS
         public void FolderSelected (INachoFolderChooser vc, McFolder folder, object cookie)
         {
             MoveThisMessage (folder);
-            vc.SetOwner (null, false, null);
+            vc.SetOwner (null, false, 0, null);
             vc.DismissFolderChooser (false, new Action (delegate {
                 NavigationController.PopViewController (true);
             }));

--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -73,7 +73,7 @@ namespace NachoClient.iOS
         protected void EndRefreshingOnUIThread (object sender)
         {
             NachoPlatform.InvokeOnUIThread.Instance.Invoke (() => {
-                if (refreshControl.Refreshing){
+                if (refreshControl.Refreshing) {
                     refreshControl.EndRefreshing ();
                 }
             });
@@ -130,7 +130,7 @@ namespace NachoClient.iOS
             hotEventView = new HotEventView (new CGRect (0, 0, View.Frame.Width, 69));
             View.AddSubview (hotEventView);
 
-            hotListView = new UITableView (new CGRect(0, hotEventView.Frame.Bottom, View.Frame.Width, View.Frame.Height - hotEventView.Frame.Bottom), UITableViewStyle.Plain);
+            hotListView = new UITableView (new CGRect (0, hotEventView.Frame.Bottom, View.Frame.Width, View.Frame.Height - hotEventView.Frame.Bottom), UITableViewStyle.Plain);
             hotListView.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
             hotListView.BackgroundColor = A.Color_NachoBackgroundGray;
             hotListView.DecelerationRate = UIScrollView.DecelerationRateFast;
@@ -271,7 +271,7 @@ namespace NachoClient.iOS
                 Log.Error (Log.LOG_UI, "MaybeSwitchToNotificationAccount: no account for {0}", obj.Id);
                 return false;
             }
-            if (NcApplication.Instance.Account.ContainsAccount(notificationAccount.Id)){
+            if (NcApplication.Instance.Account.ContainsAccount (notificationAccount.Id)) {
                 return true;
             }
             NcApplication.Instance.Account = notificationAccount;
@@ -322,7 +322,19 @@ namespace NachoClient.iOS
             } else if (segue.Identifier == "NachoNowToFolders") {
                 var vc = (INachoFolderChooser)segue.DestinationViewController;
                 var h = sender as SegueHolder;
-                vc.SetOwner (this, true, h);
+                int accountId = 0;
+                if (h.value is McEmailMessage) {
+                    accountId = ((McEmailMessage)h.value).AccountId;
+                }
+                if (h.value is McEmailMessageThread) {
+                    var message = ((McEmailMessageThread)h.value).FirstMessage ();
+                    if (null == message) {
+                        return;
+                    }
+                    accountId = message.AccountId;
+                }
+                NcAssert.False (0 == accountId);
+                vc.SetOwner (this, true, accountId, h);
             } else {
                 Log.Info (Log.LOG_UI, "Unhandled segue identifer {0}", segue.Identifier);
                 NcAssert.CaseError ();
@@ -472,7 +484,7 @@ namespace NachoClient.iOS
             if (null != calendarInvite) {
                 var account = McAccount.EmailAccountForCalendar (calendarInvite);
                 var composeViewController = new MessageComposeViewController (account);
-                composeViewController.Composer.RelatedCalendarItem  = calendarInvite;
+                composeViewController.Composer.RelatedCalendarItem = calendarInvite;
                 composeViewController.Composer.Message = McEmailMessage.MessageWithSubject (account, "Fwd: " + calendarInvite.Subject);
                 composeViewController.Present ();
 
@@ -510,7 +522,7 @@ namespace NachoClient.iOS
         /// </summary>
         public void DismissChildFolderChooser (INachoFolderChooser vc)
         {
-            vc.SetOwner (null, false, null);
+            vc.SetOwner (null, false, 0, null);
             vc.DismissFolderChooser (false, null);
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/Support/IMessageTableViewSourceDelegate.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/IMessageTableViewSourceDelegate.cs
@@ -30,6 +30,8 @@ namespace NachoClient.iOS
 
         void MultiSelectToggle (UITableView tableView);
 
+        int MultiSelectAccount (UITableView tableview);
+
         bool RefreshEmailMessages (out List<int> adds, out List<int> deletes);
 
         void BackgroundRefreshEmailMessages (NachoMessagesRefreshCompletionDelegate completionAction);

--- a/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
+++ b/NachoClient.iOS/NachoUI.iOS/Support/MessageTableViewSource.cs
@@ -10,6 +10,7 @@ using NachoCore.Model;
 using NachoCore;
 using NachoCore.Utils;
 using NachoCore.Brain;
+using System.Linq;
 
 namespace NachoClient.iOS
 {
@@ -449,7 +450,7 @@ namespace NachoClient.iOS
             MultiSelectToggle (tableView);
         }
 
-        void UpdateMultiSelectAccounts(McEmailMessageThread messageThread, int delta)
+        void UpdateMultiSelectAccounts (McEmailMessageThread messageThread, int delta)
         {
             var message = messageThread.FirstMessage ();
             if (null == message) {
@@ -467,6 +468,12 @@ namespace NachoClient.iOS
                 NcAssert.True (1 == delta);
                 MultiSelectAccounts.Add (message.AccountId, delta);
             }
+        }
+
+        public int MultiSelectAccount (UITableView tableView)
+        {
+            NcAssert.True (1 == MultiSelectAccounts.Count);
+            return MultiSelectAccounts.Keys.First<int> ();
         }
 
         /// <summary>
@@ -917,7 +924,7 @@ namespace NachoClient.iOS
                     }
                 }
             }
-            if (null != headerText && null != messageThreads && messageThreads.HasFilterSemantics()) {
+            if (null != headerText && null != messageThreads && messageThreads.HasFilterSemantics ()) {
                 headerText.Text = Folder_Helpers.FilterString (messageThreads.FilterSetting);
             }
         }


### PR DESCRIPTION
It should be visible only for Mail folder selection.
