### PR TITLE
get the cropped contact picture on iOS

### DIFF
--- a/NachoClient.Android/NachoClient.Android.csproj
+++ b/NachoClient.Android/NachoClient.Android.csproj
@@ -666,6 +666,7 @@
     <Compile Include="NachoCore\Model\Migration\NcMigration53.cs" />
     <Compile Include="NachoCore\Model\Migration\NcMigration54.cs" />
     <Compile Include="NachoCore\Utils\TelemetryJsonFileTable.cs" />
+    <Compile Include="NachoCore\Model\Migration\NcMigration55.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Properties\AndroidManifest.xml" />

--- a/NachoClient.Android/NachoCore/Model/Migration/NcMigration55.cs
+++ b/NachoClient.Android/NachoCore/Model/Migration/NcMigration55.cs
@@ -1,0 +1,30 @@
+﻿//  Copyright (C) 2015 Nacho Cove, Inc. All rights reserved.
+//
+using System;
+using NachoCore.Model;
+using NachoCore;
+using System.IO;
+
+namespace NachoClient.AndroidClient
+{
+    public class NcMigration55 : NcMigration
+    {
+        public NcMigration55 ()
+        {
+        }
+
+        public override int GetNumberOfObjects ()
+        {
+            return 1;
+        }
+
+        public override void Run (System.Threading.CancellationToken token)
+        {
+            if (NachoPlatform.Device.Instance.BaseOs () == NachoPlatform.OsCode.iOS) {
+                var deviceAccount = McAccount.GetDeviceAccount ();
+                NcModel.Instance.Db.Execute ("UPDATE McContact SET DeviceLastUpdate = 0 WHERE AccountId = ? AND PortraitId != 0", deviceAccount.Id);
+            }
+        }
+    }
+}
+

--- a/NachoClient.iOS/NachoClient.iOS.csproj
+++ b/NachoClient.iOS/NachoClient.iOS.csproj
@@ -1831,6 +1831,9 @@
     <Compile Include="..\NachoClient.Android\NachoCore\Utils\TelemetryJsonFileTable.cs">
       <Link>NachoCore\Utils\TelemetryJsonFileTable.cs</Link>
     </Compile>
+    <Compile Include="..\NachoClient.Android\NachoCore\Model\Migration\NcMigration55.cs">
+      <Link>NachoCore\Model\Migration\NcMigration55.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\HomePageController.xib" />

--- a/NachoClient.iOS/NachoPlatform.iOS/ContactsiOS.cs
+++ b/NachoClient.iOS/NachoPlatform.iOS/ContactsiOS.cs
@@ -327,7 +327,7 @@ namespace NachoPlatform
             contact.ServerId = ServerId;
 
             if (Person.HasImage) {
-                var data = Person.GetImage (ABPersonImageFormat.OriginalSize);
+                var data = Person.GetImage (ABPersonImageFormat.Thumbnail);
                 if (null != data) {
                     McPortrait portrait = null;
                     if (0 != contact.PortraitId) {


### PR DESCRIPTION
It's smaller than the original, but still plenty large for our use (a few hundred pixels per edge).

Without this, a lot of contact photos appear squished if they weren't already squares to begin with.

An alternative would be to get the orginal image, the crop box, and crop it ourselves, but I can't find any way to get the crop box

fixes nachocove/qa#1848
