### PR TITLE
Improve code for PerformFetch shutdown and badge/notification

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcResult.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcResult.cs
@@ -129,7 +129,7 @@ namespace NachoCore.Utils
             Error_FolderDeleteFailed,
             Error_FolderUpdateFailed,
             Error_SyncFailed,
-            Error_SyncFailedToComplete,
+            Error_SyncFailedToComplete_Obsolete,
             Error_FolderSyncFailed,
             Error_MeetingResponseFailed,
             Error_ContactSearchCommandFailed,


### PR DESCRIPTION
Several changes to the lifecycle for PerformFetch and to badge count /
message notification code.

Use the iOS background time remaining (rather than a fixed-length
25-second timer) to determine when perform fetch is running out of
time and needs to shut down.

Run the DB queries for badge count / message notification on a
background thread rather than the UI thread.  This prevents a slow
query from causing the app to run past its alotted time.

Update the badge count when the app transitions from foreground to
background, in case the badge count became inaccurate while the app
was in the foreground.
