### PR TITLE
Always run update badge count code in the background

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
@@ -301,7 +301,7 @@ namespace NachoClient.iOS
                 break;
             }
             UnreadCountBlock.SetValue (label);
-            (UIApplication.SharedApplication.Delegate as AppDelegate).UpdateBadge ();
+            (UIApplication.SharedApplication.Delegate as AppDelegate).UpdateBadgeCount ();
         }
 
     }


### PR DESCRIPTION
Make sure that the DB queries to calculate the badge count are always
run on a background thread.  Those queries sometimes take too long to
run on the UI thread.

Rename several methods to have names that are more clear and accurate
(if somewhat longer).

Fix nachocove/qa#1956
