### PR TITLE
Prevent unecessary database locking

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/NcTask.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcTask.cs
@@ -156,13 +156,7 @@ namespace NachoCore.Utils
                 } catch (OperationCanceledException) {
                     Log.Info (Log.LOG_SYS, "NcTask {0} cancelled.", taskName);
                 } finally {
-                    var count = NcModel.Instance.NumberDbConnections;
-                    if (15 < count || longRunning) {
-                        NcModel.Instance.Db = null;
-                        if (15 < count) {
-                            Log.Info (Log.LOG_SYS, "NcTask closing DB, connections: {0}", count);
-                        }
-                    }
+                    NcModel.Instance.Db = null;
                 }
                 if (!stfu) {
                     var finishTime = DateTime.UtcNow;

--- a/NachoClient.Android/NachoCore/Utils/NcTimer.cs
+++ b/NachoClient.Android/NachoCore/Utils/NcTimer.cs
@@ -112,11 +112,7 @@ namespace NachoCore.Utils
                         }
                         localCallback (state);
                         HasFired = true;
-                        int dbCount = NachoCore.Model.NcModel.Instance.NumberDbConnections;
-                        if (15 < dbCount) {
-                            NachoCore.Model.NcModel.Instance.Db = null;
-                            Log.Info (Log.LOG_SYS, "NcTimer {0}/{1} closing DB, connections: {2}", Id, Who, dbCount);
-                        }
+                        NachoCore.Model.NcModel.Instance.Db = null;
                     }
                 }
             };


### PR DESCRIPTION
- Recycle connections instead of destroying and re-creating them
- Rely on the automatic checkpoint instead of constantly running our own

Creating new connections locks the database for all reads.  Previously,
we were constantly destroying and creating connections as tasks and timers stopped and started.
Recycling connections from task to task prevents locking and reduces overhead.
In testing, we seem to end up with about 10 connections max

We were previously running a db checkpoint task every 2 seconds.  We also had configured
sqlite to do its own checkpointing.  Checkpointing can lock the database for reads, so we
should do it infrequently.  The automatic sqlite checkpoint schedule should be sufficient.
