### PR TITLE
Fix missing 'return' for not-enough-time-left quick sync case

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -902,17 +902,18 @@ namespace NachoClient.iOS
             NcMigration.Setup ();
             if (NcMigration.WillStartService ()) {
                 Log.Error (Log.LOG_SYS, "PerformFetch called while migrations still need to run.");
-                FinalizePerformFetch (UIBackgroundFetchResult.NoData); // or UIBackgroundFetchResult.Failed?
+                FinalizePerformFetch (UIBackgroundFetchResult.NoData);
                 return;
             }
             fetchCause = cause;
             fetchResult = UIBackgroundFetchResult.NoData;
 
-            if (10.0 > application.BackgroundTimeRemaining) {
+            if (8.0 > application.BackgroundTimeRemaining) {
                 // Launching the app took up most of the perform fetch window.  There isn't enough
                 // time left to run a full quick sync.
                 Log.Warn (Log.LOG_LIFECYCLE, "Skipping quick sync {0} because only {1:n2} seconds are left.", cause, application.BackgroundTimeRemaining);
-                FinalizePerformFetch (fetchResult);
+                FinalizePerformFetch (UIBackgroundFetchResult.NoData);
+                return;
             }
 
             fetchAccounts = McAccount.GetAllConfiguredNormalAccountIds ();


### PR DESCRIPTION
When a quick sync is started with very little background time
remaining, the app doesn't even try to do the quick sync, since there
is a good chace that it won't finish successfully.  But that code was
missing a 'return' statement, which led to the quick sync happening
anyway, but with a null completion handler, which resulted in a crash
when the quick sync was done.

Fix nachocove/qa#1968
