### PR TITLE
Yet more PerformFetch fixes

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapStrategy/ImapStrategySyncKit.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapStrategy/ImapStrategySyncKit.cs
@@ -520,11 +520,6 @@ namespace NachoCore.IMAP
                         return true;
                     });
                 }
-                var exeCtxt = NcApplication.Instance.ExecutionContext;
-                if (NcApplication.ExecutionContextEnum.QuickSync == exeCtxt) {
-                    // Need to tell the BE that we did what it asked us to, i.e. sync. Even though there's nothing to do.
-                    BEContext.Owner.StatusInd (BEContext.ProtoControl, NcResult.Info (NcResult.SubKindEnum.Info_SyncSucceeded));
-                }
             }
 
             // If there's a pending, resolving it will send the StatusInd, otherwise, we need to send it ourselves.


### PR DESCRIPTION
Improve the logic for detecting when PerformFetch should end and the
handling of the shutdown process.  This fixes a bug where a push
assist that didn't report in time caused the app to shut down without
stopping the back end or unregistering the FetchStatusHandler
listener.

Don't expect to get a push assist event for an account where fast
notification has been disabled.

Don't send duplicate Info_SyncSucceeded events for IMAP accounts.

Start shutting down the app a little bit earlier, when there is still
more time left.  I have seen some cases where the shutdown didn't
complete in time, or was cutting it very close.
