### PR TITLE
Avoid race condition crash in Android foreground/background detector

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Support/LifecycleSpy.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/LifecycleSpy.cs
@@ -68,15 +68,17 @@ namespace NachoClient.AndroidClient
                 if (null == GoToBackgroundTimer) {
                     GoToBackgroundTimer = new NcTimer ("LifecycleSpy:GoToBackgroundTimer", (state) => {
                         lock (BackgroundTimerLock) {
-                            Log.Info (Log.LOG_LIFECYCLE, "LifecycleSpy:GoToBackgroundTimer called.");
-                            GoToBackgroundTimer.Dispose ();
-                            GoToBackgroundTimer = null;
-                            isForeground = false;
-                            NcApplication.Instance.PlatformIndication = NcApplication.ExecutionContextEnum.Background;
-                            LoginHelpers.SetBackgroundTime (DateTime.UtcNow);
-                            Log.Info (Log.LOG_LIFECYCLE, "LifecycleSpy:GoToBackgroundTimer exited.");
+                            if (null != GoToBackgroundTimer) {
+                                Log.Info (Log.LOG_LIFECYCLE, "LifecycleSpy:GoToBackgroundTimer called.");
+                                GoToBackgroundTimer.Dispose ();
+                                GoToBackgroundTimer = null;
+                                isForeground = false;
+                                NcApplication.Instance.PlatformIndication = NcApplication.ExecutionContextEnum.Background;
+                                LoginHelpers.SetBackgroundTime (DateTime.UtcNow);
+                                Log.Info (Log.LOG_LIFECYCLE, "LifecycleSpy:GoToBackgroundTimer exited.");
+                            }
                         }
-                    }, null, new TimeSpan (0, 0, 5), TimeSpan.Zero);
+                    }, null, TimeSpan.FromSeconds (5), TimeSpan.Zero);
                 }
             }
         }


### PR DESCRIPTION
The callback for a timer is not run as soon as the timer fires, but is
queued up to run as a task in the thread pool.  That means the
callback can run after the timer has been disposed.  Fix
GoToBackgroundTimer in class LifecycleSpy to detect this situation and
to handle it gracefully rather than crash.

Fix nachocove/qa#1975
