### PR TITLE
Use NcTask instead of C# Task for badge/notification task

### DIFF
--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -1328,11 +1328,9 @@ namespace NachoClient.iOS
                 // NotificationCanBadge must be called on the UI thread, so it must be called before starting
                 // the task.
                 bool canBadge = NotificationCanBadge;
-                // This task might be running while the app is being shut down.  To avoid NcTask's complaints
-                // about a task still running, use a C# task instead of NcTask.
-                Task.Run (() => {
+                NcTask.Run (() => {
                     BadgeNotificationsTask (canBadge, updateDone);
-                });
+                }, "BadgeCountAndMessageNotifications");
             } else {
                 BadgeNotificationsTask (true, updateDone);
             }


### PR DESCRIPTION
BadgeCountAndMessageNotifications() runs at the same time that the app
is shutting down, so this will result in some warning messages about a
task not completing.  But the change has the benefit of cleaning up
the database connection.  This task was a major source of leaked DB
connections.
