### PR TITLE
Clean up stale DB connections

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Support/LifecycleSpy.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/LifecycleSpy.cs
@@ -75,6 +75,7 @@ namespace NachoClient.AndroidClient
                                 isForeground = false;
                                 NcApplication.Instance.PlatformIndication = NcApplication.ExecutionContextEnum.Background;
                                 LoginHelpers.SetBackgroundTime (DateTime.UtcNow);
+                                NcModel.Instance.CleanupOldDbConnections (TimeSpan.FromMinutes (10), 20);
                                 Log.Info (Log.LOG_LIFECYCLE, "LifecycleSpy:GoToBackgroundTimer exited.");
                             }
                         }

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -675,6 +675,11 @@ namespace NachoClient.iOS
 
             UIApplication.SharedApplication.KeyWindow.AddSubview (imageView);
             UIApplication.SharedApplication.KeyWindow.BringSubviewToFront (imageView);
+
+            NcTask.Run (() => {
+                NcModel.Instance.CleanupOldDbConnections (TimeSpan.FromMinutes (10), 20);
+            }, "CleanupOldDbConnections");
+
             Log.Info (Log.LOG_LIFECYCLE, "DidEnterBackground: Exit");
         }
 


### PR DESCRIPTION
The code that manages database connections was recently revamped.  The
new code is simpler and cleaner.  But it does have the potential to
leak connections over time, which could eventually lead to the app
crashing due to too many open files.

This update adds code to identify and close DB connections that have
been leaked.  The cleanup code does not use a periodic timer (as has
been done in the past).  Instead, the cleanup code runs whenever the
app goes into the background.  The leaks should be slow enough that an
infrequent cleanup like this should be enough.
