### PR TITLE
Move some message list view queries from UI thread to background thread

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -321,15 +321,11 @@ namespace NachoClient.iOS
 
         protected void MaybeRefreshThreads ()
         {
-            bool refreshVisibleCells = true;
-
             if (threadsNeedsRefresh) {
-                using (NcAbate.UIAbatement ()) {
-                    threadsNeedsRefresh = false;
-                    ReloadCapture.Start ();
-                    List<int> adds;
-                    List<int> deletes;
-                    if (messageSource.RefreshEmailMessages (out adds, out deletes)) {
+                threadsNeedsRefresh = false;
+                messageSource.BackgroundRefreshEmailMessages ((bool changed, List<int> adds, List<int> deletes) => {
+                    bool refreshVisibleCells = true;
+                    if (changed) {
                         Util.UpdateTable (TableView, adds, deletes);
                         refreshVisibleCells = false;
                     }
@@ -340,10 +336,11 @@ namespace NachoClient.iOS
                         UpdateSearchResults ();
                         refreshVisibleCells = false;
                     }
-                    ReloadCapture.Stop ();
-                }
-            }
-            if (refreshVisibleCells) {
+                    if (refreshVisibleCells) {
+                        messageSource.ReconfigureVisibleCells (TableView);
+                    }
+                });
+            } else {
                 messageSource.ReconfigureVisibleCells (TableView);
             }
         }


### PR DESCRIPTION
For some of the message list views on iOS, the database queries that
retrieve the list of messages to display have been moved from the UI
thread to a background thread.  This was done for the unified inbox
and for any view of a single folder (including a single-account
inbox).  These queries are usually fast, but sometimes they can be
slow enough to cause problems if run on the UI thread.  Other message
list views, such as deferred messages or a single thread, still run
their queries on the UI thread.
