### PR TITLE
don't prefill password during account creation

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/StandardCredentialsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/StandardCredentialsViewController.cs
@@ -49,12 +49,6 @@ namespace NachoClient.iOS
             if (Account != null) {
                 Service = Account.AccountService;
                 emailField.Text = Account.EmailAddr;
-                var creds = McCred.QueryByAccountId<McCred> (Account.Id).Single ();
-                try {
-                    passwordField.Text = creds.GetPassword ();
-                } catch (KeychainItemNotFoundException ex) {
-                    Log.Error (Log.LOG_UI, "KeychainItemNotFoundException {0}", ex.Message);
-                }
             }
             passwordField.WeakDelegate = this;
             accountIconView.Layer.CornerRadius = accountIconView.Frame.Size.Width / 2.0f;


### PR DESCRIPTION
There dones't seem to be a use case where prefilling makes sense during
account creation
