### PR TITLE
Only reindex a contact when doing so would be useful

### DIFF
--- a/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
+++ b/NachoClient.Android/NachoCore/Model/McContact/McContact.cs
@@ -898,7 +898,9 @@ namespace NachoCore.Model
                     // Re-index the contact. Must do this after the contact update because
                     // re-indexing has a contact update (for updating IndexVersion) and
                     // doing this before contact update would set up a race.
-                    NcBrain.ReindexContact (this);
+                    if (!this.IsGleaned () && ContactIndexDocument.Version == this.IndexVersion) {
+                        NcBrain.ReindexContact (this);
+                    }
                 });
                 return retval;
             }


### PR DESCRIPTION
Create a REINDEX_CONTACT event for the brain only when the contact is
not gleaned and has already been indexed.  The REINDEX_CONTACT event
is not useful in other situations, and too many of them can result in
the brain ignoring its other work, like scoring messages.
