### PR TITLE
Run ILoginEvents on UI thread

### DIFF
--- a/NachoClient.Android/NachoCore/Utils/LoginProtocolControl.cs
+++ b/NachoClient.Android/NachoCore/Utils/LoginProtocolControl.cs
@@ -147,8 +147,13 @@ namespace NachoCore.Utils
         private static void NetStatusCallback (object sender, NachoPlatform.NetStatusEventArgs nsea)
         {
             if (nsea.Status == NachoPlatform.NetStatusStatusEnum.Down) {
-                LogAndCall (nsea.Status.ToString (), () => {
-                    _Owner.NetworkDown ();
+                // ILoginEvents methods need to be called on the UI thread because the event handler
+                // may manipulate UI objects.  Most of the time the caller is already on the UI thread,
+                // but this is the one place I have found where that is not the case.
+                NachoPlatform.InvokeOnUIThread.Instance.Invoke (() => {
+                    LogAndCall (nsea.Status.ToString (), () => {
+                        _Owner.NetworkDown ();
+                    });
                 });
             }
         }


### PR DESCRIPTION
ILoginEvents.NetworkDown() was sometimes invoked on a background
thread.  This caused a crash when the method tried to change some UI
objects.  Fix the code so this method is always run on the UI thread.

Fix nachocove/qa#1987
