### PR TITLE
The default calendar should always be a Gregorian calendar

### DIFF
--- a/NachoClient.Android/NachoUI.Android/MainApplication.cs
+++ b/NachoClient.Android/NachoUI.Android/MainApplication.cs
@@ -68,6 +68,8 @@ namespace NachoClient.AndroidClient
 
             Log.Info (Log.LOG_LIFECYCLE, "OneTimeStartup: {0}", caller);
 
+            NcApplication.GuaranteeGregorianCalendar ();
+
             // This creates the NcApplication object
             NcApplication.Instance.PlatformIndication = NcApplication.ExecutionContextEnum.Foreground;
 

--- a/NachoClient.iOS/AppDelegate.cs
+++ b/NachoClient.iOS/AppDelegate.cs
@@ -287,6 +287,10 @@ namespace NachoClient.iOS
         // It gets called once during the app lifecycle.
         public override bool FinishedLaunching (UIApplication application, NSDictionary launchOptions)
         {
+            Log.Info (Log.LOG_LIFECYCLE, "FinishedLaunching: Called");
+
+            NcApplication.GuaranteeGregorianCalendar ();
+
             // move data files to Documents/Data if needed
             NachoPlatform.DataFileMigration.MigrateDataFilesIfNeeded ();
             // One-time initialization that do not need to be shut down later.
@@ -318,7 +322,6 @@ namespace NachoClient.iOS
 
             NcApplication.Instance.ContinueRemoveAccountIfNeeded ();
 
-            Log.Info (Log.LOG_LIFECYCLE, "FinishedLaunching: Called");
             NcApplication.Instance.PlatformIndication = NcApplication.ExecutionContextEnum.Background;
 
             NcApplication.Instance.StartBasalServices ();


### PR DESCRIPTION
In some locales, the C# runtime insists on using a non-Gregorian
calendar.  Examples are the Um Al Qura Islamic calendar for "Arabic
(Saudi Arabia)", and a Buddhist calendar for "Thai (Thailand)".  The
language/regional/calendar settings in the C# runtime do not always
match the operating system settings.  Even if C# wants to use an
Islamic calendar, iOS is likely using a Gregorian calendar in the rest
of the apps on the device.

On both iOS and Android, add code that runs immediately after launch
that checks the default calendar and changes it as necessary to be a
Gregorian calendar.  Because the C# runtime limits the flexibility of
locale behavior, changing the default calendar is easier said than
done.  It usually requires changing the entire locale.

Because this is a C# runtime problem, the code to fix up the default
calendar is common to all platforms.  But it has to be invoked from
OS-specific code, since it has to happen very early in the app's
lifecycle.

Fix nachocove/qa#2013
