### PR TITLE
Message view swipe actions are now responsive and don't pause

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NachoDraftMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoDraftMessages.cs
@@ -29,6 +29,7 @@ namespace NachoCore
         {
             var list = McEmailMessage.QueryActiveMessageItems (folder.AccountId, folder.Id, false);
             var threads = NcMessageThreads.ThreadByMessage (list);
+            RemoveIgnoredMessages (threads);
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
                 threadList = threads;
                 return true;

--- a/NachoClient.Android/NachoCore/Adapters/NachoFolderMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoFolderMessages.cs
@@ -39,7 +39,9 @@ namespace NachoCore
                 list = McEmailMessage.QueryActiveMessageItems (folder.AccountId, folder.Id);
                 break;
             }
-            return NcMessageThreads.ThreadByConversation (list);
+            var threadList = NcMessageThreads.ThreadByConversation (list);
+            RemoveIgnoredMessages (threadList);
+            return threadList;
         }
 
         public override bool Refresh (out List<int> adds, out List<int> deletes)

--- a/NachoClient.Android/NachoCore/Adapters/NachoLikelyToReadEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoLikelyToReadEmailMessages.cs
@@ -28,6 +28,7 @@ namespace NachoCore
             var list = McEmailMessage.QueryActiveMessageItemsByScore2 (Folder.AccountId, Folder.Id, 
                            McEmailMessage.minHotScore, McEmailMessage.minLikelyToReadScore);
             var threads = NcMessageThreads.ThreadByConversation (list);
+            RemoveIgnoredMessages (threads);
             if (NcMessageThreads.AreDifferent (ThreadList, threads, out adds, out deletes)) {
                 ThreadList = threads;
                 return true;

--- a/NachoClient.Android/NachoCore/Adapters/NachoPriorityEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoPriorityEmailMessages.cs
@@ -29,6 +29,7 @@ namespace NachoCore
             // When that happens, lower the threshold until we found something
             var list = McEmailMessage.QueryActiveMessageItemsByScore (folder.AccountId, folder.Id, threshold);
             var threads = NcMessageThreads.ThreadByConversation (list);
+            RemoveIgnoredMessages (threads);
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
                 threadList = threads;
                 return true;

--- a/NachoClient.Android/NachoCore/Adapters/NachoThreadedEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoThreadedEmailMessages.cs
@@ -31,6 +31,7 @@ namespace NachoCore
         {
             var list = McEmailMessage.QueryActiveMessageItemsByThreadId (folder.AccountId, folder.Id, threadId);
             var threads = NcMessageThreads.ThreadByMessage (list);
+            RemoveIgnoredMessages (threads);
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
                 threadList = threads;
                 return true;

--- a/NachoClient.Android/NachoCore/Adapters/NachoUnifiedHotList.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoUnifiedHotList.cs
@@ -27,6 +27,7 @@ namespace NachoCore
             // When that happens, lower the threshold until we found something
             var list = McEmailMessage.QueryUnifiedInboxItemsByScore (threshold);
             var threads = NcMessageThreads.ThreadByConversation (list);
+            RemoveIgnoredMessages (threads);
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
                 threadList = threads;
                 return true;

--- a/NachoClient.Android/NachoCore/Adapters/NachoUnifiedInbox.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoUnifiedInbox.cs
@@ -37,7 +37,9 @@ namespace NachoCore
                 list = McEmailMessage.QueryUnifiedInboxItems ();
                 break;
             }
-            return NcMessageThreads.ThreadByConversation (list);
+            var threadList = NcMessageThreads.ThreadByConversation (list);
+            RemoveIgnoredMessages (threadList);
+            return threadList;
         }
 
         public override bool Refresh (out List<int> adds, out List<int> deletes)

--- a/NachoClient.Android/NachoCore/Adapters/NachoUnifiedLikelyToRead.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoUnifiedLikelyToRead.cs
@@ -25,6 +25,7 @@ namespace NachoCore
         {
             var list = McEmailMessage.QueryUnifiedItemsByScore2 (McEmailMessage.minHotScore, McEmailMessage.minLikelyToReadScore);
             var threads = NcMessageThreads.ThreadByConversation (list);
+            RemoveIgnoredMessages (threads);
             if (NcMessageThreads.AreDifferent (ThreadList, threads, out adds, out deletes)) {
                 ThreadList = threads;
                 return true;

--- a/NachoClient.Android/NachoCore/Adapters/UserInteractionEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/UserInteractionEmailMessages.cs
@@ -32,6 +32,7 @@ namespace NachoCore
             }
             var list = McEmailMessage.QueryInteractions (contact.AccountId, contact);
             var threads = NcMessageThreads.ThreadByMessage (list);
+            RemoveIgnoredMessages (threads);
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
                 threadList = threads;
                 return true;
@@ -56,6 +57,7 @@ namespace NachoCore
             NcTask.Run (() => {
                 var rawList = McEmailMessage.QueryInteractions (contact.AccountId, contact);
                 var newThreadList = NcMessageThreads.ThreadByMessage (rawList);
+                RemoveIgnoredMessages (newThreadList);
                 NachoPlatform.InvokeOnUIThread.Instance.Invoke (() => {
                     List<int> adds = null;
                     List<int> deletes = null;


### PR DESCRIPTION
On both iOS and Android, change the message list view code so that the
Delete, Archive, and Move swipe actions are always responsive.  As
soon as the user taps one of those actions, the UI removes the selected
message(s) from the list and returns to its normal state.  Database
changes no longer happen on the UI thread.  The message list is updated
immediately rather than waiting for the status indicator event from
the back end.

Fix nachocove/qa#2041
