### PR TITLE
Avoid crash in NachoEmailMessages.GetCachedMessage()

### DIFF
--- a/NachoClient.Android/NachoCore/Adapters/NachoDraftMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoDraftMessages.cs
@@ -30,6 +30,7 @@ namespace NachoCore
             var list = McEmailMessage.QueryActiveMessageItems (folder.AccountId, folder.Id, false);
             var threads = NcMessageThreads.ThreadByMessage (list);
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
+                ClearCache ();
                 threadList = threads;
                 return true;
             }

--- a/NachoClient.Android/NachoCore/Adapters/NachoFolderMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoFolderMessages.cs
@@ -46,6 +46,7 @@ namespace NachoCore
         {
             var threads = QueryMessagesByConversation ();
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
+                ClearCache ();
                 threadList = threads;
                 return true;
             }
@@ -66,6 +67,7 @@ namespace NachoCore
                     List<int> deletes = null;
                     bool changed = NcMessageThreads.AreDifferent (threadList, newThreadList, out adds, out deletes);
                     if (changed) {
+                        ClearCache ();
                         threadList = newThreadList;
                     }
                     if (null != completionAction) {

--- a/NachoClient.Android/NachoCore/Adapters/NachoLikelyToReadEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoLikelyToReadEmailMessages.cs
@@ -29,6 +29,7 @@ namespace NachoCore
                            McEmailMessage.minHotScore, McEmailMessage.minLikelyToReadScore);
             var threads = NcMessageThreads.ThreadByConversation (list);
             if (NcMessageThreads.AreDifferent (ThreadList, threads, out adds, out deletes)) {
+                ClearCache ();
                 ThreadList = threads;
                 return true;
             }

--- a/NachoClient.Android/NachoCore/Adapters/NachoPriorityEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoPriorityEmailMessages.cs
@@ -17,8 +17,6 @@ namespace NachoCore
         public NachoPriorityEmailMessages (McFolder folder)
         {
             this.folder = folder;
-            List<int> adds;
-            List<int> deletes;
             threadList = new List<McEmailMessageThread> ();
         }
 
@@ -30,6 +28,7 @@ namespace NachoCore
             var list = McEmailMessage.QueryActiveMessageItemsByScore (folder.AccountId, folder.Id, threshold);
             var threads = NcMessageThreads.ThreadByConversation (list);
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
+                ClearCache ();
                 threadList = threads;
                 return true;
             }

--- a/NachoClient.Android/NachoCore/Adapters/NachoThreadedEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoThreadedEmailMessages.cs
@@ -32,6 +32,7 @@ namespace NachoCore
             var list = McEmailMessage.QueryActiveMessageItemsByThreadId (folder.AccountId, folder.Id, threadId);
             var threads = NcMessageThreads.ThreadByMessage (list);
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
+                ClearCache ();
                 threadList = threads;
                 return true;
             }

--- a/NachoClient.Android/NachoCore/Adapters/NachoUnifiedHotList.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoUnifiedHotList.cs
@@ -15,8 +15,6 @@ namespace NachoCore
 
         public NachoUnifiedHotList ()
         {
-            List<int> adds;
-            List<int> deletes;
             threadList = new List<McEmailMessageThread> ();
         }
 
@@ -28,6 +26,7 @@ namespace NachoCore
             var list = McEmailMessage.QueryUnifiedInboxItemsByScore (threshold);
             var threads = NcMessageThreads.ThreadByConversation (list);
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
+                ClearCache ();
                 threadList = threads;
                 return true;
             }

--- a/NachoClient.Android/NachoCore/Adapters/NachoUnifiedInbox.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoUnifiedInbox.cs
@@ -44,6 +44,7 @@ namespace NachoCore
         {
             var threads = QueryMessagesByConversation ();
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
+                ClearCache ();
                 threadList = threads;
                 return true;
             }
@@ -64,6 +65,7 @@ namespace NachoCore
                     List<int> deletes;
                     bool changed = NcMessageThreads.AreDifferent (threadList, newThreadList, out adds, out deletes);
                     if (changed) {
+                        ClearCache ();
                         threadList = newThreadList;
                     }
                     if (null != completionAction) {

--- a/NachoClient.Android/NachoCore/Adapters/NachoUnifiedLikelyToRead.cs
+++ b/NachoClient.Android/NachoCore/Adapters/NachoUnifiedLikelyToRead.cs
@@ -26,6 +26,7 @@ namespace NachoCore
             var list = McEmailMessage.QueryUnifiedItemsByScore2 (McEmailMessage.minHotScore, McEmailMessage.minLikelyToReadScore);
             var threads = NcMessageThreads.ThreadByConversation (list);
             if (NcMessageThreads.AreDifferent (ThreadList, threads, out adds, out deletes)) {
+                ClearCache ();
                 ThreadList = threads;
                 return true;
             }

--- a/NachoClient.Android/NachoCore/Adapters/UserInteractionEmailMessages.cs
+++ b/NachoClient.Android/NachoCore/Adapters/UserInteractionEmailMessages.cs
@@ -27,12 +27,14 @@ namespace NachoCore
             adds = null;
             deletes = null;
             if (null == contact) {
+                ClearCache ();
                 threadList = new List<McEmailMessageThread> ();
                 return true;
             }
             var list = McEmailMessage.QueryInteractions (contact.AccountId, contact);
             var threads = NcMessageThreads.ThreadByMessage (list);
             if (NcMessageThreads.AreDifferent (threadList, threads, out adds, out deletes)) {
+                ClearCache ();
                 threadList = threads;
                 return true;
             }

--- a/NachoClient.Android/NachoCore/Utils/EmailSearch.cs
+++ b/NachoClient.Android/NachoCore/Utils/EmailSearch.cs
@@ -47,6 +47,7 @@ namespace NachoCore.Utils
             lock (serverResultsLock) {
                 serverResults.Clear ();
             }
+            ClearCache ();
             indexResults = new List<MatchedItem> ();
             finalResults = new List<McEmailMessageThread> ();
         }
@@ -240,6 +241,7 @@ namespace NachoCore.Utils
                     var results = new List<McEmailMessageThread> (scoredResults.Select (x => x.thread));
 
                     NachoPlatform.InvokeOnUIThread.Instance.Invoke (() => {
+                        ClearCache ();
                         finalResults = results;
                         updateUi (searchString, results);
                     });

--- a/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageListViewController.cs
@@ -482,7 +482,6 @@ namespace NachoClient.iOS
 
         protected void Reload ()
         {
-            Messages.ClearCache ();
             if (Messages.HasBackgroundRefresh ()) {
                 Log.Info (Log.LOG_UI, "MessageListViewController.Reload: using NachoEmailMessages background refresh");
                 Messages.BackgroundRefresh (HandleReloadResults);
@@ -1149,7 +1148,6 @@ namespace NachoClient.iOS
 
         public void SearchForText (string searchText)
         {
-            SearchResults.ClearCache ();
             SearchResults.SearchFor (searchText);
         }
 

--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -496,7 +496,6 @@ namespace NachoClient.iOS
 
         void ReloadHotMessages ()
         {
-            HotMessages.ClearCache ();
             NcTask.Run (() => {
                 List<int> messageAdds;
                 List<int> messageDeletes;


### PR DESCRIPTION
The NachoEmailMessages cache has to be cleared right when the list of
message threads is changed.  Clearing the cache ahead of time is not
safe enough.

Fix nachocove/qa#2001
