### PR TITLE
Don't crash on startup when user had changed the tabs

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/NachoTabBarController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoTabBarController.cs
@@ -27,6 +27,20 @@ namespace NachoClient.iOS
 
         public NachoTabBarController () : base ()
         {
+        }
+
+        protected UITabBarItem nachoNowItem;
+        protected UITabBarItem settingsItem;
+        protected UITabBarItem foldersItem;
+        protected UITabBarItem deadlinesItem;
+        protected UITabBarItem deferredItem;
+        protected UITabBarItem inboxItem;
+        protected UITabBarItem chatsItem;
+
+        public override void ViewDidLoad ()
+        {
+            base.ViewDidLoad ();
+
             var nowNavController = new UINavigationController (new NachoNowViewController ());
             nachoNowItem = nowNavController.TabBarItem = MakeTabBarItem ("Hot", "nav-hot");
 
@@ -80,19 +94,6 @@ namespace NachoClient.iOS
                 supportNavController,
                 aboutNavController
             };
-        }
-
-        protected UITabBarItem nachoNowItem;
-        protected UITabBarItem settingsItem;
-        protected UITabBarItem foldersItem;
-        protected UITabBarItem deadlinesItem;
-        protected UITabBarItem deferredItem;
-        protected UITabBarItem inboxItem;
-        protected UITabBarItem chatsItem;
-
-        public override void ViewDidLoad ()
-        {
-            base.ViewDidLoad ();
 
             instance = this;
 


### PR DESCRIPTION
NachoTabBarController.RestoreCustomTabBarOrder() depends on code in
NachoTabBarController's constructor.  But RestoreCustomTabBarOrder()
is called indirectly through the base class constructor and therefore
runs before NachoTabBarController's constructor.  This causes a crash
on app startup if the user has changed the tabs at the bottom of the
screen.

To avoid this problem, move all the code from the constructor to
ViewDidLoad().

Fix nachocove/qa#2054
