### PR TITLE
Avoid blank settings view after user uses the back button

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/GeneralSettingsViewController.cs
@@ -94,6 +94,12 @@ namespace NachoClient.iOS
             NcApplication.Instance.StatusIndEvent -= StatusIndicatorCallback;
         }
 
+        // Since this is one of the tabs, this view controller should never be cleaned up.
+        // Override Cleanup() to do nothing.
+        protected override void Cleanup ()
+        {
+        }
+
         #endregion
 
         #region Table Delegate & Data Source

--- a/NachoClient.iOS/NachoUI.iOS/InboxViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/InboxViewController.cs
@@ -35,6 +35,12 @@ namespace NachoClient.iOS
             base.ViewWillAppear (animated);
         }
 
+        // Since this is one of the tabs, this view controller should never be cleaned up.
+        // Override Cleanup() to do nothing.
+        protected override void Cleanup ()
+        {
+        }
+
         void ShowAccountSwitcher ()
         {
             SwitchAccountViewController.ShowDropdown (this, SwitchToAccount);

--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -177,6 +177,12 @@ namespace NachoClient.iOS
             base.ViewDidDisappear (animated);
         }
 
+        // Since this is one of the tabs, this view controller should never be cleaned up.
+        // Override Cleanup() to do nothing.
+        protected override void Cleanup ()
+        {
+        }
+
         #endregion
 
         #region User Actions


### PR DESCRIPTION
Don't run cleanup code for view controllers that are tabs.  Unlike
other view controllers that are created and destroyed, tabs live for
the lifetime of the app and shouldn't be cleaned up.

Fix nachocove/qa#2045
