### PR TITLE
Avoid infinite loop of Sync / FSync commands

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
@@ -473,7 +473,7 @@ namespace NachoCore.ActiveSync
                             new Trans { Event = (uint)AsEvt.E.ReSync, Act = DoNop, State = (uint)Lst.FSync2W },
                             new Trans { Event = (uint)AsEvt.E.ReProv, Act = DoProv, State = (uint)Lst.ProvW },
                             new Trans { Event = (uint)AsEvt.E.AuthFail, Act = DoUiCredReq, State = (uint)Lst.UiPCrdW },
-                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoFSync, State = (uint)Lst.FSyncW },
+                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoReFSync, State = (uint)Lst.FSyncW },
                         }
                     },
 
@@ -501,7 +501,7 @@ namespace NachoCore.ActiveSync
                             new Trans { Event = (uint)AsEvt.E.ReDisc, Act = DoDisc, State = (uint)Lst.DiscW },
                             new Trans { Event = (uint)AsEvt.E.ReProv, Act = DoProv, State = (uint)Lst.ProvW },
                             new Trans { Event = (uint)AsEvt.E.AuthFail, Act = DoUiCredReq, State = (uint)Lst.UiPCrdW },
-                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoFSync, State = (uint)Lst.FSync2W },
+                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoReFSync, State = (uint)Lst.FSync2W },
                         }
                     },
 
@@ -529,7 +529,7 @@ namespace NachoCore.ActiveSync
                             new Trans { Event = (uint)AsEvt.E.ReSync, Act = DoPick, ActSetsState = true },
                             new Trans { Event = (uint)AsEvt.E.ReProv, Act = DoProv, State = (uint)Lst.ProvW },
                             new Trans { Event = (uint)AsEvt.E.AuthFail, Act = DoUiCredReq, State = (uint)Lst.UiPCrdW },
-                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoFSync, State = (uint)Lst.FSyncW },
+                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoReFSync, State = (uint)Lst.FSyncW },
                         }
                     },
 
@@ -557,7 +557,7 @@ namespace NachoCore.ActiveSync
                             new Trans { Event = (uint)AsEvt.E.ReProv, Act = DoProv, State = (uint)Lst.ProvW },
                             new Trans { Event = (uint)AsEvt.E.ReSync, Act = DoSync, State = (uint)Lst.SyncW },
                             new Trans { Event = (uint)AsEvt.E.AuthFail, Act = DoUiCredReq, State = (uint)Lst.UiPCrdW },
-                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoFSync, State = (uint)Lst.FSyncW },
+                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoReFSync, State = (uint)Lst.FSyncW },
                         }
                     },
 
@@ -585,7 +585,7 @@ namespace NachoCore.ActiveSync
                             new Trans { Event = (uint)AsEvt.E.ReProv, Act = DoProv, State = (uint)Lst.ProvW },
                             new Trans { Event = (uint)AsEvt.E.ReSync, Act = DoSync, State = (uint)Lst.SyncW },
                             new Trans { Event = (uint)AsEvt.E.AuthFail, Act = DoUiCredReq, State = (uint)Lst.UiPCrdW },
-                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoFSync, State = (uint)Lst.FSyncW },
+                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoReFSync, State = (uint)Lst.FSyncW },
                         }
                     },
 
@@ -613,7 +613,7 @@ namespace NachoCore.ActiveSync
                             new Trans { Event = (uint)AsEvt.E.ReProv, Act = DoProv, State = (uint)Lst.ProvW },
                             new Trans { Event = (uint)AsEvt.E.ReSync, Act = DoSync, State = (uint)Lst.SyncW },
                             new Trans { Event = (uint)AsEvt.E.AuthFail, Act = DoUiCredReq, State = (uint)Lst.UiPCrdW },
-                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoFSync, State = (uint)Lst.FSyncW },
+                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoReFSync, State = (uint)Lst.FSyncW },
                         }
                     },
 
@@ -641,7 +641,7 @@ namespace NachoCore.ActiveSync
                             new Trans { Event = (uint)AsEvt.E.ReProv, Act = DoProv, State = (uint)Lst.ProvW },
                             new Trans { Event = (uint)AsEvt.E.ReSync, Act = DoSync, State = (uint)Lst.SyncW },
                             new Trans { Event = (uint)AsEvt.E.AuthFail, Act = DoUiCredReq, State = (uint)Lst.UiPCrdW },
-                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoFSync, State = (uint)Lst.FSyncW },
+                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoReFSync, State = (uint)Lst.FSyncW },
                         }
                     },
 
@@ -669,7 +669,7 @@ namespace NachoCore.ActiveSync
                             new Trans { Event = (uint)AsEvt.E.ReDisc, Act = DoDisc, State = (uint)Lst.DiscW },
                             new Trans { Event = (uint)AsEvt.E.ReProv, Act = DoProv, State = (uint)Lst.ProvW },
                             new Trans { Event = (uint)AsEvt.E.ReSync, Act = DoSync, State = (uint)Lst.SyncW },
-                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoFSync, State = (uint)Lst.FSyncW },
+                            new Trans { Event = (uint)CtlEvt.E.ReFSync, Act = DoReFSync, State = (uint)Lst.FSyncW },
                         }
                     },
 
@@ -909,6 +909,12 @@ namespace NachoCore.ActiveSync
         {
             SetCmd (new AsFolderSyncCommand (this));
             ExecuteCmd ();
+        }
+
+        private void DoReFSync ()
+        {
+            FolderReSyncHappened ();
+            DoFSync ();
         }
 
         private void DoNopOrPick ()
@@ -1223,6 +1229,30 @@ namespace NachoCore.ActiveSync
                 if (PushAssist.IsStartOrParked ()) {
                     PushAssist.Execute ();
                 }
+            }
+        }
+
+        // A server has been encountered that repeatedly sends a sync response status of FolderChange_12,
+        // but the ensuing FolderSync command doesn't return any changes to the folder structure.
+        // Keep track of the number of folder resync requests that happen without any folder changes,
+        // so the Sync/FSync looping can be stopped before it goes on too long.
+        // https://github.com/nachocove/qa/issues/2057
+
+        private int FolderReSyncCount = 0;
+
+        public void FolderReSyncHappened ()
+        {
+            ++FolderReSyncCount;
+        }
+
+        public void ResetFolderReSyncCount ()
+        {
+            FolderReSyncCount = 0;
+        }
+
+        public bool TooManyFolderReSyncs {
+            get {
+                return 5 < FolderReSyncCount;
             }
         }
 

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderSyncCommand/AsFolderSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsFolderSyncCommand/AsFolderSyncCommand.cs
@@ -41,7 +41,9 @@ namespace NachoCore.ActiveSync
                 target.AsLastFolderSync = DateTime.UtcNow;
                 return true;
             });
+
             switch (status) {
+
             case Xml.FolderHierarchy.FolderSyncStatusCode.Success_1:
                 var syncKey = doc.Root.Element (m_ns + Xml.FolderHierarchy.SyncKey).Value;
                 Log.Info (Log.LOG_AS, "{0}: process response: SyncKey={1}", CmdNameWithAccount, syncKey);
@@ -118,6 +120,7 @@ namespace NachoCore.ActiveSync
 
                 if (HadFolderChanges) {
                     BEContext.ProtoControl.StatusInd (NcResult.Info (NcResult.SubKindEnum.Info_FolderSetChanged));
+                    ((AsProtoControl)BEContext.ProtoControl).ResetFolderReSyncCount ();
                 }
                 return Event.Create ((uint)SmEvt.E.Success, "FSYNCSUCCESS");
 

--- a/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/ActiveSync/Commands/AsSyncCommand/AsSyncCommand.cs
@@ -375,7 +375,16 @@ namespace NachoCore.ActiveSync
             if (null != globEvent) {
                 return globEvent;
             }
-            switch ((Xml.AirSync.StatusCode)status) {
+
+            var adjustedStatus = (Xml.AirSync.StatusCode)status;
+            if (Xml.AirSync.StatusCode.FolderChange_12 == adjustedStatus && ((AsProtoControl)BEContext.ProtoControl).TooManyFolderReSyncs) {
+                // The server keeps sending FolderChange responses, but doesn't send any actual folder changes.
+                // To avoid looping forever, pretend that the status is Success.
+                adjustedStatus = Xml.AirSync.StatusCode.Success_1;
+            }
+
+            switch (adjustedStatus) {
+
             case Xml.AirSync.StatusCode.Success_1:
                 return null;
 


### PR DESCRIPTION
Detect a cycle of Sync / FSync commands that are not accomplishing
anything, and break the cycle.  This protects against misbehaving
ActiveSync servers that either send sync status of FolderChange_12
when they shouldn't or don't send folder changes when they should.

It is unknown if anything useful can be done with the account when the
app ignores the sync status FolderChange_12.  It may be that nothing
can be synched.  But at least it won't go into an infinite loop.

Fix nachocove/qa#2057
