### PR TITLE
change idle timeout to 4.5 minutes, as gmail seems to close the connection after 5 minutes

### DIFF
--- a/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapProtoControl.cs
+++ b/NachoClient.Android/NachoCore/BackEnd/IMAP/ImapProtoControl.cs
@@ -983,7 +983,9 @@ namespace NachoCore.IMAP
                     // but I've found that Google Mail will drop connections after a little under 10, so my recommendation is that you
                     // cancel the doneToken within roughly 9-10 minutes and then loop back to calling Idle() again.
                     //var timeout = new TimeSpan(0, 9, 0);
-                    return new TimeSpan(0, 9, 0);
+                    //
+                    // UPDATE: Based on my tests, gmail seems to drop the connection after 5 minutes now.
+                    return new TimeSpan(0, 4, 30);
                 } else {
                     return new TimeSpan(0, 30, 0);
                 }


### PR DESCRIPTION
Recent tests (while debugging some pinger code) I noticed that we were getting i/o timeouts from gmail after exactly 5 minutes:

```
2016-05-06T14:04:15.846 DEBUG imap.go:416:getServerResponses |device=Ncho3C15C2C87C063C15C2C87C06|client=us-east-1:73d79113-6a9f-42f4-9bc5-0926c410b23f|context=f84c4725|session=1951bc0fcd25d9d6|protocol=IMAP|tag=LGTXE:3|message=IDLE Command|timeout=0
2016-05-06T14:04:15.847 DEBUG imap.go:451:getServerResponse |device=Ncho3C15C2C87C063C15C2C87C06|client=us-east-1:73d79113-6a9f-42f4-9bc5-0926c410b23f|context=f84c4725|session=1951bc0fcd25d9d6|protocol=IMAP|tag=LGTXE:3|message=Getting server response|timeout=0

2016-05-06T14:09:15.744 DEBUG imap.go:467:getServerResponse |device=Ncho3C15C2C87C063C15C2C87C06|client=us-east-1:73d79113-6a9f-42f4-9bc5-0926c410b23f|context=f84c4725|session=1951bc0fcd25d9d6|protocol=IMAP|tag=LGTXE:3|message=Timeout error|err=read tcp 173.194.203.108:993: i/o timeout
```

So I'm adjusting the time we wait, so we don't sit and wait on a closed socket (MailKit isn't as good at detecting the closed connection as go is).
