### PR TITLE
Don't crash when user enters a really invalid chat address

### DIFF
--- a/NachoClient.Android/NachoUI.Android/Support/EmailAddressField.cs
+++ b/NachoClient.Android/NachoUI.Android/Support/EmailAddressField.cs
@@ -100,7 +100,9 @@ namespace NachoClient.AndroidClient
                     }
                 } else {
                     var mailbox = wrapper.EmailAddress.ToMailboxAddress ();
-                    if (!String.IsNullOrEmpty (mailbox.Name)) {
+                    if (null == mailbox) {
+                        textView.Text = wrapper.EmailAddress.address;
+                    } else if (!String.IsNullOrEmpty (mailbox.Name)) {
                         textView.Text = mailbox.Name;
                     } else {
                         textView.Text = mailbox.Address;

--- a/NachoClient.iOS/NachoUI.iOS/ChatMessagesViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ChatMessagesViewController.cs
@@ -568,8 +568,8 @@ namespace NachoClient.iOS
             }else if (String.Equals (address.address, Account.EmailAddr, StringComparison.OrdinalIgnoreCase)) {
                 NcAlertView.ShowMessage (NavigationController.TopViewController, "Cannot Add Self", String.Format ("Sorry, but it's not possible to setup a chat with yourself ({0})", Account.EmailAddr));
             } else {
-                var mailbox = MimeKit.MailboxAddress.Parse (address.address);
-                if (mailbox == null) {
+                MimeKit.MailboxAddress mailbox;
+                if (!MimeKit.MailboxAddress.TryParse (address.address, out mailbox) || null == mailbox) {
                     NcAlertView.ShowMessage (NavigationController.TopViewController, "Invalid Email Address", String.Format ("Sorry, the email address you provided does not appear to be valid."));
                 } else {
                     if (Chat != null) {
@@ -577,7 +577,7 @@ namespace NachoClient.iOS
                         ReloadMessages ();
                         HeaderView.ToView.Clear ();
                         foreach (var participant in ParticipantsByEmailId.Values) {
-                            var participantAddress = new NcEmailAddress(NcEmailAddress.Kind.To, participant.EmailAddress);
+                            var participantAddress = new NcEmailAddress (NcEmailAddress.Kind.To, participant.EmailAddress);
                             HeaderView.ToView.Append (participantAddress);
                         }
                         ParticipantsByEmailId = null;


### PR DESCRIPTION
Both iOS and Android would crash if the user entered a chat address
with unbalanced quote marks.  (There are probably other kinds of bad
addresses that would cause a crash, but I didn't try to find them
all.)  Fix the problem on both platforms.

Fix nachocove/qa#2059
