### PR TITLE
fix race condition causing blank inbox

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/ChatsViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/ChatsViewController.cs
@@ -309,6 +309,7 @@ namespace NachoClient.iOS
             Chats.Clear ();
             UnreadCountsByChat.Clear ();
             NewChatButton.Enabled = account.HasCapability (McAccount.AccountCapabilityEnum.EmailSender);
+            SetNeedsReload ();
         }
 
         #endregion

--- a/NachoClient.iOS/NachoUI.iOS/InboxViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/InboxViewController.cs
@@ -24,6 +24,9 @@ namespace NachoClient.iOS
             SwitchAccountButton = new SwitchAccountButton (ShowAccountSwitcher);
             NavigationItem.TitleView = SwitchAccountButton;
             SwitchAccountButton.SetAccountImage (Account);
+            if (NcApplication.Instance.Account.Id != Account.Id) {
+                SwitchToAccount (NcApplication.Instance.Account);
+            }
             base.ViewDidLoad ();
         }
 
@@ -55,7 +58,7 @@ namespace NachoClient.iOS
             UpdateFilterBar ();
             TableView.ReloadData ();  // to clear the table
             HasLoadedOnce = false;
-            // Relying on ViewWillAppear to call Reload
+            SetNeedsReload ();
         }
 
         protected override void UpdateNavigationItem ()

--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -126,6 +126,10 @@ namespace NachoClient.iOS
             EmptyView.Hidden = true;
             View.AddSubview (EmptyView);
 
+            if (NcApplication.Instance.Account.Id != Account.Id) {
+                SwitchToAccount (NcApplication.Instance.Account);
+            }
+
             ReloadHotMessages ();
             ReloadCalendar ();
         }
@@ -1274,7 +1278,7 @@ namespace NachoClient.iOS
             ExtraActionRows = 0;
             TableView.ReloadData (); // to clear table so we don't show stale data from other account
             HasLoadedOnce = false;
-            // Relying on ViewWillAppear to do any reloading
+            SetNeedsReload ();
         }
 
         private void ComposeResponse (McEmailMessageThread thread, EmailHelper.Action action)


### PR DESCRIPTION
Here's what would happen:
- inbox controller would construct and note the current account
- user would switch accounts before viewing inbox
- user would view inbox
- viewDidLoad would run and call Reload using the old account
- viewWillAppear would run and notice the account difference and call SwitchToAccount
- SwitchToAccoutn would blank out the message source (by creating a new one)
- SwitchToAccount would expect viewWillAppear to call Reload
- viewWillAppear doesn't call Reload on first load because we want to call it as early as possible (in viewDidLoad)
- HandleReload would run and see an empty source

The first fix checks the account in viewDidLoad and switches if necessary before the first Reload.  This fixes the race
condition described above.

The second fix, calling SetNeedsReload in SwitchToAccount, makes sure that if a reload is pending while the user switches
accounts, another reload will be queued.  It also has the effect of preemptnig the Reload in viewDidLoad or viewDidAppear
when they notice an account difference, but it's not a problem to call reload a few lines earlier in those cases.
