### PR TITLE
fix hot delete crash

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/NachoNowViewController.cs
@@ -281,12 +281,7 @@ namespace NachoClient.iOS
                     NcEmailArchiver.Delete (thread);
                 }, "NachoNowViewController.DeleteMessage");
                 HotMessages.IgnoreMessage (thread.FirstMessageId);
-                if (!IsReloading) {
-                    HotMessages.RemoveIgnoredMessages ();
-                    TableView.DeleteRows (new NSIndexPath[] { indexPath }, UITableViewRowAnimation.Automatic);
-                } else {
-                    SetNeedsReload ();
-                }
+                SetNeedsReload ();
             }
         }
 
@@ -301,12 +296,7 @@ namespace NachoClient.iOS
                     NcEmailArchiver.Archive (thread);
                 }, "MessageListViewController.ArchiveMessage");
                 HotMessages.IgnoreMessage (thread.FirstMessageId);
-                if (!IsReloading) {
-                    HotMessages.RemoveIgnoredMessages ();
-                    TableView.DeleteRows (new NSIndexPath[] { indexPath }, UITableViewRowAnimation.Automatic);
-                } else {
-                    SetNeedsReload ();
-                }
+                SetNeedsReload ();
             }
         }
 


### PR DESCRIPTION
can't use TableView.DeleteRow on hot screen delete because new rows should fill in for the deleted row,
meaning there should probably, but not always, be a corresponding InsertRow.  Instead of duplicating that
logic, just call reload
