### PR TITLE
Make sure the message body view isn't permanently hidden

### DIFF
--- a/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
+++ b/NachoClient.iOS/NachoUI.iOS/MessageViewController.cs
@@ -182,6 +182,7 @@ namespace NachoClient.iOS
                 BodyView.DataDetectorTypes = UIDataDetectorType.Link | UIDataDetectorType.PhoneNumber | UIDataDetectorType.Address;
             }
             BodyView.Delegate = this;
+            BodyView.Hidden = false;
 
             ScrollView.AddCompoundView (HeaderView);
             ScrollView.AddCompoundView (AttachmentsView);


### PR DESCRIPTION
When a message download fails, the UIWebView that shows the message
body might be marked as hidden.  When that same UIWebVie was reused
for a different message, it was not being unhidden, which meant the
message body was blank.  There was no way to get out of this situation
without restarting the app.

Change MessageViewController.LoadView() to make sure the UIWebView
object is not hidden.
