### PR TITLE
Fix race condition by replacing nullable type

### DIFF
--- a/NachoCore/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
+++ b/NachoCore/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
@@ -44,6 +44,9 @@ namespace NachoCore.ActiveSync
 
         public override BackEndStateEnum BackEndState {
             get {
+                // Important to copy value because another thread may be updating it
+                // and we don't want it to change between the time we check it for -1
+                // and the time we return it.
                 var presetRawValue = BackEndStatePresetRawValue;
                 if (presetRawValue != -1) {
                     return (BackEndStateEnum)presetRawValue;

--- a/NachoCore/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
+++ b/NachoCore/NachoCore/BackEnd/ActiveSync/AsProtoControl/AsProtoControl.cs
@@ -44,8 +44,9 @@ namespace NachoCore.ActiveSync
 
         public override BackEndStateEnum BackEndState {
             get {
-                if (null != BackEndStatePreset) {
-                    return (BackEndStateEnum)BackEndStatePreset;
+                var presetRawValue = BackEndStatePresetRawValue;
+                if (presetRawValue != -1) {
+                    return (BackEndStateEnum)presetRawValue;
                 }
                 var state = Sm.State;
                 if ((uint)Lst.Parked == state) {
@@ -73,15 +74,15 @@ namespace NachoCore.ActiveSync
                 case (uint)Lst.ProvW:
                 case (uint)Lst.SettingsW:
                 case (uint)Lst.FSyncW:
-                case (uint)Lst.FSync2W: 
+                case (uint)Lst.FSync2W:
                 case (uint)Lst.SyncW:
                 case (uint)Lst.PingW:
                 case (uint)Lst.QOpW:
                 case (uint)Lst.HotQOpW:
                 case (uint)Lst.FetchW:
                 case (uint)Lst.IdleW:
-                    return (ProtocolState.HasSyncedInbox) ? 
-                        BackEndStateEnum.PostAutoDPostInboxSync : 
+                    return (ProtocolState.HasSyncedInbox) ?
+                        BackEndStateEnum.PostAutoDPostInboxSync :
                         BackEndStateEnum.PostAutoDPreInboxSync;
 
                 default:
@@ -154,12 +155,12 @@ namespace NachoCore.ActiveSync
              *  - NcCommStatus will eventually shut us down as TempFail counts against Quality. 
              *  - Max deferrals on pending will pull "bad" pendings out of the Q.
              */
-            Sm = new NcStateMachine ("ASPC") { 
+            Sm = new NcStateMachine ("ASPC") {
                 Name = string.Format ("ASPC({0})", AccountId),
-                LocalEventType = typeof(CtlEvt),
-                LocalStateType = typeof(Lst),
+                LocalEventType = typeof (CtlEvt),
+                LocalStateType = typeof (Lst),
                 TransIndication = UpdateSavedState,
-                TransTable = new[] {
+                TransTable = new [] {
                     new Node {
                         State = (uint)St.Start,
                         Drop = new [] {
@@ -168,7 +169,7 @@ namespace NachoCore.ActiveSync
                             (uint)AsEvt.E.ReSync,
                             (uint)CtlEvt.E.UiSetCred,
                             (uint)CtlEvt.E.UiSetServConf,
-                            (uint)CtlEvt.E.UiCertOkNo, 
+                            (uint)CtlEvt.E.UiCertOkNo,
                             (uint)CtlEvt.E.UiCertOkYes,
                         },
                         Invalid = new [] {
@@ -190,7 +191,7 @@ namespace NachoCore.ActiveSync
 
                     new Node {
                         // There is no HardFail. Can't pass DiscW w/out a working server - period.
-                        State = (uint)Lst.DiscW, 
+                        State = (uint)Lst.DiscW,
                         Drop = new [] {
                             (uint)PcEvt.E.PendQOrHint,
                             (uint)PcEvt.E.PendQHot,
@@ -779,7 +780,7 @@ namespace NachoCore.ActiveSync
         // State-machine's state persistance callback.
         private void UpdateSavedState ()
         {
-            BackEndStatePreset = null;
+            BackEndStatePresetRawValue = -1;
             var protocolState = ProtocolState;
             uint stateToSave = Sm.State;
             switch (stateToSave) {
@@ -813,7 +814,7 @@ namespace NachoCore.ActiveSync
         // State-machine action methods.
         private void DoUiServConfReq ()
         {
-            BackEndStatePreset = BackEndStateEnum.ServerConfWait;
+            BackEndStatePresetRawValue = (int)BackEndStateEnum.ServerConfWait;
             // Send the request toward the UI.
             AutoDFailureReason = (BackEnd.AutoDFailureReasonEnum)Sm.Arg;
             Owner.ServConfReq (this, AutoDFailureReason);
@@ -821,7 +822,7 @@ namespace NachoCore.ActiveSync
 
         private void DoSetServConf ()
         {
-            if (CmdIs (typeof(AsAutodiscoverCommand))) {
+            if (CmdIs (typeof (AsAutodiscoverCommand))) {
                 var autoDiscoCmd = (AsAutodiscoverCommand)Cmd;
                 autoDiscoCmd.Sm.PostEvent ((uint)AsAutodiscoverCommand.TlEvt.E.ServerSet, "ASPCDSSC");
             }
@@ -830,18 +831,18 @@ namespace NachoCore.ActiveSync
         private void DoUiCredReq ()
         {
             lock (CmdLockObject) {
-                if (null != Cmd && !CmdIs (typeof(AsAutodiscoverCommand))) {
+                if (null != Cmd && !CmdIs (typeof (AsAutodiscoverCommand))) {
                     CancelCmd ();
                 }
             }
-            BackEndStatePreset = BackEndStateEnum.CredWait;
+            BackEndStatePresetRawValue = (int)BackEndStateEnum.CredWait;
             // Send the request toward the UI.
             Owner.CredReq (this);
         }
 
         private void DoSetCred ()
         {
-            if (CmdIs (typeof(AsAutodiscoverCommand))) {
+            if (CmdIs (typeof (AsAutodiscoverCommand))) {
                 var autoDiscoCmd = (AsAutodiscoverCommand)Cmd;
                 autoDiscoCmd.Sm.PostEvent ((uint)AsAutodiscoverCommand.TlEvt.E.CredSet, "ASPCDSC");
             }
@@ -849,14 +850,14 @@ namespace NachoCore.ActiveSync
 
         private void DoUiCertOkReq ()
         {
-            BackEndStatePreset = BackEndStateEnum.CertAskWait;
+            BackEndStatePresetRawValue = (int)BackEndStateEnum.CertAskWait;
             _ServerCertToBeExamined = (X509Certificate2)Sm.Arg;
             Owner.CertAskReq (this, _ServerCertToBeExamined);
         }
 
         private void DoCertOkNo ()
         {
-            if (CmdIs (typeof(AsAutodiscoverCommand))) {
+            if (CmdIs (typeof (AsAutodiscoverCommand))) {
                 var autoDiscoCmd = (AsAutodiscoverCommand)Cmd;
                 autoDiscoCmd.Sm.PostEvent ((uint)AsAutodiscoverCommand.SharedEvt.E.SrvCertN, "ASPCDCON");
             }
@@ -864,7 +865,7 @@ namespace NachoCore.ActiveSync
 
         private void DoCertOkYes ()
         {
-            if (CmdIs (typeof(AsAutodiscoverCommand))) {
+            if (CmdIs (typeof (AsAutodiscoverCommand))) {
                 var autoDiscoCmd = (AsAutodiscoverCommand)Cmd;
                 autoDiscoCmd.Sm.PostEvent ((uint)AsAutodiscoverCommand.SharedEvt.E.SrvCertY, "ASPCDCOY");
             }
@@ -975,10 +976,10 @@ namespace NachoCore.ActiveSync
                     Log.Info (Log.LOG_AS, "DoExtraOrDont: Nothing to do.");
                 } else {
                     Log.Info (Log.LOG_AS, "DoExtraOrDont: starting extra request.");
-                    var dummySm = new NcStateMachine ("ASPC:EXTRA") { 
+                    var dummySm = new NcStateMachine ("ASPC:EXTRA") {
                         Name = string.Format ("ASPC:EXTRA({0})", AccountId),
-                        LocalEventType = typeof(AsEvt),
-                        TransTable = new[] {
+                        LocalEventType = typeof (AsEvt),
+                        TransTable = new [] {
                             new Node {
                                 State = (uint)St.Start,
                                 Invalid = new [] {
@@ -1010,9 +1011,9 @@ namespace NachoCore.ActiveSync
                         break;
 
                     case PickActionEnum.Sync:
-                        // TODO add support for user-initiated Sync of >= 1 folders.
-                        // if current op is a sync including specified folder(s) - we must make sure we don't
-                        // have 2 concurrent syncs of the same folder.
+                    // TODO add support for user-initiated Sync of >= 1 folders.
+                    // if current op is a sync including specified folder(s) - we must make sure we don't
+                    // have 2 concurrent syncs of the same folder.
                     case PickActionEnum.Ping:
                     case PickActionEnum.Wait:
                     default:
@@ -1023,7 +1024,7 @@ namespace NachoCore.ActiveSync
                     return;
                 }
 
-            // If we got here, we decided that doing an extra request was a bad idea, ...
+                // If we got here, we decided that doing an extra request was a bad idea, ...
             } else if (0 == ConcurrentExtraRequests) {
 
                 // ... and we are currently processing no extra requests. Only in this case will we 

--- a/NachoCore/NachoCore/BackEnd/IMAP/ImapProtoControl.cs
+++ b/NachoCore/NachoCore/BackEnd/IMAP/ImapProtoControl.cs
@@ -35,6 +35,9 @@ namespace NachoCore.IMAP
 
         public override BackEndStateEnum BackEndState {
             get {
+                // Important to copy value because another thread may be updating it
+                // and we don't want it to change between the time we check it for -1
+                // and the time we return it.
                 var presetRawValue = BackEndStatePresetRawValue;
                 if (presetRawValue != -1) {
                     return (BackEndStateEnum)presetRawValue;

--- a/NachoCore/NachoCore/BackEnd/NcProtoControl.cs
+++ b/NachoCore/NachoCore/BackEnd/NcProtoControl.cs
@@ -32,7 +32,15 @@ namespace NachoCore
 
         protected bool LastIsDoNotDelayOk;
         protected BackEndStateEnum LastBackEndState;
-        protected BackEndStateEnum? BackEndStatePreset;
+
+        /// <remarks>
+        /// Using an integer "raw value" instead of a BackEndStateEnum because
+        /// 1. Need to store a "not set" value that isn't defined as an enum option
+        /// 2. Don't want to change the enum definition because it's used a lot of places
+        /// 3. Using a nullalble value here (as the previous code did) causes a race condition when reading
+        /// 4. ints are atomic in C#, so we'll never see an inconsistent value
+        /// </remarks>
+        protected int BackEndStatePresetRawValue;
 
         public int AccountId;
 

--- a/NachoCore/NachoCore/BackEnd/SMTP/SmtpProtoControl.cs
+++ b/NachoCore/NachoCore/BackEnd/SMTP/SmtpProtoControl.cs
@@ -49,6 +49,9 @@ namespace NachoCore.SMTP
 
         public override BackEndStateEnum BackEndState {
             get {
+                // Important to copy value because another thread may be updating it
+                // and we don't want it to change between the time we check it for -1
+                // and the time we return it.
                 var presetRawValue = BackEndStatePresetRawValue;
                 if (presetRawValue != -1) {
                     return (BackEndStateEnum)presetRawValue;

--- a/NachoCore/NachoCore/BackEnd/SMTP/SmtpProtoControl.cs
+++ b/NachoCore/NachoCore/BackEnd/SMTP/SmtpProtoControl.cs
@@ -49,8 +49,9 @@ namespace NachoCore.SMTP
 
         public override BackEndStateEnum BackEndState {
             get {
-                if (null != BackEndStatePreset) {
-                    return (BackEndStateEnum)BackEndStatePreset;
+                var presetRawValue = BackEndStatePresetRawValue;
+                if (presetRawValue != -1) {
+                    return (BackEndStateEnum)presetRawValue;
                 }
                 var state = Sm.State;
                 if ((uint)Lst.Parked == state) {
@@ -140,12 +141,12 @@ namespace NachoCore.SMTP
             Capabilities = McAccount.SmtpCapabilities;
             SetupAccount ();
 
-            Sm = new NcStateMachine ("SMTPPC") { 
+            Sm = new NcStateMachine ("SMTPPC") {
                 Name = string.Format ("SMTPPC({0})", AccountId),
-                LocalEventType = typeof(SmtpEvt),
-                LocalStateType = typeof(Lst),
+                LocalEventType = typeof (SmtpEvt),
+                LocalStateType = typeof (Lst),
                 TransIndication = UpdateSavedState,
-                TransTable = new[] {
+                TransTable = new [] {
                     new Node {
                         State = (uint)St.Start,
                         Drop = new uint[] {
@@ -439,7 +440,7 @@ namespace NachoCore.SMTP
         {
             Cmd.Execute (Sm);
         }
-        
+
         private void DoDisc ()
         {
             // HACK HACK: There appears to be a race-condition when the NcBackend (via UI) 
@@ -456,7 +457,7 @@ namespace NachoCore.SMTP
             //  UI:Info:1:: avl: handleStatusEnums 2 sender=Running reader=Running
             // But this is an illegal state in SubMitWait:
             //  STATE:Error:1:: SM(Account:3): S=SubmitWait & E=Running/avl: EventFromEnum running => INVALID EVENT
-            BackEndStatePreset = BackEndStateEnum.Running;
+            BackEndStatePresetRawValue = (int)BackEndStateEnum.Running;
             SetCmd (new SmtpDiscoveryCommand (this, MainClient));
             ExecuteCmd ();
         }
@@ -482,7 +483,7 @@ namespace NachoCore.SMTP
 
         private void DoUiServConfReq ()
         {
-            BackEndStatePreset = BackEndStateEnum.ServerConfWait;
+            BackEndStatePresetRawValue = (int)BackEndStateEnum.ServerConfWait;
             // Send the request toward the UI.
             if (null == Sm.Arg) {
                 Log.Error (Log.LOG_SMTP, "DoUiServConfReq: Sm.Arg is null");
@@ -502,7 +503,7 @@ namespace NachoCore.SMTP
 
         private void DoUiCertOkReq ()
         {
-            BackEndStatePreset = BackEndStateEnum.CertAskWait;
+            BackEndStatePresetRawValue = (int)BackEndStateEnum.CertAskWait;
             if (null == Sm.Arg) {
                 Log.Error (Log.LOG_SMTP, "DoUiCertOkReq: Sm.Arg is null");
                 throw new Exception ("DoUiCertOkReq: Sm.Arg can not be null");
@@ -577,7 +578,7 @@ namespace NachoCore.SMTP
             }
 
             var send = McPending.QueryEligible (AccountId, McAccount.SmtpCapabilities).
-                Where (x => 
+                Where (x =>
                     McPending.Operations.EmailSend == x.Operation ||
                        McPending.Operations.EmailForward == x.Operation ||
                        McPending.Operations.EmailReply == x.Operation
@@ -638,7 +639,7 @@ namespace NachoCore.SMTP
         private void DoUiCredReq ()
         {
             CancelCmd ();
-            BackEndStatePreset = BackEndStateEnum.CredWait;
+            BackEndStatePresetRawValue = (int)BackEndStateEnum.CredWait;
             // Send the request toward the UI.
             Owner.CredReq (this);
         }
@@ -653,7 +654,7 @@ namespace NachoCore.SMTP
         // State-machine's state persistance callback.
         private void UpdateSavedState ()
         {
-            BackEndStatePreset = null;
+            BackEndStatePresetRawValue = -1;
             var protocolState = ProtocolState;
             uint stateToSave = Sm.State;
             if ((uint)Lst.Parked != stateToSave &&

--- a/NachoCore/NachoCore/BackEnd/SalesForce/SalesForceProtoControl.cs
+++ b/NachoCore/NachoCore/BackEnd/SalesForce/SalesForceProtoControl.cs
@@ -51,6 +51,9 @@ namespace NachoCore.SFDC
 
         public override BackEndStateEnum BackEndState {
             get {
+                // Important to copy value because another thread may be updating it
+                // and we don't want it to change between the time we check it for -1
+                // and the time we return it.
                 var presetRawValue = BackEndStatePresetRawValue;
                 if (presetRawValue != -1) {
                     return (BackEndStateEnum)presetRawValue;

--- a/NachoCore/NachoCore/BackEnd/SalesForce/SalesForceProtoControl.cs
+++ b/NachoCore/NachoCore/BackEnd/SalesForce/SalesForceProtoControl.cs
@@ -51,8 +51,9 @@ namespace NachoCore.SFDC
 
         public override BackEndStateEnum BackEndState {
             get {
-                if (null != BackEndStatePreset) {
-                    return (BackEndStateEnum)BackEndStatePreset;
+                var presetRawValue = BackEndStatePresetRawValue;
+                if (presetRawValue != -1) {
+                    return (BackEndStateEnum)presetRawValue;
                 }
                 switch (Sm.State) {
                 case (uint)St.Start:
@@ -63,13 +64,13 @@ namespace NachoCore.SFDC
 
                 case (uint)Lst.UiServConfW:
                     return BackEndStateEnum.ServerConfWait;
-                
+
                 case (uint)Lst.DiscW:
                     return BackEndStateEnum.Running;
-                
+
                 case (uint)Lst.Parked:
                 case (uint)Lst.SyncW:
-                    return FirstSyncDone ?  BackEndStateEnum.PostAutoDPostInboxSync : BackEndStateEnum.PostAutoDPreInboxSync;
+                    return FirstSyncDone ? BackEndStateEnum.PostAutoDPostInboxSync : BackEndStateEnum.PostAutoDPreInboxSync;
 
                 default:
                     NcAssert.CaseError (string.Format ("BackEndState: Unhandled state {0}", StateName ((uint)Sm.State)));
@@ -121,12 +122,12 @@ namespace NachoCore.SFDC
             ProtoControl = this;
             Capabilities = SalesForceCapabilities;
             SetupAccount ();
-            Sm = new NcStateMachine ("SFDCPC") { 
+            Sm = new NcStateMachine ("SFDCPC") {
                 Name = string.Format ("SFDCPC({0})", AccountId),
-                LocalEventType = typeof(SfdcEvt),
-                LocalStateType = typeof(Lst),
+                LocalEventType = typeof (SfdcEvt),
+                LocalStateType = typeof (Lst),
                 TransIndication = UpdateSavedState,
-                TransTable = new[] {
+                TransTable = new [] {
                     new Node {
                         State = (uint)St.Start,
                         Drop = new uint[] {
@@ -146,7 +147,7 @@ namespace NachoCore.SFDC
                             new Trans { Event = (uint)SfdcEvt.E.UiSetCred, Act = DoDisc, State = (uint)Lst.DiscW },
                             new Trans { Event = (uint)PcEvt.E.Park, Act = DoPark, State = (uint)Lst.Parked },
                         }
-                    },     
+                    },
                     new Node {
                         State = (uint)Lst.UiCrdW,
                         Drop = new [] {
@@ -255,7 +256,7 @@ namespace NachoCore.SFDC
 
         void UpdateSavedState ()
         {
-            BackEndStatePreset = null;
+            BackEndStatePresetRawValue = -1;
             if (LastBackEndState != BackEndState) {
                 var res = NcResult.Info (NcResult.SubKindEnum.Info_BackEndStateChanged);
                 res.Value = AccountId;
@@ -274,7 +275,7 @@ namespace NachoCore.SFDC
 
         void DoDisc ()
         {
-            BackEndStatePreset = BackEndStateEnum.Running;
+            BackEndStatePresetRawValue = (int)BackEndStateEnum.Running;
             if (SFDCSetup != null) {
                 SFDCSetup.Cancel ();
                 SFDCSetup = null;
@@ -372,7 +373,7 @@ namespace NachoCore.SFDC
         void DoUiCredReq ()
         {
             CancelCmd ();
-            BackEndStatePreset = BackEndStateEnum.CredWait;
+            BackEndStatePresetRawValue = (int)BackEndStateEnum.CredWait;
             // Send the request toward the UI.
             Owner.CredReq (this);
         }


### PR DESCRIPTION
- using an int allows for atomic operations, so a reading thread will never see an inconsistent value
- using an int still allows us to tell the difference between set/unset, even if it's not quite as nice as a nullable type

fixes issue #3401 

Whitespace-ignoring diff: https://github.com/nachocove/NachoClientX/commit/0e52e7ceb266530b859ad855a998cdb92b1ecbcd?w=1